### PR TITLE
[AI] Add WritingContext required rollout flag

### DIFF
--- a/docs/architecture/chapter-writing-context-assembler.md
+++ b/docs/architecture/chapter-writing-context-assembler.md
@@ -180,7 +180,9 @@ The assembler should consume current sources through adapters before changing st
 ## Failure And Fallback Rules
 
 - Optional external retrieval failures degrade; they do not block if SQL/current continuity is safe.
-- Legacy context fallback must set `LEGACY_CONTEXT_FALLBACK_APPLIED`.
+- Legacy context fallback must be explicit, traceable, and limited to old-payload compatibility. It must set compatibility metadata or a reason code such as `LEGACY_CONTEXT_FALLBACK_APPLIED`.
+- Worker compatibility mode is allowed only when `writing_context` is absent. If `writing_context` is present but malformed, missing required sections, malformed preflight, invalid preflight status, or blocked, the worker must fail fast instead of falling back to `working_set`.
+- `WRITING_CONTEXT_REQUIRED=1` disables old-payload compatibility mode and makes absent `writing_context` fail with `WRITING_CONTEXT_REQUIRED`.
 - Draft-only continuity may be used for the target chapter only when the caller allows degraded writing and no approved continuity exists.
 - If the assembler cannot preserve source trace for a high-impact retained fact, it must block or drop the fact and record `SOURCE_TRACE_REQUIRED_BUT_MISSING`.
 - Budget trimming must preserve high-impact metadata before optional historical detail.

--- a/services/memory-bridge/worker_chapter_writer.py
+++ b/services/memory-bridge/worker_chapter_writer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import json
+import os
 from typing import Any, Dict, Optional
 from worker_common import call_llm_json
 
@@ -11,11 +12,16 @@ REQUIRED_CONTEXT_SECTIONS = {
     "debug_source_metadata",
 }
 
+def _env_truthy(name: str) -> bool:
+    return str(os.getenv(name) or "").strip().lower() in {"1", "true", "yes", "on"}
+
 def _validate_present_writing_context(
     writing_context: Optional[Dict[str, Any]],
     writing_context_preflight: Optional[Dict[str, Any]],
 ) -> str:
     if writing_context is None:
+        if _env_truthy("WRITING_CONTEXT_REQUIRED"):
+            raise ValueError("WRITING_CONTEXT_REQUIRED")
         return "compatibility_absent"
     if not isinstance(writing_context, dict):
         raise ValueError("WRITING_CONTEXT_MALFORMED")


### PR DESCRIPTION
## Summary
- Adds `WRITING_CONTEXT_REQUIRED=1` strict rollout flag for the V3 chapter writer.
- When enabled, absent `writing_context` now fails with `WRITING_CONTEXT_REQUIRED` instead of entering old-payload compatibility mode.
- Keeps default compatibility mode off by default for deploy safety.
- Updates the chapter WritingContext assembler contract with explicit fallback/strict-mode rules.

## Verification
- `python3 -m py_compile services/memory-bridge/worker_chapter_writer.py` via WSL passed.
- `git diff --cached --check` passed.

## Issue policy
- Continuing the existing WritingContext rollout without opening a new issue; notification follow-up remains tracked separately in #28.
