### PR TITLE
[feature] Add writing context contracts and adapter diagnostics

### DIFF
--- a/apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts
+++ b/apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts
@@ -23,6 +23,7 @@ import {
     type PreChapterProfileV1,
     type TruthContextPackV1,
 } from "@/features/analysis/server/truthPackGovernance";
+import { buildWritingContextFromPlanning } from "@/features/writing-context/server/writingContextAdapter";
 
 export type ChapterPlanArgs = {
     storyId: number;
@@ -1600,6 +1601,26 @@ export async function runChapterPlanning(
     try {
         const writingIntentMode = args.writingIntentMode === "RETCON_REWRITE" ? "RETCON_REWRITE" : "CONTINUE_CANON";
         let pack = await buildPlanningMemoryPackV5(pool, args);
+        let writingContext = buildWritingContextFromPlanning({
+            storyId: args.storyId,
+            storySlug: args.storySlug,
+            chapterId: args.chapterId,
+            targetWordCount: args.targetWordCount,
+            userPrompt: args.userPrompt,
+            writingIntentMode,
+            pack,
+        });
+        console.info(
+            "[writing.context.diagnostic]",
+            JSON.stringify({
+                story_id: args.storyId,
+                chapter_id: args.chapterId,
+                readiness: writingContext.debug_source_metadata.readiness.status,
+                reasons: writingContext.debug_source_metadata.readiness.reasons,
+                evidence_refs_count: writingContext.debug_source_metadata.evidence_refs.length,
+                degraded_reasons: writingContext.debug_source_metadata.degraded_reasons,
+            })
+        );
         if (pack.allowedCharacters.length === 0) {
             throw new Error("PLAN_INVALID_NO_ALLOWED_CHARACTERS");
         }
@@ -1705,6 +1726,27 @@ export async function runChapterPlanning(
             };
             if (!analysisInsufficient) {
                 pack = await buildPlanningMemoryPackV5(pool, args);
+                writingContext = buildWritingContextFromPlanning({
+                    storyId: args.storyId,
+                    storySlug: args.storySlug,
+                    chapterId: args.chapterId,
+                    targetWordCount: args.targetWordCount,
+                    userPrompt: args.userPrompt,
+                    writingIntentMode,
+                    pack,
+                });
+                console.info(
+                    "[writing.context.diagnostic]",
+                    JSON.stringify({
+                        story_id: args.storyId,
+                        chapter_id: args.chapterId,
+                        readiness: writingContext.debug_source_metadata.readiness.status,
+                        reasons: writingContext.debug_source_metadata.readiness.reasons,
+                        evidence_refs_count: writingContext.debug_source_metadata.evidence_refs.length,
+                        degraded_reasons: writingContext.debug_source_metadata.degraded_reasons,
+                        refreshed: true,
+                    })
+                );
                 continuity = evaluateContinuityGate({
                     plan: finalPlan,
                     pack,

--- a/apps/studio/src/features/writing-context/server/__tests__/readiness.test.ts
+++ b/apps/studio/src/features/writing-context/server/__tests__/readiness.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { evaluateWritingContextReadiness } from "../readiness";
+import type { WritingContext, WritingFactMetadata } from "../types";
+
+const meta: WritingFactMetadata = {
+    source_trace: {
+        source_system: "ts_planning",
+        source_function: "test",
+        chapter_id: "ch01",
+    },
+    confidence: 1,
+    currentness: "current",
+    conflict_status: "clean",
+};
+
+function baseContext(): WritingContext {
+    return {
+        contract_version: "writing_context_v1",
+        intent: {
+            story_id: 1,
+            chapter_id: "ch01",
+            chapter_goal: "Write the next chapter.",
+            writing_intent_mode: "CONTINUE_CANON",
+            target_word_count: 2000,
+            metadata: meta,
+        },
+        immediate_continuity: {
+            recent_snapshot_refs: ["snap:1"],
+            open_loops: [],
+            carry_forward_hooks: [],
+        },
+        current_state: {
+            active_cast: [{ kind: "allowed_character", label: "A", metadata: meta }],
+            character_states: [{ kind: "character_state", label: "A", value: "present", metadata: meta }],
+            setting_facts: [],
+            object_facts: [],
+        },
+        historical_memory: { canon: [], relationships: [], timeline: [], world: [] },
+        constraints: { allowed_characters: [], valid_anchors: [], active_objects: [], open_threads: [] },
+        forbidden_reveals: { required: false, rules: [], contradictory: false },
+        style_anchors: { facts: [] },
+        uncertainties: [],
+        debug_source_metadata: {
+            source_snapshot_ids: [1],
+            evidence_refs: [],
+            used_counts_by_layer: {},
+            dropped_counts_by_layer: {},
+            degraded_reasons: [],
+            readiness: { status: "proceed", reasons: [] },
+        },
+    };
+}
+
+test("blocks when chapter intent is missing", () => {
+    const context = baseContext();
+    context.intent.chapter_goal = "";
+    assert.deepEqual(evaluateWritingContextReadiness(context), {
+        status: "blocked",
+        reasons: ["MISSING_CHAPTER_INTENT"],
+    });
+});
+
+test("degrades when active cast state is missing but writing can continue", () => {
+    const context = baseContext();
+    context.current_state.character_states = [];
+    assert.deepEqual(evaluateWritingContextReadiness(context), {
+        status: "degraded",
+        reasons: ["CURRENT_ACTIVE_CAST_STATE_MISSING"],
+    });
+});
+
+test("proceeds when required context is present", () => {
+    assert.deepEqual(evaluateWritingContextReadiness(baseContext()), {
+        status: "proceed",
+        reasons: [],
+    });
+});

--- a/apps/studio/src/features/writing-context/server/__tests__/writingContextAdapter.test.ts
+++ b/apps/studio/src/features/writing-context/server/__tests__/writingContextAdapter.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildWritingContextFromPlanning } from "../writingContextAdapter";
+
+const baseInput = {
+    storyId: 1,
+    storySlug: "demo",
+    chapterId: "ch01",
+    targetWordCount: 2000,
+    userPrompt: "Continue the escape.",
+    writingIntentMode: "CONTINUE_CANON" as const,
+    pack: {
+        canonLines: ["- (fact|cf:0.90) A -> B"],
+        relationshipLines: ["- A trusts B"],
+        timelineLines: ["- ch01 before ch02"],
+        worldCoreLines: ["- magic has a cost"],
+        canonicalSettingFacts: ["city gate"],
+        canonicalObjectFacts: ["silver key"],
+        characterStateCards: [
+            {
+                entity: "A",
+                role: "ACTOR",
+                type: "character",
+                current_state: "at the city gate",
+                evidence_ids: ["canon:1"],
+            },
+        ],
+        carryForwardHooks: ["find the key"],
+        openLoops: ["escape patrol"],
+        allowedCharacters: ["A"],
+        sourceSnapshotIds: [10],
+        memoryRuntimeV5: {
+            used_counts_by_layer: { recent_structured: 1 },
+            dropped_counts_by_layer: { arc: 0 },
+            degraded_reasons: [],
+            evidence_refs: { canon_refs: ["canon:1"], snapshot_refs: ["snap:10"] },
+        },
+        conflictReport: { unresolved_critical_count: 0 },
+        truthContextPackV1: {
+            priority_a: { ambiguity_constraints: ["protect unrevealed identity"] },
+            priority_b: {},
+            staleness_flags: [],
+        },
+    },
+};
+
+test("maps planning pack into current state and readiness", () => {
+    const context = buildWritingContextFromPlanning(baseInput);
+    assert.equal(context.current_state.character_states[0]?.label, "A");
+    assert.equal(context.current_state.setting_facts[0]?.label, "city gate");
+    assert.equal(context.debug_source_metadata.readiness.status, "proceed");
+});
+
+test("adds source metadata to high-impact facts", () => {
+    const context = buildWritingContextFromPlanning(baseInput);
+    const metadata = context.current_state.character_states[0]?.metadata;
+    assert.equal(metadata?.source_trace.source_system, "ts_planning");
+    assert.equal(metadata?.source_trace.source_function, "buildPlanningMemoryPackV5");
+    assert.equal(metadata?.source_trace.chapter_id, "ch01");
+    assert.equal(metadata?.currentness, "current");
+});
+
+test("does not throw when optional source data is missing", () => {
+    const context = buildWritingContextFromPlanning({
+        ...baseInput,
+        pack: {},
+    });
+    assert.equal(context.intent.chapter_id, "ch01");
+    assert.equal(context.debug_source_metadata.readiness.status, "degraded");
+});

--- a/apps/studio/src/features/writing-context/server/readiness.ts
+++ b/apps/studio/src/features/writing-context/server/readiness.ts
@@ -1,0 +1,49 @@
+import type { WritingContext, WritingContextReadinessResult } from "./types";
+
+function hasText(value: string | undefined): boolean {
+    return Boolean(value && value.trim().length > 0);
+}
+
+export function evaluateWritingContextReadiness(context: WritingContext): WritingContextReadinessResult {
+    const blockingReasons: string[] = [];
+    const degradedReasons: string[] = [];
+
+    if (!hasText(context.intent.chapter_id)) {
+        blockingReasons.push("MISSING_CHAPTER_ID");
+    }
+    if (!hasText(context.intent.chapter_goal)) {
+        blockingReasons.push("MISSING_CHAPTER_INTENT");
+    }
+    if (context.forbidden_reveals.contradictory) {
+        blockingReasons.push("FORBIDDEN_REVEALS_CONTRADICTORY");
+    }
+    if (context.forbidden_reveals.required && context.forbidden_reveals.rules.length === 0) {
+        blockingReasons.push("FORBIDDEN_REVEALS_REQUIRED_BUT_MISSING");
+    }
+
+    const hasImmediateContinuity =
+        context.immediate_continuity.recent_snapshot_refs.length > 0 ||
+        context.immediate_continuity.open_loops.length > 0 ||
+        context.immediate_continuity.carry_forward_hooks.length > 0;
+    if (!hasImmediateContinuity) {
+        degradedReasons.push("IMMEDIATE_CONTINUITY_PARTIAL");
+    }
+    if (context.current_state.active_cast.length === 0 || context.current_state.character_states.length === 0) {
+        degradedReasons.push("CURRENT_ACTIVE_CAST_STATE_MISSING");
+    }
+    for (const uncertainty of context.uncertainties) {
+        if (uncertainty.severity === "blocking") {
+            blockingReasons.push(uncertainty.code);
+        } else if (uncertainty.severity === "warning") {
+            degradedReasons.push(uncertainty.code);
+        }
+    }
+
+    if (blockingReasons.length > 0) {
+        return { status: "blocked", reasons: Array.from(new Set(blockingReasons)) };
+    }
+    if (degradedReasons.length > 0) {
+        return { status: "degraded", reasons: Array.from(new Set(degradedReasons)) };
+    }
+    return { status: "proceed", reasons: [] };
+}

--- a/apps/studio/src/features/writing-context/server/types.ts
+++ b/apps/studio/src/features/writing-context/server/types.ts
@@ -1,0 +1,119 @@
+export type WritingContextReadiness = "proceed" | "degraded" | "blocked";
+
+export type WritingContextCurrentness =
+    | "current"
+    | "recent"
+    | "historical"
+    | "stale"
+    | "superseded"
+    | "draft_only"
+    | "unknown";
+
+export type WritingContextConflictStatus =
+    | "clean"
+    | "conflicting"
+    | "low_confidence"
+    | "unvetted"
+    | "incomplete_coverage"
+    | "unknown";
+
+export type WritingContextSourceSystem =
+    | "ts_planning"
+    | "story_context_pack"
+    | "truth_context_pack"
+    | "working_set"
+    | "unknown";
+
+export type WritingFactMetadata = {
+    source_trace: {
+        source_system: WritingContextSourceSystem;
+        source_file?: string;
+        source_function?: string;
+        source_id?: string | number;
+        chapter_id?: string;
+    };
+    /**
+     * Confidence is normalized to 0.0-1.0, where 1.0 means fully verified canon.
+     * Use "unknown" when a source does not expose a comparable confidence value.
+     */
+    confidence: number | "unknown";
+    currentness: WritingContextCurrentness;
+    conflict_status: WritingContextConflictStatus;
+};
+
+export type WritingContextFact = {
+    kind: string;
+    label: string;
+    value?: string;
+    metadata: WritingFactMetadata;
+};
+
+export type WritingContextUncertainty = {
+    code: string;
+    severity: "info" | "warning" | "blocking";
+    detail: string;
+    metadata: WritingFactMetadata;
+};
+
+export type WritingContext = {
+    contract_version: "writing_context_v1";
+    intent: {
+        story_id: number;
+        story_slug?: string;
+        chapter_id: string;
+        chapter_goal: string;
+        writing_intent_mode: "CONTINUE_CANON" | "RETCON_REWRITE";
+        target_word_count: number;
+        metadata: WritingFactMetadata;
+    };
+    immediate_continuity: {
+        recent_snapshot_refs: string[];
+        open_loops: WritingContextFact[];
+        carry_forward_hooks: WritingContextFact[];
+    };
+    current_state: {
+        active_cast: WritingContextFact[];
+        character_states: WritingContextFact[];
+        setting_facts: WritingContextFact[];
+        object_facts: WritingContextFact[];
+    };
+    historical_memory: {
+        canon: WritingContextFact[];
+        relationships: WritingContextFact[];
+        timeline: WritingContextFact[];
+        world: WritingContextFact[];
+    };
+    constraints: {
+        allowed_characters: WritingContextFact[];
+        valid_anchors: WritingContextFact[];
+        active_objects: WritingContextFact[];
+        open_threads: WritingContextFact[];
+        raw_priority_a?: Record<string, unknown>;
+        raw_priority_b?: Record<string, unknown>;
+    };
+    forbidden_reveals: {
+        required: boolean;
+        rules: WritingContextFact[];
+        contradictory: boolean;
+    };
+    style_anchors: {
+        facts: WritingContextFact[];
+    };
+    uncertainties: WritingContextUncertainty[];
+    debug_source_metadata: {
+        source_snapshot_ids: number[];
+        evidence_refs: string[];
+        used_counts_by_layer: Record<string, number>;
+        dropped_counts_by_layer: Record<string, number>;
+        degraded_reasons: string[];
+        readiness: {
+            status: WritingContextReadiness;
+            reasons: string[];
+        };
+    };
+};
+
+export type WritingContextReadinessResult = {
+    status: WritingContextReadiness;
+    reasons: string[];
+};

--- a/apps/studio/src/features/writing-context/server/writingContextAdapter.ts
+++ b/apps/studio/src/features/writing-context/server/writingContextAdapter.ts
@@ -1,0 +1,412 @@
+import { evaluateWritingContextReadiness } from "./readiness";
+import type {
+    WritingContext,
+    WritingContextConflictStatus,
+    WritingContextCurrentness,
+    WritingContextFact,
+    WritingContextSourceSystem,
+    WritingContextUncertainty,
+    WritingFactMetadata,
+} from "./types";
+
+type EvidenceRefs = {
+    canon_refs?: string[];
+    timeline_refs?: string[];
+    snapshot_refs?: string[];
+    arc_refs?: string[];
+    saga_refs?: string[];
+    core_refs?: string[];
+};
+
+type PlanningMemoryPackLike = {
+    canonLines?: string[];
+    relationshipLines?: string[];
+    timelineLines?: string[];
+    worldCoreLines?: string[];
+    canonicalSettingFacts?: string[];
+    canonicalObjectFacts?: string[];
+    characterStateCards?: Array<{
+        entity: string;
+        role: string;
+        type: string;
+        current_state: string;
+        evidence_ids?: string[];
+    }>;
+    carryForwardHooks?: string[];
+    openLoops?: string[];
+    allowedCharacters?: string[];
+    memoryRuntimeV5?: {
+        used_counts_by_layer?: Record<string, number>;
+        dropped_counts_by_layer?: Record<string, number>;
+        degraded_reasons?: string[];
+        evidence_refs?: EvidenceRefs;
+    };
+    sourceSnapshotIds?: number[];
+    conflictReport?: {
+        unresolved_critical_count?: number;
+    };
+    truthContextPackV1?: {
+        priority_a?: Record<string, unknown>;
+        priority_b?: Record<string, unknown>;
+        staleness_flags?: Array<{ entity_id: string; stale: boolean }>;
+    };
+};
+
+export type BuildWritingContextFromPlanningInput = {
+    storyId: number;
+    storySlug?: string;
+    chapterId: string;
+    targetWordCount: number;
+    userPrompt?: string;
+    writingIntentMode?: "CONTINUE_CANON" | "RETCON_REWRITE";
+    pack: PlanningMemoryPackLike;
+};
+
+function metadata(args: {
+    sourceSystem: WritingContextSourceSystem;
+    sourceFunction: string;
+    chapterId: string;
+    sourceId?: string | number;
+    confidence?: number | "unknown";
+    currentness?: WritingContextCurrentness;
+    conflictStatus?: WritingContextConflictStatus;
+}): WritingFactMetadata {
+    return {
+        source_trace: {
+            source_system: args.sourceSystem,
+            source_file: sourceFileFor(args.sourceSystem),
+            source_function: args.sourceFunction,
+            source_id: args.sourceId,
+            chapter_id: args.chapterId,
+        },
+        confidence: normalizeConfidence(args.confidence),
+        currentness: args.currentness || "unknown",
+        conflict_status: args.conflictStatus || "unknown",
+    };
+}
+
+function sourceFileFor(sourceSystem: WritingContextSourceSystem): string | undefined {
+    const sources: Partial<Record<WritingContextSourceSystem, string>> = {
+        ts_planning: "apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts",
+        truth_context_pack: "apps/studio/src/features/analysis/server/truthPackGovernance.ts",
+        story_context_pack: "apps/studio/src/features/guard/server/storyContextBuilder.ts",
+        working_set: "apps/studio/src/features/autowrite/server/chapterContextService.ts",
+    };
+    return sources[sourceSystem];
+}
+
+function normalizeConfidence(value: number | "unknown" | undefined): number | "unknown" {
+    if (value === "unknown" || value === undefined || !Number.isFinite(value)) return "unknown";
+    return Math.max(0, Math.min(1, value));
+}
+
+function fact(args: {
+    kind: string;
+    label: string;
+    value?: string;
+    sourceSystem: WritingContextSourceSystem;
+    sourceFunction: string;
+    chapterId: string;
+    sourceId?: string | number;
+    confidence?: number | "unknown";
+    currentness?: WritingContextCurrentness;
+    conflictStatus?: WritingContextConflictStatus;
+}): WritingContextFact {
+    return {
+        kind: args.kind,
+        label: args.label,
+        value: args.value,
+        metadata: metadata(args),
+    };
+}
+
+function factsFromStrings(args: {
+    values: string[] | undefined;
+    kind: string;
+    sourceSystem: WritingContextSourceSystem;
+    sourceFunction: string;
+    chapterId: string;
+    currentness: WritingContextCurrentness;
+    conflictStatus?: WritingContextConflictStatus;
+    limit?: number;
+}): WritingContextFact[] {
+    return (args.values || [])
+        .map((value) => String(value || "").trim())
+        .filter(Boolean)
+        .slice(0, args.limit || 20)
+        .map((value, index) =>
+            fact({
+                kind: args.kind,
+                label: value,
+                value,
+                sourceSystem: args.sourceSystem,
+                sourceFunction: args.sourceFunction,
+                chapterId: args.chapterId,
+                sourceId: `${args.kind}:${index}`,
+                confidence: "unknown",
+                currentness: args.currentness,
+                conflictStatus: args.conflictStatus || "unknown",
+            })
+        );
+}
+
+function stringList(raw: unknown): string[] {
+    if (!Array.isArray(raw)) return [];
+    return raw.map((item) => String(item || "").trim()).filter(Boolean);
+}
+
+function collectEvidenceRefs(refs: EvidenceRefs | undefined): string[] {
+    if (!refs) return [];
+    const keys: Array<keyof EvidenceRefs> = ["canon_refs", "timeline_refs", "snapshot_refs", "arc_refs", "saga_refs", "core_refs"];
+    return keys.flatMap((key) => stringList(refs[key]));
+}
+
+function forbiddenRevealRules(input: BuildWritingContextFromPlanningInput): WritingContextFact[] {
+    const priorityA = input.pack.truthContextPackV1?.priority_a || {};
+    const priorityB = input.pack.truthContextPackV1?.priority_b || {};
+    const priorityAVisibility = priorityA.knowledge_visibility as { reveal_sensitivity?: string } | undefined;
+    const priorityBVisibility = priorityB.knowledge_visibility as { reveal_sensitivity?: string } | undefined;
+    const rules = [
+        ...stringList(priorityA.ambiguity_constraints),
+        ...(priorityAVisibility?.reveal_sensitivity ? [`reveal_sensitivity:${priorityAVisibility.reveal_sensitivity}`] : []),
+        ...(priorityBVisibility?.reveal_sensitivity ? [`reveal_sensitivity:${priorityBVisibility.reveal_sensitivity}`] : []),
+    ];
+    return factsFromStrings({
+        values: Array.from(new Set(rules)),
+        kind: "forbidden_reveal_rule",
+        sourceSystem: "truth_context_pack",
+        sourceFunction: "compileTruthContextPackV1",
+        chapterId: input.chapterId,
+        currentness: "current",
+        conflictStatus: "clean",
+    });
+}
+
+function uncertainties(input: BuildWritingContextFromPlanningInput): WritingContextUncertainty[] {
+    const degraded = input.pack.memoryRuntimeV5?.degraded_reasons || [];
+    const staleFlags = input.pack.truthContextPackV1?.staleness_flags || [];
+    const fromDegraded: WritingContextUncertainty[] = degraded.map((reason) => ({
+        code: reason,
+        severity: "warning" as const,
+        detail: reason,
+        metadata: metadata({
+            sourceSystem: "ts_planning",
+            sourceFunction: "buildPlanningMemoryPackV5",
+            chapterId: input.chapterId,
+            sourceId: reason,
+            currentness: "unknown",
+            conflictStatus: reason.includes("CONFLICT") ? "conflicting" : "unknown",
+        }),
+    }));
+    const fromStale: WritingContextUncertainty[] = staleFlags
+        .filter((flag) => flag.stale)
+        .map((flag) => ({
+            code: "STALE_ENTITY_STATE",
+            severity: "warning" as const,
+            detail: flag.entity_id,
+            metadata: metadata({
+                sourceSystem: "truth_context_pack",
+                sourceFunction: "compileTruthContextPackV1",
+                chapterId: input.chapterId,
+                sourceId: flag.entity_id,
+                currentness: "stale",
+                conflictStatus: "unknown",
+            }),
+        }));
+    const out = [...fromDegraded, ...fromStale];
+    if ((input.pack.conflictReport?.unresolved_critical_count || 0) === 0) return out;
+    out.push({
+        code: "UNRESOLVED_CRITICAL_CONFLICT",
+        severity: "blocking",
+        detail: "Planning pack reports unresolved critical conflicts.",
+        metadata: metadata({
+            sourceSystem: "ts_planning",
+            sourceFunction: "buildPlanningMemoryPackV5",
+            chapterId: input.chapterId,
+            currentness: "current",
+            conflictStatus: "conflicting",
+        }),
+    });
+    return out;
+}
+
+export function buildWritingContextFromPlanning(input: BuildWritingContextFromPlanningInput): WritingContext {
+    const evidenceRefs = collectEvidenceRefs(input.pack.memoryRuntimeV5?.evidence_refs);
+    const characterStates = (input.pack.characterStateCards || []).map((card) =>
+        fact({
+            kind: "character_state",
+            label: card.entity,
+            value: card.current_state,
+            sourceSystem: "ts_planning",
+            sourceFunction: "buildPlanningMemoryPackV5",
+            chapterId: input.chapterId,
+            sourceId: card.evidence_ids?.[0] || card.entity,
+            confidence: "unknown",
+            currentness: "current",
+            conflictStatus: "clean",
+        })
+    );
+    const allowedCharacters = factsFromStrings({
+        values: input.pack.allowedCharacters,
+        kind: "allowed_character",
+        sourceSystem: "truth_context_pack",
+        sourceFunction: "compileTruthContextPackV1",
+        chapterId: input.chapterId,
+        currentness: "current",
+        conflictStatus: "clean",
+    });
+    const forbiddenRules = forbiddenRevealRules(input);
+    const context: WritingContext = {
+        contract_version: "writing_context_v1",
+        intent: {
+            story_id: input.storyId,
+            story_slug: input.storySlug,
+            chapter_id: input.chapterId,
+            chapter_goal: String(input.userPrompt || "").trim(),
+            writing_intent_mode: input.writingIntentMode === "RETCON_REWRITE" ? "RETCON_REWRITE" : "CONTINUE_CANON",
+            target_word_count: input.targetWordCount,
+            metadata: metadata({
+                sourceSystem: "ts_planning",
+                sourceFunction: "runChapterPlanning",
+                chapterId: input.chapterId,
+                currentness: "current",
+                conflictStatus: "clean",
+                confidence: 1,
+            }),
+        },
+        immediate_continuity: {
+            recent_snapshot_refs: (input.pack.sourceSnapshotIds || []).map((id) => `snap:${id}`),
+            open_loops: factsFromStrings({
+                values: input.pack.openLoops,
+                kind: "open_thread",
+                sourceSystem: "ts_planning",
+                sourceFunction: "buildPlanningMemoryPackV5",
+                chapterId: input.chapterId,
+                currentness: "recent",
+            }),
+            carry_forward_hooks: factsFromStrings({
+                values: input.pack.carryForwardHooks,
+                kind: "carry_forward_hook",
+                sourceSystem: "ts_planning",
+                sourceFunction: "buildPlanningMemoryPackV5",
+                chapterId: input.chapterId,
+                currentness: "recent",
+            }),
+        },
+        current_state: {
+            active_cast: allowedCharacters,
+            character_states: characterStates,
+            setting_facts: factsFromStrings({
+                values: input.pack.canonicalSettingFacts,
+                kind: "setting_fact",
+                sourceSystem: "truth_context_pack",
+                sourceFunction: "compileTruthContextPackV1",
+                chapterId: input.chapterId,
+                currentness: "current",
+                conflictStatus: "clean",
+            }),
+            object_facts: factsFromStrings({
+                values: input.pack.canonicalObjectFacts,
+                kind: "object_fact",
+                sourceSystem: "truth_context_pack",
+                sourceFunction: "compileTruthContextPackV1",
+                chapterId: input.chapterId,
+                currentness: "current",
+                conflictStatus: "clean",
+            }),
+        },
+        historical_memory: {
+            canon: factsFromStrings({
+                values: input.pack.canonLines,
+                kind: "canon_fact",
+                sourceSystem: "story_context_pack",
+                sourceFunction: "buildStoryContextPack",
+                chapterId: input.chapterId,
+                currentness: "historical",
+            }),
+            relationships: factsFromStrings({
+                values: input.pack.relationshipLines,
+                kind: "relationship_state",
+                sourceSystem: "story_context_pack",
+                sourceFunction: "buildStoryContextPack",
+                chapterId: input.chapterId,
+                currentness: "historical",
+            }),
+            timeline: factsFromStrings({
+                values: input.pack.timelineLines,
+                kind: "timeline_anchor",
+                sourceSystem: "story_context_pack",
+                sourceFunction: "buildStoryContextPack",
+                chapterId: input.chapterId,
+                currentness: "historical",
+            }),
+            world: factsFromStrings({
+                values: input.pack.worldCoreLines,
+                kind: "world_rule",
+                sourceSystem: "story_context_pack",
+                sourceFunction: "buildStoryContextPack",
+                chapterId: input.chapterId,
+                currentness: "historical",
+            }),
+        },
+        constraints: {
+            allowed_characters: allowedCharacters,
+            valid_anchors: factsFromStrings({
+                values: input.pack.canonicalSettingFacts,
+                kind: "valid_anchor",
+                sourceSystem: "truth_context_pack",
+                sourceFunction: "compileTruthContextPackV1",
+                chapterId: input.chapterId,
+                currentness: "current",
+                conflictStatus: "clean",
+            }),
+            active_objects: factsFromStrings({
+                values: input.pack.canonicalObjectFacts,
+                kind: "active_object",
+                sourceSystem: "truth_context_pack",
+                sourceFunction: "compileTruthContextPackV1",
+                chapterId: input.chapterId,
+                currentness: "current",
+                conflictStatus: "clean",
+            }),
+            open_threads: factsFromStrings({
+                values: input.pack.carryForwardHooks,
+                kind: "open_thread_constraint",
+                sourceSystem: "ts_planning",
+                sourceFunction: "buildPlanningMemoryPackV5",
+                chapterId: input.chapterId,
+                currentness: "recent",
+            }),
+            raw_priority_a: input.pack.truthContextPackV1?.priority_a,
+            raw_priority_b: input.pack.truthContextPackV1?.priority_b,
+        },
+        forbidden_reveals: {
+            required: forbiddenRules.length > 0,
+            rules: forbiddenRules,
+            contradictory: false,
+        },
+        style_anchors: {
+            facts: [],
+        },
+        uncertainties: uncertainties(input),
+        debug_source_metadata: {
+            source_snapshot_ids: input.pack.sourceSnapshotIds || [],
+            evidence_refs: evidenceRefs,
+            used_counts_by_layer: input.pack.memoryRuntimeV5?.used_counts_by_layer || {},
+            dropped_counts_by_layer: input.pack.memoryRuntimeV5?.dropped_counts_by_layer || {},
+            degraded_reasons: input.pack.memoryRuntimeV5?.degraded_reasons || [],
+            readiness: {
+                status: "proceed",
+                reasons: [],
+            },
+        },
+    };
+    const readiness = evaluateWritingContextReadiness(context);
+    return {
+        ...context,
+        debug_source_metadata: {
+            ...context.debug_source_metadata,
+            readiness,
+        },
+    };
+}

--- a/docs/architecture/story-memory-contract.md
+++ b/docs/architecture/story-memory-contract.md
@@ -1,0 +1,110 @@
+# Story Memory Contract
+
+Issue: #3
+Status: Contract draft
+Last updated: 2026-05-02
+
+## Purpose
+
+Story memory is the durable narrative record that future planning, writing, validation, and review use to preserve continuity. This contract defines memory categories and state semantics only. It does not define a database schema, migration, promotion algorithm, task queue taxonomy, editor storage model, or prompt format.
+
+#11 will assemble current memory into `WritingContext`. #12 will define how post-write outputs are promoted into durable memory. #5 owns editor/document storage and approval boundaries.
+
+## Durable Categories
+
+| Category | Meaning | Current evidence | Contract rule |
+|---|---|---|---|
+| `canon_fact` | A durable fact about a character, object, place, group, rule, or situation. | `StoryContextPack` reads `canon_fact` subject/predicate/object/confidence at `apps/studio/src/features/guard/server/storyContextBuilder.ts:615`. Python core lookup reads `canon_fact` and vetting state at `services/memory-bridge/worker_memory_context.py:481`. | Must include source trace, confidence, currentness, and conflict status before being treated as high-impact context. |
+| `event` | A thing that happened in prose or planning and may change future continuity. | V3 `ChapterLedger` carries `added_facts` and `modified_states` at `apps/studio/src/features/autowrite/server/chapterFirstTypes.ts:45`; ledger extraction persists them at `services/memory-bridge/worker_task_handlers.py:2126`. | Must not become current state automatically unless #12 promotion rules approve it. |
+| `timeline_anchor` | A dated or relative ordering anchor for events, locations, and participants. | `StoryContextPack` reads `timeline_anchor` fields at `apps/studio/src/features/guard/server/storyContextBuilder.ts:724`. `TruthContextPackV1` has `timeline_state` in priority A at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:620`. | Must distinguish ordering evidence from narrative interpretation. |
+| `character_state` | A current or historical state of a character, such as location, status, injury, role, or motivation. | `buildWorkingSet.active_state.cast` models status and last seen chapter at `apps/studio/src/features/autowrite/server/chapterContextService.ts:29`. V3 rollup merges modified states into `world_state` at `services/memory-bridge/worker_memory_rollup_v3.py:53`. | Current state needs one active value per property unless explicitly conflicting. |
+| `relationship_state` | A current or historical state between entities. | `StoryContextPack` exposes `relationshipLines` at `apps/studio/src/features/guard/server/storyContextBuilder.ts:17`; it also classifies relationship canon from tags/predicates at `apps/studio/src/features/guard/server/storyContextBuilder.ts:608`. | Relationship state must carry participants, directionality when relevant, and currentness. |
+| `emotion_state` | Emotional target, mood, or affective state relevant to a chapter or entity. | `writing_snapshot_v3` stores `emotional_target` at `db/migrations/000_baseline_20260502.sql:3575`; `buildPlanningMemoryPackV5` reads recent snapshot emotional target at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:523`. | Treat chapter-level emotion as guidance unless promoted to entity-level state by #12. |
+| `world_rule` | A rule of the setting, magic, politics, technology, society, or environment. | Python recent structured memory extracts `world_rules` from snapshot JSON at `services/memory-bridge/worker_memory_context.py:108`; `StoryContextPack` reads worldbuilding notes at `apps/studio/src/features/guard/server/storyContextBuilder.ts:583`. | World rules are high-impact and must not be dropped silently when relevant. |
+| `lore_addition` | New lore introduced by a chapter that may become canon after approval. | `chapter_ledger.added_facts` exists in baseline schema at `db/migrations/000_baseline_20260502.sql:1043`; V3 ledger extraction writes added facts at `services/memory-bridge/worker_task_handlers.py:2126`. | New lore from drafts is `draft_only` until #12 promotion marks it approved. |
+| `open_thread` | An unresolved plot, promise, risk, question, or hook that should influence later chapters. | `writing_snapshot_v3` stores `open_loops` at `db/migrations/000_baseline_20260502.sql:3575`; Python recent structured memory extracts open loops at `services/memory-bridge/worker_memory_context.py:108`. | Open threads must have source, urgency when available, and currentness. |
+| `closed_thread` | A formerly open thread that a chapter resolved or intentionally abandoned. | V3 `ChapterLedger` has `resolved_loops` at `apps/studio/src/features/autowrite/server/chapterFirstTypes.ts:45`; ledger extraction persists `resolved_loops` at `services/memory-bridge/worker_task_handlers.py:2126`. | A closed thread must reference the open thread or enough source evidence to avoid accidental closure. |
+| `style_signal` | Durable style evidence or guidance, including tone, pacing, perspective, density, and author style. | `StoryContextPack` exposes `styleLines` at `apps/studio/src/features/guard/server/storyContextBuilder.ts:13`; `buildWorkingSet.anchor.style_dna` contains tone, pacing, and perspective at `apps/studio/src/features/autowrite/server/chapterContextService.ts:18`. | Style signals can guide prose but must never override canon, forbidden reveals, or current state. |
+
+## Current State vs Historical Memory
+
+`current_state` is the latest approved value for an entity, property, relationship, thread, or world condition at the target chapter boundary. It answers: what is true now?
+
+`historical_memory` is evidence of what happened before, why current state is true, and which facts were once true but are no longer active. It answers: how did the story get here?
+
+Rules:
+
+- The same source can contribute to both. For example, a chapter ledger event may become historical memory and also update current state after #12 promotion.
+- Current state must be compact and contradiction-aware. Historical memory may preserve multiple past values if currentness is clear.
+- Stale or superseded memory may remain historical memory but must not be presented as current state.
+- Draft-only memory must not be current state unless an approval/promotion rule explicitly allows it.
+
+Current evidence already separates these concerns partially:
+
+- `buildWorkingSet.active_state` models active cast/world/timeline, while `meso_context` and `ephemeral` model milestones and recent deltas. Evidence: `apps/studio/src/features/autowrite/server/chapterContextService.ts:29`.
+- Python planning context has layer priority `recent_structured`, `arc`, `saga`, `core_db`, separating recent structured evidence from longer-range memory. Evidence: `services/memory-bridge/worker_memory_context.py:780`.
+- `story_milestone` has `is_stale` and `stale_reason`, supporting historical retention without treating stale rollups as current. Evidence: `db/migrations/000_baseline_20260502.sql:2778`.
+
+## Memory States
+
+| State | Meaning | Required behavior |
+|---|---|---|
+| `current` | The fact/state is the best approved value at the target chapter boundary. | May be used directly in `WritingContext.current_state`. |
+| `historical` | The fact/state was true or relevant earlier but is not necessarily active now. | May explain continuity but must not be phrased as current truth. |
+| `stale` | A later retcon, invalidation, or data change made the memory unsafe as active context. | Keep only as historical/debug evidence unless revalidated. |
+| `superseded` | A newer approved value replaces this memory. | Do not use as current state; keep source trace for audit. |
+| `draft_only` | The memory came from generated or edited draft content that has not passed the relevant approval boundary. | Do not promote into durable current state inside #3. |
+| `low_confidence` | The memory source exists but confidence is below the threshold required for high-impact writing. | Use only with uncertainty or as a prompt question unless no safer source exists. |
+| `conflicting` | Two or more sources disagree on a high-impact fact/state. | Block or degrade according to `WritingContext` readiness depending on impact. |
+| `unknown` | The system does not know the value or cannot map source quality. | Say unknown; do not invent a default as if it were memory. |
+
+Known current equivalents:
+
+- `writing_snapshot_v3.fact_status` supports `CLEAN`, `CONFLICT`, `UNVETTED`, `EMPTY_WARNING`, and `INCOMPLETE_COVERAGE`. Evidence: `db/migrations/000_baseline_20260502.sql:3597`.
+- `writing_snapshot_v3.approval_status` supports `DRAFT`, `APPROVED`, `SUPERSEDED`, and `CANCELED`. Evidence: `db/migrations/000_baseline_20260502.sql:3597`.
+- `chapter_ledger` and `story_milestone` both carry stale fields. Evidence: `db/migrations/000_baseline_20260502.sql:1043` and `db/migrations/000_baseline_20260502.sql:2778`.
+- `writingPipelineService.invalidateDownstream` marks downstream ledgers and milestones stale after a retcon. Evidence: `apps/studio/src/features/autowrite/server/writingPipelineService.ts:640`.
+
+## Contract-Level Rules
+
+- High-impact memory must include source trace, confidence, currentness, and conflict status before it can be used as direct writing context.
+- Memory category and memory state are separate. Example: a `character_state` can be `current`, `historical`, `stale`, `draft_only`, or `conflicting`.
+- Current state must prefer approved, non-stale, chapter-appropriate sources.
+- Historical memory may include stale or superseded records only when clearly labeled.
+- Generated chapter output can propose memory but cannot approve or promote memory by itself.
+- Style signals are advisory and lower priority than canon, current state, forbidden reveals, and continuity constraints.
+- Missing memory is a first-class `unknown`, not permission to fill a gap with default prose assumptions.
+
+## Out Of Scope For #3
+
+- No database schema design or migration.
+- No implementation of `WritingContext` adapters.
+- No changes to `CHAPTER_WRITE_V3`, `CHAPTER_LEDGER_EXTRACT`, `MEMORY_ROLLUP_V3`, `WRITING_*`, or `NARRATIVE_*` task behavior.
+- No prompt rewrite.
+- No UI changes.
+- No editor/document storage or approval boundary design; #5 owns that.
+- No post-write promotion algorithm; #12 owns that.
+- No queue taxonomy cleanup.
+- No deletion or deprecation of existing runtime paths.
+
+## Evidence Mapping
+
+| Existing source | Memory role | Evidence | Gap |
+|---|---|---|---|
+| `writing_snapshot_v3` | Approved analysis snapshot and pre-writing readiness source. | Worker inserts fact status, narrative score, emotional target, open loops, degraded mode, completeness, ready flag, pre-chapter profile, truth context pack, and delta report at `services/memory-bridge/worker_task_handlers.py:1684`; baseline schema confirms state columns at `db/migrations/000_baseline_20260502.sql:3575`. | Snapshot JSON needs category normalization before it is durable story memory. |
+| `story_active_analysis_snapshot` plus `writing_snapshot_v3` | Recent structured facts, loops, and world rules. | Python `load_recent_chapter_structured` requires approved, ready, non-degraded, clean snapshots at `services/memory-bridge/worker_memory_context.py:64`. | This is a selection policy, not a promotion policy. |
+| `story_milestone` | Arc/saga memory and rollup summaries. | Python `load_arc_memory` reads non-stale milestones at `services/memory-bridge/worker_memory_context.py:229`; V3 rollup writes `story_milestone` from ledger at `services/memory-bridge/worker_memory_rollup_v3.py:83`; baseline schema includes `summary_json`, `quality_score`, stale fields, and delta report at `db/migrations/000_baseline_20260502.sql:2778`. | Current rollup merge is simplified and not a final conflict-resolution policy. |
+| `chapter_ledger` | Chapter-level delta source: facts, state changes, resolved/open loops, and stale markers. | Baseline schema at `db/migrations/000_baseline_20260502.sql:1043`; ledger extraction writes added facts, modified states, resolved/unresolved loops, and metadata at `services/memory-bridge/worker_task_handlers.py:2126`. | #12 must decide when these deltas become approved durable memory. |
+| `chapter_continuity_issue` | Validation/audit findings that can block or degrade future context. | Ledger task audits prose and writes continuity issues after ledger extraction at `services/memory-bridge/worker_task_handlers.py:2151`; TypeScript continuity issue type includes severity and evidence payload at `apps/studio/src/features/autowrite/server/chapterFirstTypes.ts:60`. | #3 does not decide mandatory gate severity. |
+| `canon_fact` and `timeline_anchor` | Legacy/canonical fact and timeline memory inputs. | `buildStoryContextPack` reads canon facts at `apps/studio/src/features/guard/server/storyContextBuilder.ts:615` and timeline anchors at `apps/studio/src/features/guard/server/storyContextBuilder.ts:724`. | They are currently rendered as lines; #11 must adapt them into structured metadata. |
+| Legacy scene versions | Working prose memory and compatibility history. | Python `load_working_memory` reads verified `narrative_scene` and current `narrative_scene_version.text_content` at `services/memory-bridge/worker_memory_context.py:157`. | #5 decides future document/chapter block storage; scene versions remain compatibility/history. |
+| `TruthContextPackV1` | Governance metadata for priority, staleness, thread pressure, and dropped/compressed context. | Type fields at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:148`; compiler records evidence refs and degraded reasons at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:629`. | It is governance input, not the full story memory category model. |
+
+## Unknowns For Follow-Up
+
+- #11 must define the concrete adapter output and where it lives.
+- #11 must decide how to merge TS and Python layer priorities without creating two competing contracts.
+- #12 must define promotion, rejection, supersession, and conflict-resolution rules.
+- #12 must decide how approved generated prose creates durable event and state memory.
+- #5 must define the approval boundary for edited document/chapter blocks before draft-only memory can become durable.
+- A later queue taxonomy issue must decide how `WRITING_*`, `NARRATIVE_*`, and V3 tasks are named and exposed.

--- a/docs/architecture/writing-context-contract.md
+++ b/docs/architecture/writing-context-contract.md
@@ -1,0 +1,95 @@
+# WritingContext Contract
+
+Issue: #3
+Status: Contract draft
+Last updated: 2026-05-02
+
+## Purpose
+
+`WritingContext` is the canonical context contract for automated chapter writing. It defines what the planner and writer are allowed to know, what they must protect, what can be omitted under budget pressure, and how sources are traced.
+
+This contract is semantic only. It does not change runtime behavior, task payloads, database schema, prompts, or UI. #11 owns implementation adapters that assemble this contract. #12 owns post-write memory promotion rules.
+
+Approved near-term consumer path:
+
+```text
+CHAPTER_WRITE_V3 -> CHAPTER_LEDGER_EXTRACT -> MEMORY_ROLLUP_V3
+```
+
+The existing canonical map approves this path and identifies `buildStoryContextPack`, `buildPlanningMemoryPackV5`, `worker_memory_context.py`, and `truthPackGovernance.ts` as sources that should become adapters into one shared contract. Evidence: `docs/architecture/writing-pipeline-canonical-map.md:25`, `docs/architecture/writing-pipeline-canonical-map.md:208`, `docs/architecture/writing-pipeline-canonical-map.md:220`.
+
+## Canonical Sections
+
+| Section | Meaning | Required for minimum viable AutoWrite | Current evidence |
+|---|---|---:|---|
+| `intent` | The chapter goal, user instruction, target chapter id, writing mode, and any approved plan constraints. | Yes | `writingPipelineService.ts` passes `chapter_goal`, `working_set`, and `style_options` into `CHAPTER_WRITE_V3` task payloads at `apps/studio/src/features/autowrite/server/writingPipelineService.ts:556`. `runChapterPlanning` calls `buildPlanningMemoryPackV5` before planning at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:1600`. |
+| `immediate_continuity` | The local prose tail, recent chapter facts, open loops, unresolved immediate beats, and recent scene/version state needed to continue without a jump. | Yes | `buildStoryContextPack` derives local chapter ids and loads local prose tail at `apps/studio/src/features/guard/server/storyContextBuilder.ts:537`. Python `load_working_memory` reads verified recent scene prose at `services/memory-bridge/worker_memory_context.py:157`. |
+| `current_state` | Current character, relationship, world, object, emotional, and thread state that should be treated as active at the chapter boundary. | Yes when available; degraded if partial. | `buildWorkingSet` has `active_state.cast`, `world_flags`, and `timeline_facts` at `apps/studio/src/features/autowrite/server/chapterContextService.ts:29`. V3 rollup merges ledger `modified_states` into `world_state` at `services/memory-bridge/worker_memory_rollup_v3.py:53`. |
+| `historical_memory` | Older facts, milestones, saga memory, and long-range context that explain why current state is true. | No; retain after required sections. | `buildPlanningMemoryPackV5` reads approved `writing_snapshot_v3` rows at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:523`. Python `load_arc_memory` reads non-stale `story_milestone` rows at `services/memory-bridge/worker_memory_context.py:229`. |
+| `constraints` | Hard writing constraints: allowed characters, valid anchors, timeline state, open threads, budget decisions, and author annotations. | Yes for facts that can create contradictions. | `TruthContextPackV1` contains priority packs, token budget stats, compression drops, staleness flags, and thread pressure at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:148`. `compileTruthContextPackV1` builds priority A/B facts at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:596`. |
+| `forbidden_reveals` | Information the writer must not reveal yet, including POV-limited knowledge, withheld canon, blocked entities, or reveal-sensitive material. | Yes when present; absence must be explicit. | `compileTruthContextPackV1` adds `ambiguity_constraints` for high reveal sensitivity at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:620`. `buildPlanningMemoryPackV5` filters blocked entities from author annotations at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:492`. |
+| `style_anchors` | Tone, pacing, perspective, prose density, author style, and style examples that shape prose without overriding canon. | Degraded if missing. | `StoryContextPack` exposes `styleLines` at `apps/studio/src/features/guard/server/storyContextBuilder.ts:13`. `buildWorkingSet.anchor.style_dna` contains tone, pacing, and perspective at `apps/studio/src/features/autowrite/server/chapterContextService.ts:18`. |
+| `uncertainties` | Missing, stale, low-confidence, conflicting, or fallback data that the writer must handle conservatively. | Yes when any source is incomplete. | `buildPlanningMemoryPackV5` emits degraded reasons including `MISSING_RECENT_STRUCTURED` and `LEGACY_CONTEXT_FALLBACK_APPLIED` at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:710`. Python context builders emit `memory_runtime.degraded_reasons` at `services/memory-bridge/worker_memory_context.py:772` and `services/memory-bridge/worker_memory_context.py:848`. |
+| `debug_source_metadata` | Source ids, source tables, confidence, currentness, conflict status, retrieval warnings, and drop counts used to audit the context. | Yes for high-impact facts. | `StoryContextPack.stats` tracks retrieval warnings and external retrieval status at `apps/studio/src/features/guard/server/storyContextBuilder.ts:21`. `buildPlanningMemoryPackV5` records evidence and source snapshot ids at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:486`. Python context builders expose used/dropped layer counts at `services/memory-bridge/worker_memory_context.py:793` and `services/memory-bridge/worker_memory_context.py:871`. |
+
+## Required Fact Metadata
+
+Every high-impact fact in `intent`, `immediate_continuity`, `current_state`, `constraints`, `forbidden_reveals`, or `uncertainties` must carry enough metadata for #11 to render and audit it:
+
+| Field | Requirement |
+|---|---|
+| `source_trace` | At minimum: source system, source table or function, source id when known, chapter id when applicable, and source timestamp/hash when available. |
+| `confidence` | Numeric or enum confidence from the source. If no source confidence exists, mark `unknown` rather than inventing a score. |
+| `currentness` | One of `current`, `recent`, `historical`, `stale`, `superseded`, `draft_only`, or `unknown`. |
+| `conflict_status` | One of `clean`, `conflicting`, `low_confidence`, `unvetted`, `incomplete_coverage`, or `unknown`. |
+
+Current evidence already contains partial equivalents: `canon_fact.confidence` is selected by `buildStoryContextPack` at `apps/studio/src/features/guard/server/storyContextBuilder.ts:615`; `writing_snapshot_v3` stores `fact_status`, `ready_for_writing`, and `degraded_mode` in the baseline schema at `db/migrations/000_baseline_20260502.sql:3575`; `chapter_ledger` stores `is_stale` and `stale_reason` at `db/migrations/000_baseline_20260502.sql:1043`.
+
+## Truncation Priority
+
+When #11 implements budget enforcement, truncation must follow this priority order:
+
+1. Preserve `intent`, `forbidden_reveals`, blocking `constraints`, and blocking `uncertainties`.
+2. Preserve `immediate_continuity` needed to continue the previous approved prose.
+3. Preserve `current_state` for active cast, active location, active emotional state, unresolved loop status, and current world state.
+4. Preserve `debug_source_metadata` for all retained high-impact facts, even if compressed.
+5. Preserve `style_anchors` needed for tone, pacing, and perspective.
+6. Compress then trim `historical_memory`, keeping summaries and source references before full detail.
+7. Drop optional historical examples, redundant source lines, and low-impact style examples first.
+
+This contract intentionally does not set token counts. Existing implementations already use local caps and drop stats, such as `TruthContextPackV1.token_budget_stats` and `compression_drops` at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:154`, TS planning drop counters at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:471`, and Python layer drop counters at `services/memory-bridge/worker_memory_context.py:766`.
+
+## Readiness Rules
+
+`WritingContext` readiness has three outcomes.
+
+| Outcome | Rule | Examples |
+|---|---|---|
+| `proceed` | Intent is present, immediate continuity is sufficient, no hard conflicts exist in active constraints, and high-impact facts either have clean source metadata or are explicitly marked as uncertain. | Chapter goal exists, recent continuity is available from approved snapshots or working memory, active cast is present, and no forbidden reveal conflict is reported. |
+| `degraded` | Intent is present, writing can continue, but one or more non-blocking context sections are partial, stale, low-confidence, or fallback-derived. The writer must be conservative and surface uncertainty in debug metadata. | Protagonist current state is missing but recent continuity and chapter intent exist. Style anchors are missing but no canon contradiction risk is detected. Recent structured memory is missing and legacy context fallback is applied. |
+| `blocked` | Required intent is absent, a hard conflict affects what should be written, forbidden reveal constraints cannot be enforced, or immediate continuity is too incomplete to continue safely. | Missing chapter intent or chapter goal. Active chapter id is invalid. A high-impact relationship state has conflicting current values with no approved source. Forbidden reveal rules are required by profile but absent or contradictory. |
+
+Minimum viable AutoWrite requires `intent`, at least one usable immediate continuity source, and either clean current state or explicit degraded reasons. Missing historical memory alone must not block writing.
+
+## Evidence Mapping
+
+| Existing source | Maps to `WritingContext` | Evidence | Gap |
+|---|---|---|---|
+| `StoryContextPack` | `style_anchors`, world constraints, canon lines, relationship lines, timeline lines, historian status, retrieval metadata. | Type fields at `apps/studio/src/features/guard/server/storyContextBuilder.ts:13`; builder loads story overview/world/canon/timeline/historian guidance at `apps/studio/src/features/guard/server/storyContextBuilder.ts:537`, `apps/studio/src/features/guard/server/storyContextBuilder.ts:680`, and `apps/studio/src/features/guard/server/storyContextBuilder.ts:960`. | Line-oriented strings need structured fact metadata before becoming canonical. |
+| `TruthContextPackV1` | `constraints`, `forbidden_reveals`, `uncertainties`, truncation/drop metadata. | Type fields at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:148`; compiler builds priority A/B, evidence refs, degraded reasons, reveal and voice constraints at `apps/studio/src/features/analysis/server/truthPackGovernance.ts:596`. | Priority packs are close to truncation policy but are not yet the full `WritingContext` section model. |
+| `buildPlanningMemoryPackV5` | `intent`, recent structured memory, planning constraints, evidence refs, degraded reasons. | Function starts at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:470`; reads approved `writing_snapshot_v3` at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:523`; applies fallback `buildStoryContextPack` at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:710`; compiles truth pack at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:884`. | It is planner-specific and large; #11 should adapt it rather than copy it as the canonical shape. |
+| Planning guard usage | `blocked` readiness and allowed-entity constraints. | `runChapterPlanning` rejects empty allowed character sets at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:1600`; author annotations can block entities at `apps/studio/src/features/scenes/server/workflow/steps/chapterPlanning.ts:492`. | The exact set of hard blockers beyond missing intent/characters remains #11 implementation scope. |
+| `buildWorkingSet` | `intent`, `current_state`, `historical_memory`, `style_anchors`, and V3 writer payload seed. | WorkingSet shape at `apps/studio/src/features/autowrite/server/chapterContextService.ts:12`; reads active cast, milestones, chapter ledger, and recent changes at `apps/studio/src/features/autowrite/server/chapterContextService.ts:60`; enqueued into `CHAPTER_WRITE_V3` at `apps/studio/src/features/autowrite/server/writingPipelineService.ts:536`. | The current type has simplified/defaulted fields such as empty `world_rules`, empty `world_flags`, and `motivation: "N/A"`; these must be treated as unknowns, not facts. |
+| Chapter-first types | Post-write memory categories and continuity issues. | `ChapterLedger` defines `added_facts`, `modified_states`, `resolved_loops`, `unresolved_loops`, and stale fields at `apps/studio/src/features/autowrite/server/chapterFirstTypes.ts:45`. | These are candidate TS types, not final shared API or DB schema definitions. |
+| Python `worker_memory_context.py` planning context | `immediate_continuity`, `historical_memory`, core facts, saga guardrails, layer priority, degraded reasons. | `load_recent_chapter_structured` reads approved clean snapshots at `services/memory-bridge/worker_memory_context.py:64`; `load_arc_memory` reads non-stale milestones at `services/memory-bridge/worker_memory_context.py:229`; `build_planning_context_v5` returns layer priority and runtime degraded reasons at `services/memory-bridge/worker_memory_context.py:715`. | Uses Python dict shape `memory_contract_version: v5`; #11 must reconcile naming and metadata with TS. |
+| Python `build_prose_context_v5` | Prose-time continuity, working prose, recent structured facts, saga guardrails, and core lookup. | `load_working_memory` reads verified scene prose at `services/memory-bridge/worker_memory_context.py:157`; `build_prose_context_v5` returns working/recent/saga/core layers and degraded reasons at `services/memory-bridge/worker_memory_context.py:821`. | It still reads legacy scene prose; #5 decides future document/chapter block source of truth. |
+| Writing analysis snapshots | Historical and current analysis source with readiness state. | `process_writing_analysis_task` inserts `writing_snapshot_v3` with `fact_status`, `open_loops`, `degraded_mode`, `ready_for_writing`, pre-chapter profile, truth context pack, and analysis delta at `services/memory-bridge/worker_task_handlers.py:1684`; baseline schema confirms columns at `db/migrations/000_baseline_20260502.sql:3575`. | Snapshot JSON category semantics remain broader than this contract and need adapter normalization. |
+| V3 ledger and rollup outputs | Post-write deltas that later become future `current_state` and `historical_memory`. | Ledger extraction inserts `chapter_ledger` with added facts, modified states, resolved/unresolved loops, metadata, and continuity issues at `services/memory-bridge/worker_task_handlers.py:2088`; rollup consolidates ledger into `story_milestone` at `services/memory-bridge/worker_memory_rollup_v3.py:8`. | #12 must decide promotion, conflict resolution, and approval semantics before these outputs become authoritative current state. |
+
+## Unknowns For Follow-Up
+
+- #11 must decide the concrete serialized shape, adapter module boundaries, and exact field names.
+- #11 must decide how many blockers exist beyond the examples in this contract.
+- #12 must decide how `chapter_ledger` facts and states are promoted, superseded, or rejected.
+- #5 must decide whether future continuity reads come from document/chapter blocks instead of legacy scene versions.
+- Task taxonomy must decide whether `WRITING_*` and `NARRATIVE_*` remain public queue types or merge under the V3 path.


### PR DESCRIPTION
## Summary
- Adds the #3 WritingContext and Story Memory contract docs.
- Adds the first TypeScript `WritingContext` runtime shape and adapter for chapter planning.
- Wires the adapter into chapter planning as diagnostic logging only, without changing prompt rendering, task payloads, or API response shape.

## Scope Notes
- No Python, SQL, migration, prompt, or UI changes.
- Existing mixed worktree changes outside this scope were not staged or committed.
- #3 was updated and closed with implementation notes.

## Verification
- `npm run typecheck` passed.
- `npm run build` passed.
- Focused `npx eslint ...` passed with warnings only and no errors.
- `git diff --check` passed.
- Test runner is not configured in `apps/studio` (`jest`/`vitest` binaries absent), so new `.test.ts` files are typechecked but not executed.
