### PR TITLE
[BE] Wire WritingContext into V3 enqueue

### DIFF
--- a/apps/studio/src/features/autowrite/server/writingPipelineService.ts
+++ b/apps/studio/src/features/autowrite/server/writingPipelineService.ts
@@ -11,6 +11,7 @@ import {
     resolvePackBudgetPolicy,
 } from "@/features/analysis/server/truthPackGovernance";
 import { buildWorkingSet } from "./chapterContextService";
+import { assembleChapterWritingContext } from "./chapterWritingContextAssembler";
 
 export interface WritingPipelineConfig {
     storyId: number;
@@ -535,6 +536,15 @@ export async function enqueueChapterWriteV3(config: WritingPipelineConfig) {
 
         // 1. Build WorkingSet
         const workingSet = await buildWorkingSet(client, config.storyId, chapterId);
+        const assembledWritingContext = assembleChapterWritingContext({
+            workingSet,
+            userIntent: config.instructions,
+            targetWordCount: config.targetWordCount,
+            mode: "prose",
+        });
+        if (assembledWritingContext.preflight.status === "blocked") {
+            throw new Error(`CHAPTER_WRITE_V3 context blocked: ${assembledWritingContext.preflight.block_reasons.join(", ")}`);
+        }
 
         // 2. Create Ingest Job
         const jobRes = await client.query<{ id: number }>(
@@ -565,6 +575,9 @@ export async function enqueueChapterWriteV3(config: WritingPipelineConfig) {
                     chapter_id: chapterId,
                     chapter_goal: config.instructions,
                     working_set: workingSet,
+                    writing_context: assembledWritingContext.context,
+                    writing_context_preflight: assembledWritingContext.preflight,
+                    writing_context_debug: assembledWritingContext.debug,
                     style_options: {
                       target_word_count: config.targetWordCount || 2500
                     }


### PR DESCRIPTION
## Summary
- Wires the read-only chapter WritingContext assembler into V3 enqueue for issue #24.
- Keeps existing `working_set` payload unchanged for Python worker compatibility.
- Adds `writing_context`, `writing_context_preflight`, and `writing_context_debug` to `CHAPTER_WRITE_V3` task payload.
- Blocks enqueue when assembler preflight returns `blocked`.

## Verification
- `npm run typecheck` in `apps/studio` via WSL passed.
- `npx eslint src/features/autowrite/server/writingPipelineService.ts src/features/autowrite/server/chapterWritingContextAssembler.ts` in `apps/studio` via WSL completed with existing warnings in `writingPipelineService.ts` for max-lines/complexity; no errors.
- `npm run build` in `apps/studio` via WSL passed.
- `git diff --cached --check` passed.

## Compatibility
- No Python worker changes.
- No prompt changes.
- `working_set` remains in the task payload.
