### PR TITLE
[Test] Tighten WritingContext fallback semantics

### DIFF
--- a/services/memory-bridge/tests/test_chapter_writer_context_strict.py
+++ b/services/memory-bridge/tests/test_chapter_writer_context_strict.py
@@ -47,11 +47,16 @@ class TestChapterWriterContextStrictness(unittest.TestCase):
         os.environ.pop("WRITING_CONTEXT_REQUIRED", None)
 
     def test_absent_context_uses_explicit_compatibility_mode_by_default(self):
-        with patch("worker_chapter_writer.call_llm_json", return_value={"prose": "ok"}):
+        with patch("worker_chapter_writer.call_llm_json", return_value={"prose": "ok"}) as call:
             result = generate_chapter_v3(None, 1, "ch02", working_set(), "continue")
 
         self.assertEqual(result["metadata"]["writing_context_mode"], "compatibility_absent")
         self.assertFalse(result["metadata"]["writing_context_used"])
+        self.assertEqual(result["metadata"]["fallback_reason_code"], "LEGACY_PAYLOAD_COMPAT")
+        self.assertEqual(result["metadata"]["fallback_source"], "working_set")
+        prompt = call.call_args.args[0][1]["content"]
+        self.assertIn("WORKINGSET COMPATIBILITY CONTEXT:", prompt)
+        self.assertIn("Pitch: A test story", prompt)
 
     def test_required_flag_blocks_absent_context(self):
         os.environ["WRITING_CONTEXT_REQUIRED"] = "1"
@@ -67,8 +72,54 @@ class TestChapterWriterContextStrictness(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "WRITING_CONTEXT_PREFLIGHT_MALFORMED"):
             generate_chapter_v3(None, 1, "ch02", working_set(), "continue", writing_context=writing_context())
 
-    def test_valid_context_records_contract_mode(self):
+    def test_present_context_requires_known_preflight_status(self):
+        with self.assertRaisesRegex(ValueError, "WRITING_CONTEXT_PREFLIGHT_STATUS_INVALID"):
+            generate_chapter_v3(
+                None,
+                1,
+                "ch02",
+                working_set(),
+                "continue",
+                writing_context=writing_context(),
+                writing_context_preflight={"status": "mystery"},
+            )
+
+    def test_blocked_preflight_does_not_fallback(self):
+        with self.assertRaisesRegex(ValueError, "WRITING_CONTEXT_PREFLIGHT_BLOCKED"):
+            generate_chapter_v3(
+                None,
+                1,
+                "ch02",
+                working_set(),
+                "continue",
+                writing_context=writing_context(),
+                writing_context_preflight={"status": "blocked", "block_reasons": ["MISSING_CURRENT_STATE"]},
+            )
+
+    def test_degraded_context_records_contract_mode(self):
         with patch("worker_chapter_writer.call_llm_json", return_value={"prose": "ok"}):
+            result = generate_chapter_v3(
+                None,
+                1,
+                "ch02",
+                working_set(),
+                "continue",
+                writing_context=writing_context(),
+                writing_context_preflight={
+                    "status": "degraded",
+                    "degraded_reasons": ["LOW_CONFIDENCE_RELATIONSHIP_STATE"],
+                    "block_reasons": [],
+                },
+            )
+
+        self.assertEqual(result["metadata"]["writing_context_mode"], "contract")
+        self.assertTrue(result["metadata"]["writing_context_used"])
+        self.assertEqual(result["metadata"]["writing_context_preflight_status"], "degraded")
+        self.assertIsNone(result["metadata"]["fallback_reason_code"])
+        self.assertIsNone(result["metadata"]["fallback_source"])
+
+    def test_valid_context_records_contract_mode_without_working_set_prompt_blend(self):
+        with patch("worker_chapter_writer.call_llm_json", return_value={"prose": "ok"}) as call:
             result = generate_chapter_v3(
                 None,
                 1,
@@ -83,6 +134,11 @@ class TestChapterWriterContextStrictness(unittest.TestCase):
         self.assertEqual(result["metadata"]["writing_context_mode"], "contract")
         self.assertTrue(result["metadata"]["writing_context_used"])
         self.assertEqual(result["metadata"]["writing_context_preflight_status"], "proceed")
+        self.assertIsNone(result["metadata"]["fallback_reason_code"])
+        self.assertIsNone(result["metadata"]["fallback_source"])
+        prompt = call.call_args.args[0][1]["content"]
+        self.assertIn("Disabled because a valid WritingContext is present", prompt)
+        self.assertNotIn("Pitch: A test story", prompt)
 
 
 if __name__ == "__main__":

--- a/services/memory-bridge/worker_chapter_writer.py
+++ b/services/memory-bridge/worker_chapter_writer.py
@@ -39,6 +39,19 @@ def _validate_present_writing_context(
         raise ValueError("WRITING_CONTEXT_PREFLIGHT_BLOCKED")
     return "contract"
 
+def _fallback_metadata(context_mode: str) -> Dict[str, Any]:
+    if context_mode == "compatibility_absent":
+        return {
+            "writing_context_used": False,
+            "fallback_reason_code": "LEGACY_PAYLOAD_COMPAT",
+            "fallback_source": "working_set",
+        }
+    return {
+        "writing_context_used": True,
+        "fallback_reason_code": None,
+        "fallback_source": None,
+    }
+
 def _compact_fact_list(items: Any, *, limit: int = 8) -> list[str]:
     if not isinstance(items, list):
         return []
@@ -88,6 +101,36 @@ def _render_writing_context_block(
     ]
     return "\n".join(lines) + "\n"
 
+def _render_working_set_compatibility_block(working_set: Dict[str, Any], context_mode: str) -> str:
+    if context_mode != "compatibility_absent":
+        return (
+            "WORKINGSET COMPATIBILITY CONTEXT:\n"
+            "Disabled because a valid WritingContext is present. Do not infer canon from WorkingSet.\n"
+        )
+
+    anchor = working_set.get("anchor", {})
+    active = working_set.get("active_state", {})
+    meso = working_set.get("meso_context", {})
+    ephemeral = working_set.get("ephemeral", {})
+    return f"""WORKINGSET COMPATIBILITY CONTEXT:
+Fallback reason: LEGACY_PAYLOAD_COMPAT
+
+STORY ANCHOR:
+Pitch: {anchor.get('story_pitch')}
+Style: {json.dumps(anchor.get('style_dna'))}
+
+ACTIVE WORLD STATE & CAST:
+Cast: {json.dumps(active.get('cast'))}
+Timeline: {json.dumps(active.get('timeline_facts'))}
+
+CONTINUITY (MESO CONTEXT):
+Unresolved Loops: {json.dumps(meso.get('unresolved_loops'))}
+Recent History: {json.dumps(meso.get('milestone_summaries'))}
+
+RECENT CHANGES (EPHEMERAL):
+{json.dumps(ephemeral.get('recent_changes'))}
+"""
+
 def generate_chapter_v3(
     conn,
     story_id: int,
@@ -105,10 +148,6 @@ def generate_chapter_v3(
     """
 
     # Prompt Construction
-    anchor = working_set.get("anchor", {})
-    active = working_set.get("active_state", {})
-    meso = working_set.get("meso_context", {})
-    ephemeral = working_set.get("ephemeral", {})
     context_mode = _validate_present_writing_context(writing_context, writing_context_preflight)
     preflight_status = (
         writing_context_preflight.get("status")
@@ -116,25 +155,14 @@ def generate_chapter_v3(
         else None
     )
     writing_context_block = _render_writing_context_block(writing_context, writing_context_preflight)
+    working_set_block = _render_working_set_compatibility_block(working_set, context_mode)
+    fallback_metadata = _fallback_metadata(context_mode)
 
     prompt = f"""You are a master novelist writing a long-form fiction chapter.
 
 {writing_context_block}
 
-STORY ANCHOR:
-Pitch: {anchor.get('story_pitch')}
-Style: {json.dumps(anchor.get('style_dna'))}
-
-ACTIVE WORLD STATE & CAST:
-Cast: {json.dumps(active.get('cast'))}
-Timeline: {json.dumps(active.get('timeline_facts'))}
-
-CONTINUITY (MESO CONTEXT):
-Unresolved Loops: {json.dumps(meso.get('unresolved_loops'))}
-Recent History: {json.dumps(meso.get('milestone_summaries'))}
-
-RECENT CHANGES (EPHEMERAL):
-{json.dumps(ephemeral.get('recent_changes'))}
+{working_set_block}
 
 CHAPTER OBJECTIVE:
 {chapter_goal}
@@ -169,8 +197,10 @@ Return JSON:
     response.setdefault("metadata", {})
     if isinstance(response["metadata"], dict):
         response["metadata"]["writing_context_mode"] = context_mode
-        response["metadata"]["writing_context_used"] = isinstance(writing_context, dict)
+        response["metadata"]["writing_context_used"] = fallback_metadata["writing_context_used"]
         response["metadata"]["writing_context_preflight_status"] = preflight_status or "not_provided"
+        response["metadata"]["fallback_reason_code"] = fallback_metadata["fallback_reason_code"]
+        response["metadata"]["fallback_source"] = fallback_metadata["fallback_source"]
         response["metadata"]["writing_context_debug_version"] = (
             writing_context_debug.get("assembler_version")
             if isinstance(writing_context_debug, dict)


### PR DESCRIPTION
## Summary
- Adds explicit fallback metadata when `writing_context` is absent and the worker uses legacy `working_set` compatibility context.
- Fails present-but-invalid `WritingContext` payloads instead of silently falling back to `working_set`.
- Stops prompt construction from treating `WritingContext` and `WorkingSet` as equal sources when valid context is present.

## Validation
- `python3 -m unittest services/memory-bridge/tests/test_chapter_writer_context_strict.py`
- `python3 -m py_compile services/memory-bridge/worker_chapter_writer.py services/memory-bridge/worker_task_handlers.py`
- `git diff --check -- services/memory-bridge/worker_chapter_writer.py services/memory-bridge/tests/test_chapter_writer_context_strict.py`

## Notes
- Base branch: `staging`
- Scope is limited to the chapter writer worker and its strict context tests.