### PR TITLE
Rebuild Novel Lab Write workspace

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -40,9 +40,11 @@ Refactor direction for large modules:
 - Scenes UI:
   - `src/app/scenes/page.tsx`
   - `src/app/scenes/[sceneId]/page.tsx`
+  - `src/app/stories/[slug]/write/page.tsx`
   - `src/features/scenes/components/ScenesPageClient.tsx`
   - `src/features/scenes/components/SceneDetailClient.tsx`
   - `src/features/scenes/components/DraftRunner.tsx`
+  - `src/features/scenes/components/writeTab/NovelLabWorkspace.tsx` (Novel Lab command/artifact Write slice)
 - Dictionary & Shelf:
   - `src/features/dictionary/components/DictionaryManager.tsx`
   - `src/app/shelf/page.tsx`
@@ -245,17 +247,6 @@ Thực thể chính:
 - `narrative_scene_version`
 - `narrative_pipeline_run`
 - `timeline_event`
-- `story_worldbuilding_note`
-- `story_style_profile`
-- `canon_fact`
-- `timeline_anchor`
-- `style_profile_scene`
-- `memory_enrich_task`
-
-## 6) Env và chạy local
-
-`.env` tối thiểu:
-
 - `DATABASE_URL`
 - `LLM_API_BASE`
 - `LLM_MODEL`
@@ -313,11 +304,15 @@ This section is the canonical UI reference for Map/Write surfaces until a separa
 
 Primary references:
 
-1. `docs/architecture/stage3_structure_contract.md` (product + interaction contract)
-2. `apps/studio/src/features/map/components/MapPageClient.tsx` (current map UX patterns)
-3. `apps/studio/src/features/scenes/components/DraftRunner.tsx` (write UX patterns)
-4. `apps/studio/README.md` section 8 (visual rules below)
-5. `db/migrations/009_stage3_structure_mapping.sql` (Stage 3 schema)
+1. `docs/architecture/ui-information-architecture.md` (surface ownership and Write IA)
+2. `docs/architecture/conversational-command-orchestrator.md` (Novel Lab command/control contract)
+3. `docs/architecture/conversational-command-mvp-map.md` (MVP slash command mapping)
+4. `apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx` (current Novel Lab Write workspace composition)
+5. `apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx` (center command/task stream)
+6. `apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx` (right artifact editor/review surface)
+7. `apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx` (right inspector summary rail)
+8. `apps/studio/src/features/map/components/MapPageClient.tsx` (current map UX patterns)
+9. `apps/studio/README.md` section 8 (visual rules below)
 
 ### Visual rules (must follow)
 
@@ -355,6 +350,11 @@ Primary references:
 - `MAP_LOCKED` blocks all map writes, but export remains enabled
 - Show state badge clearly: `DRAFT` / `COMMITTED` / `LOCKED`
 - Use one `busy` state to prevent double-submit on header actions
+- Novel Lab Write uses `Context Clean` -> `proceed`, `Context Partial` -> `degraded`, and `Context Blocked` -> `blocked`.
+- The center work stream owns commands, task progress, and result summaries only; long generated prose belongs in the right artifact workspace.
+- Slash commands appear from the composer when invoked, not as a permanent command palette.
+- The right artifact workspace owns editable prose, review actions, and the inspector rail.
+- `Approve revision` stays locked until continuity validation passes; `Run continuity check` is primary while validation is pending.
 
 ## 9) UI Philosophy (Global)
 

--- a/apps/studio/src/app/globals.css
+++ b/apps/studio/src/app/globals.css
@@ -1,15 +1,32 @@
 @import "tailwindcss";
 
 :root {
-  --background: #060c12;
-  --foreground: #e8edf2;
-  --surface-1: #0f1722;
-  --surface-2: #121d2b;
-  --border-soft: #223247;
-  --text-muted: #91a3ba;
+  --bg-app: #0b0f14;
+  --bg-sidebar: #101720;
+  --bg-surface: #111827;
+  --bg-surface-muted: #0f1620;
+  --bg-hover: #182332;
+  --border-subtle: #2a3441;
+  --border-strong: #3a4a5e;
+  --text-primary: #e5e7eb;
+  --text-secondary: #9ca3af;
+  --text-muted: #6f7d8d;
   --accent: #42c7b8;
   --accent-2: #f2b35f;
-  --danger: #ff6b6b;
+  --danger: #ef4444;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-soft:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 12px 32px rgba(0, 0, 0, 0.05);
+  --background: var(--bg-app);
+  --foreground: var(--text-primary);
+  --surface-1: var(--bg-surface);
+  --surface-2: var(--bg-surface-muted);
+  --border-soft: var(--border-subtle);
 }
 
 @theme inline {
@@ -20,17 +37,14 @@
 }
 
 body {
-  background:
-    radial-gradient(1200px 700px at 12% -8%, rgba(66, 199, 184, 0.16), transparent 60%),
-    radial-gradient(900px 560px at 90% -20%, rgba(242, 179, 95, 0.14), transparent 58%),
-    linear-gradient(180deg, #070d14 0%, #04090f 100%);
+  background: #0b0f14;
   color: var(--foreground);
-  font-family: var(--font-geist-sans), "Segoe UI", sans-serif;
-  letter-spacing: 0.01em;
+  font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0;
 }
 
 ::selection {
-  background: rgba(66, 199, 184, 0.28);
+  background: rgba(66, 199, 184, 0.24);
 }
 
 .app-shell {
@@ -41,54 +55,103 @@ body {
   position: sticky;
   top: 0;
   z-index: 30;
-  backdrop-filter: blur(12px);
-  background: rgba(6, 12, 18, 0.86);
-  border-bottom: 1px solid var(--border-soft);
+  backdrop-filter: blur(14px);
+  background: rgba(11, 15, 20, 0.92);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.app-header__inner {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  width: 100%;
+  min-height: 54px;
+  padding: 0 18px;
+}
+
+.app-body {
+  width: 100%;
+  padding: 0;
+}
+
+.app-context-bar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.app-context-bar > span:not(.status-pill) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-context-bar__crumb {
+  color: var(--text-primary);
+}
+
+.app-context-bar__slash {
+  color: var(--text-muted);
 }
 
 .brand-mark {
   display: inline-flex;
   flex-direction: column;
   line-height: 0.9;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-weight: 500;
+  letter-spacing: 0;
   text-transform: uppercase;
-  color: #f4f8fc;
+  color: var(--text-primary);
 }
 
 .shell-control {
-  border: 1px solid var(--border-soft);
-  background: var(--surface-1);
-  color: var(--foreground);
-  border-radius: 10px;
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 180ms ease,
+    transform 150ms ease;
 }
 
 .shell-control:focus,
 .shell-control:focus-visible {
   outline: none;
-  border-color: #3f6b90;
-  box-shadow: 0 0 0 3px rgba(66, 199, 184, 0.2);
+  border-color: rgba(66, 199, 184, 0.38);
+  box-shadow: 0 0 0 3px rgba(66, 199, 184, 0.14);
 }
 
 .shell-link {
-  border: 1px solid var(--border-soft);
-  background: linear-gradient(180deg, rgba(17, 28, 42, 0.9), rgba(12, 20, 30, 0.95));
-  border-radius: 10px;
-  color: #e7edf5;
-  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 180ms ease,
+    transform 150ms ease;
 }
 
 .shell-link:hover {
-  border-color: #34506d;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
 }
 
 .shell-link--active {
-  border-color: #2f6b99;
-  background: linear-gradient(180deg, rgba(24, 45, 68, 0.95), rgba(16, 31, 48, 0.98));
-  box-shadow: inset 0 0 0 1px rgba(122, 187, 236, 0.22);
+  border-color: rgba(66, 199, 184, 0.36);
+  background: rgba(66, 199, 184, 0.1);
+  color: var(--accent);
 }
 
 .shell-link:active {
@@ -96,57 +159,697 @@ body {
 }
 
 .surface-card {
-  border: 1px solid var(--border-soft);
-  background: linear-gradient(180deg, rgba(18, 29, 43, 0.82), rgba(12, 20, 30, 0.82));
-  border-radius: 14px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
   transition: border-color 180ms ease, box-shadow 180ms ease;
 }
 
 .surface-card:hover {
-  border-color: #2d4561;
+  border-color: var(--border-strong);
 }
 
 .muted {
   color: var(--text-muted);
 }
 
+.accent-text {
+  color: var(--accent);
+}
+
 .status-pill {
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--border-soft);
-  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
   padding: 2px 8px;
   font-size: 11px;
-  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+  letter-spacing: 0;
 }
 
 .status-pill--locked {
-  border-color: #5d4430;
+  border-color: rgba(242, 179, 95, 0.36);
   color: var(--accent-2);
   background: rgba(242, 179, 95, 0.08);
 }
 
 .status-pill--drafting {
-  border-color: #2f5b58;
+  border-color: rgba(66, 199, 184, 0.26);
   color: var(--accent);
-  background: rgba(66, 199, 184, 0.09);
+  background: rgba(66, 199, 184, 0.08);
 }
 
 .status-pill--other {
-  border-color: #34506d;
-  color: #a2c2df;
-  background: rgba(58, 98, 139, 0.11);
+  border-color: var(--border-subtle);
+  color: var(--text-secondary);
+  background: var(--bg-surface-muted);
+}
+
+.workspace-sidebar {
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border-subtle);
+}
+
+.command-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-soft);
+}
+
+.right-panel {
+  min-height: calc(100svh - 9rem);
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border-subtle);
+}
+
+.quiet-empty-state {
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface-muted);
+  color: var(--text-secondary);
+}
+
+.primary-action {
+  border: 1px solid rgba(66, 199, 184, 0.42);
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: #07100f;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 180ms ease,
+    transform 150ms ease;
+}
+
+.primary-action:hover {
+  background: #69d6ca;
+  border-color: #69d6ca;
+}
+
+.locked-action {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface-muted);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.status-pill--clean {
+  border-color: rgba(34, 197, 94, 0.28);
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.status-pill--partial {
+  border-color: rgba(242, 179, 95, 0.34);
+  color: var(--accent-2);
+  background: rgba(242, 179, 95, 0.09);
+}
+
+.status-pill--blocked {
+  border-color: rgba(239, 68, 68, 0.34);
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.novel-lab-workspace {
+  display: grid;
+  grid-template-columns: 236px minmax(420px, 0.92fr) minmax(520px, 1.18fr);
+  gap: 1px;
+  min-height: calc(100svh - 55px);
+  background: var(--border-subtle);
+}
+
+.novel-lab-nav,
+.work-stream,
+.artifact-workspace {
+  min-width: 0;
+  background: rgba(13, 18, 25, 0.98);
+}
+
+.novel-lab-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 16px;
+}
+
+.novel-lab-story-card {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.novel-lab-cover {
+  width: 48px;
+  height: 64px;
+  border-radius: 6px;
+  border: 1px solid rgba(66, 199, 184, 0.22);
+  background:
+    linear-gradient(150deg, rgba(66, 199, 184, 0.28), transparent 52%),
+    linear-gradient(180deg, #182332, #0d131c);
+}
+
+.novel-lab-nav-row,
+.novel-lab-chapter-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-radius: var(--radius-sm);
+  padding: 8px;
+  color: var(--text-secondary);
+}
+
+.novel-lab-nav-row--active,
+.novel-lab-chapter-row--selected {
+  background: rgba(66, 199, 184, 0.09);
+  color: var(--text-primary);
+}
+
+.novel-lab-nav-row--secondary {
+  opacity: 0.72;
+}
+
+.novel-lab-chapter-row {
+  border: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.slash-menu,
+.document-artifact,
+.inspector-mini-card,
+.inspector-note {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface-muted);
+}
+
+.slash-menu {
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  bottom: calc(100% + 10px);
+  z-index: 5;
+  padding: 10px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.slash-menu__section {
+  padding: 4px 8px 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.slash-menu-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.8fr) minmax(0, 1.2fr);
+  gap: 8px;
+  width: 100%;
+  border-radius: 6px;
+  padding: 7px 8px;
+  text-align: left;
+}
+
+.slash-menu-row:hover {
+  background: var(--bg-hover);
+}
+
+.slash-menu-row--muted {
+  opacity: 0.78;
+}
+
+.slash-menu-more summary {
+  cursor: pointer;
+  padding: 7px 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.artifact-workspace {
+  display: flex;
+  overflow: hidden;
+}
+
+.artifact-main {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  background: #0d1219;
+}
+
+.artifact-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 16px 18px;
+}
+
+.artifact-header h2 {
+  font-size: 18px;
+  font-weight: 650;
+}
+
+.artifact-kicker {
+  margin-bottom: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.artifact-actions,
+.artifact-tabs,
+.inspector-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.artifact-tabs {
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 10px 14px;
+}
+
+.document-artifact {
+  margin: 0;
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 22px;
+}
+
+.document-editor {
+  width: 100%;
+  min-height: 180px;
+  resize: vertical;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-sm);
+  background: #0d131c;
+  color: var(--text-primary);
+  padding: 14px;
+  font-size: 14px;
+  line-height: 1.6;
+  outline: none;
+}
+
+.document-editor:focus {
+  border-color: rgba(66, 199, 184, 0.38);
+  box-shadow: 0 0 0 3px rgba(66, 199, 184, 0.1);
+}
+
+.document-preview {
+  margin-top: 16px;
+  max-width: 760px;
+  color: #d9dee6;
+}
+
+.document-block {
+  position: relative;
+  margin-bottom: 16px;
+  border-radius: var(--radius-sm);
+  padding: 8px 12px 8px 28px;
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.document-block--selected {
+  background: rgba(66, 199, 184, 0.06);
+  outline: 1px solid rgba(66, 199, 184, 0.18);
+}
+
+.document-handle {
+  position: absolute;
+  left: 8px;
+  top: 13px;
+  color: var(--text-muted);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+}
+
+.document-comment,
+.mini-toolbar {
+  display: inline-flex;
+  border: 1px solid rgba(242, 179, 95, 0.32);
+  border-radius: var(--radius-pill);
+  background: rgba(242, 179, 95, 0.08);
+  color: var(--accent-2);
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+.mini-toolbar {
+  position: absolute;
+  right: 12px;
+  top: -12px;
+  background: #101720;
+}
+
+.artifact-inspector {
+  position: relative;
+  flex: 0 0 auto;
+  border-left: 1px solid var(--border-subtle);
+  background: rgba(15, 22, 32, 0.95);
+  padding: 12px;
+  overflow: auto;
+}
+
+.work-stream {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100svh - 55px);
+}
+
+.work-stream__scroll {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  padding: 28px 22px 120px;
+}
+
+.work-stream__intro {
+  max-width: 620px;
+  margin: 0 auto 28px;
+}
+
+.work-stream__intro h1 {
+  margin-top: 8px;
+  color: var(--text-primary);
+  font-size: 22px;
+  font-weight: 650;
+}
+
+.work-stream__intro p {
+  margin-top: 8px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.work-stream__eyebrow {
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.work-message,
+.work-task-list {
+  max-width: 620px;
+  margin: 0 auto;
+}
+
+.work-message {
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.035);
+  padding: 14px 16px;
+}
+
+.work-message__label {
+  margin-bottom: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.work-task-list {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.work-task-card {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-md);
+  background: rgba(17, 24, 39, 0.72);
+  padding: 14px 16px;
+}
+
+.work-task-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.work-task-card__title {
+  margin-top: 8px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.work-task-card p {
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.work-task-card button {
+  margin-top: 12px;
+  color: var(--accent);
+  font-size: 12px;
+}
+
+.work-composer-wrap {
+  position: sticky;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 16px 18px 18px;
+  background: linear-gradient(180deg, transparent, rgba(13, 18, 25, 0.92) 30%, rgba(13, 18, 25, 1));
+}
+
+.work-composer {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  max-width: 680px;
+  margin: 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-lg);
+  background: #111827;
+  padding: 10px;
+}
+
+.work-composer input {
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 14px;
+  outline: none;
+}
+
+.work-composer__menu {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+  font-family: var(--font-geist-mono), monospace;
+}
+
+.artifact-empty {
+  display: grid;
+  align-content: center;
+  justify-items: start;
+  gap: 18px;
+  min-height: 420px;
+  padding: 36px;
+}
+
+.artifact-empty__title {
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 650;
+}
+
+.artifact-empty p {
+  margin-top: 8px;
+  max-width: 480px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.artifact-empty__actions,
+.document-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.inspector-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+  font-size: 12px;
+}
+
+.inspector-summary-list,
+.inspector-stack {
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.inspector-summary-row {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr);
+  gap: 10px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.inspector-summary-row strong {
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.inspector-summary-row p {
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+.inspector-resize-handle {
+  position: absolute;
+  left: -3px;
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  cursor: col-resize;
+}
+
+.workflow-timeline {
+  margin-top: 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.workflow-step {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  gap: 10px;
+}
+
+.workflow-dot {
+  margin-top: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--text-muted);
+}
+
+.workflow-dot--done {
+  background: #22c55e;
+}
+
+.workflow-dot--active {
+  background: var(--accent);
+}
+
+.workflow-dot--pending {
+  background: var(--accent-2);
+}
+
+.workflow-dot--locked {
+  background: var(--text-muted);
+}
+
+.inspector-card-grid {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.inspector-mini-card,
+.inspector-note {
+  padding: 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.inspector-note {
+  margin-top: 12px;
+}
+
+@media (max-width: 1180px) {
+  .novel-lab-workspace {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .artifact-workspace {
+    grid-column: 1 / -1;
+    min-height: 620px;
+  }
+}
+
+@media (max-width: 760px) {
+  .app-header__inner {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 10px 14px;
+  }
+
+  .app-context-bar {
+    flex-wrap: wrap;
+    white-space: normal;
+  }
+
+  .novel-lab-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .artifact-workspace {
+    flex-direction: column;
+  }
+
+  .artifact-header {
+    flex-direction: column;
+  }
+
+  .artifact-inspector {
+    width: auto !important;
+    border-left: 0;
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  .inspector-resize-handle {
+    display: none;
+  }
 }
 
 .llama-toggle {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid var(--border-soft);
-  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
   padding: 4px 8px 4px 10px;
-  background: rgba(17, 28, 42, 0.9);
-  color: #d6e2ef;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
   transition: border-color 140ms ease, background 140ms ease, opacity 140ms ease;
 }
 
@@ -156,7 +859,7 @@ body {
 
 .llama-toggle__label {
   font-size: 11px;
-  letter-spacing: 0.03em;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 
@@ -165,7 +868,7 @@ body {
   width: 30px;
   height: 16px;
   border-radius: 999px;
-  background: #334155;
+  background: var(--border-strong);
 }
 
 .llama-toggle__thumb {
@@ -180,17 +883,17 @@ body {
 }
 
 .llama-toggle--on {
-  border-color: #2b7a71;
-  background: rgba(33, 80, 74, 0.35);
+  border-color: rgba(91, 91, 214, 0.32);
+  background: rgba(91, 91, 214, 0.07);
 }
 
 .llama-toggle--on .llama-toggle__track {
-  background: #2b7a71;
+  background: var(--accent);
 }
 
 .llama-toggle--on .llama-toggle__thumb {
   left: 16px;
-  background: #eafffa;
+  background: #ffffff;
 }
 
 .agent-stage {

--- a/apps/studio/src/app/layout.tsx
+++ b/apps/studio/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
-import { JetBrains_Mono, Space_Grotesk } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import AppShell from "@/components/AppShell";
 import "./globals.css";
 
-const appSans = Space_Grotesk({
+const appSans = Inter({
   variable: "--font-geist-sans",
   subsets: ["latin"],
 });

--- a/apps/studio/src/app/page.tsx
+++ b/apps/studio/src/app/page.tsx
@@ -1,5 +1,12 @@
-import { redirect } from "next/navigation";
+import WriteTabClient from "@/features/scenes/components/WriteTabClient";
+import { listStories } from "@/features/scenes/server/workflow/repoStory";
+import { pool } from "@/server/db/pool";
 
-export default function Home() {
-  redirect("/shelf");
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const stories = await listStories(pool);
+  const storySlug = stories[0]?.slug ?? "default";
+
+  return <WriteTabClient storySlug={storySlug} />;
 }

--- a/apps/studio/src/components/AppShell.tsx
+++ b/apps/studio/src/components/AppShell.tsx
@@ -2,315 +2,58 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import { StoryProvider, useStory } from "@/features/story/StoryContext";
 import StorySelector from "@/features/story/StorySelector";
 
-export default function AppShell({ children }: { children: React.ReactNode }) {
+export default function AppShell({ children }: { children: ReactNode }) {
   return (
     <StoryProvider>
       <div className="app-shell">
         <header className="app-header">
-          <div className="mx-auto flex w-full max-w-7xl flex-col gap-2 px-4 py-3">
-            <div className="flex items-center justify-between">
-              <Link href="/shelf" className="brand-mark text-sm">
-                <span>Novel</span>
-                <span>AI</span>
-              </Link>
-              <StorySelector />
-            </div>
-            <HeaderContextRow />
+          <div className="app-header__inner">
+            <Link href="/" className="brand-mark text-sm" aria-label="Novel Lab home">
+              <span>Novel</span>
+              <span>Lab</span>
+            </Link>
+            <CompactContextBar />
+            <StorySelector />
           </div>
         </header>
-        <div className="mx-auto w-full max-w-none px-1 pb-6 pt-2">{children}</div>
+        <div className="app-body">{children}</div>
       </div>
     </StoryProvider>
   );
 }
 
-function sceneStatusClass(status: string | null): string {
-  if (!status) return "status-pill status-pill--other";
-  if (status === "LOCKED") return "status-pill status-pill--locked";
-  if (status === "DRAFTING" || status === "DRAFTED") return "status-pill status-pill--drafting";
-  return "status-pill status-pill--other";
+function routeLabel(pathname: string): string {
+  if (pathname.includes("/reviews")) return "Reviews";
+  if (pathname.includes("/memory")) return "Memory";
+  if (pathname.includes("/read")) return "Reader";
+  if (pathname.includes("/publish")) return "Publish";
+  if (pathname.includes("/ingest")) return "Ingest";
+  if (pathname.includes("/analysis")) return "Analysis";
+  if (pathname.includes("/map")) return "Map";
+  if (pathname.includes("/write") || pathname === "/") return "Write";
+  return "Studio";
 }
 
-function HeaderContextRow() {
+function CompactContextBar() {
   const pathname = usePathname();
-  const { storySlug, headerContext, headerBusy, headerBusyLabel, runHeaderAction } = useStory();
-  const [llamaRunning, setLlamaRunning] = useState(false);
-  const [llamaBusy, setLlamaBusy] = useState(false);
-  const [llamaError, setLlamaError] = useState<string | null>(null);
-  const [workerPanelOpen, setWorkerPanelOpen] = useState(false);
-  const [workerBusy, setWorkerBusy] = useState(false);
-  const [workerError, setWorkerError] = useState<string | null>(null);
-  const [laneStatus, setLaneStatus] = useState<Record<string, { running: boolean; pid: number | null }>>({});
-  const [queueMetrics, setQueueMetrics] = useState<Record<string, Record<string, number>>>({});
-
-  const areaLabel = pathname.includes("/map") ? "Map" : pathname.includes("/write") ? "Write" : "Studio";
+  const { headerContext } = useStory();
+  const areaLabel = routeLabel(pathname);
   const chapter = headerContext.chapterLabel ?? "No chapter";
-  const scene = headerContext.sceneLabel ?? "No scene";
-
-  const refreshLlamaStatus = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/${encodeURIComponent(storySlug)}/ingest/worker`, { cache: "no-store" });
-      const json = (await res.json()) as {
-        ok?: boolean;
-        llama?: { running?: boolean };
-        lanes?: Array<{ lane: string; running?: boolean; pid?: number | null }>;
-        queue?: Record<string, Record<string, number>>;
-      };
-      if (res.ok && json.ok !== false) {
-        setLlamaRunning(Boolean(json.llama?.running));
-        const nextLaneMap: Record<string, { running: boolean; pid: number | null }> = {};
-        for (const row of Array.isArray(json.lanes) ? json.lanes : []) {
-          nextLaneMap[String(row.lane || "")] = {
-            running: Boolean(row.running),
-            pid: Number.isFinite(Number(row.pid)) ? Number(row.pid) : null,
-          };
-        }
-        setLaneStatus(nextLaneMap);
-        setQueueMetrics(json.queue && typeof json.queue === "object" ? json.queue : {});
-      }
-    } catch {
-      // ignore header status failures
-    }
-  }, [storySlug]);
-
-  useEffect(() => {
-    void refreshLlamaStatus();
-    const timer = window.setInterval(() => {
-      void refreshLlamaStatus();
-    }, 15000);
-    return () => window.clearInterval(timer);
-  }, [refreshLlamaStatus]);
-
-  const toggleLlama = useCallback(async () => {
-    if (llamaBusy) return;
-    setLlamaBusy(true);
-    setLlamaError(null);
-    try {
-      await runHeaderAction(llamaRunning ? "Stopping llama server" : "Starting llama server", async () => {
-        const action = llamaRunning ? "stop_llama" : "start_llama";
-        const res = await fetch(`/api/${encodeURIComponent(storySlug)}/ingest/worker`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action }),
-        });
-        const json = (await res.json()) as { ok?: boolean; error?: string; hint?: string; llama?: { running?: boolean } };
-        if (!res.ok || json.ok === false) {
-          throw new Error(json.hint || json.error || "LLAMA_TOGGLE_FAILED");
-        }
-        setLlamaRunning(Boolean(json.llama?.running));
-      });
-    } catch (err: unknown) {
-      setLlamaError(err instanceof Error ? err.message : "Llama toggle failed");
-    } finally {
-      setLlamaBusy(false);
-    }
-  }, [llamaBusy, llamaRunning, runHeaderAction, storySlug]);
-
-  const runWorkerAction = useCallback(
-    async (label: string, action: string, lane?: "split" | "analysis" | "writing" | "all") => {
-      if (workerBusy) return;
-      setWorkerBusy(true);
-      setWorkerError(null);
-      try {
-        await runHeaderAction(label, async () => {
-          const res = await fetch(`/api/${encodeURIComponent(storySlug)}/ingest/worker`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(lane ? { action, lane } : { action }),
-          });
-          const json = (await res.json()) as { ok?: boolean; error?: string; hint?: string };
-          if (!res.ok || json.ok === false) throw new Error(json.hint || json.error || "WORKER_ACTION_FAILED");
-        });
-      } catch (err: unknown) {
-        setWorkerError(err instanceof Error ? err.message : "Worker action failed");
-      } finally {
-        setWorkerBusy(false);
-        void refreshLlamaStatus();
-      }
-    },
-    [refreshLlamaStatus, runHeaderAction, storySlug, workerBusy]
-  );
-
-  const laneStats = (lane: "split" | "analysis" | "writing") => {
-    const row = queueMetrics[lane] || {};
-    return {
-      ready: Number(row.READY || 0),
-      running: Number(row.RUNNING || 0),
-      failed: Number(row.FAILED || 0),
-    };
-  };
 
   return (
-    <div className="surface-card flex flex-wrap items-center justify-between gap-2 p-2">
-      <div className="flex flex-wrap items-center gap-2 text-sm">
-        <span className="muted text-xs uppercase tracking-wide">{areaLabel}</span>
-        <span className="shell-link px-2 py-1 text-xs">Chapter: {chapter}</span>
-        <span className="shell-link px-2 py-1 text-xs">Scene: {scene}</span>
-        {headerContext.sceneStatus ? (
-          <span className={sceneStatusClass(headerContext.sceneStatus)}>{headerContext.sceneStatus}</span>
-        ) : null}
-      </div>
-      <div className="flex items-center gap-2 text-xs">
-        <button
-          type="button"
-          className="shell-link px-2 py-1"
-          onClick={() => setWorkerPanelOpen((v) => !v)}
-          title="Global worker control"
-        >
-          Worker Ctrl
-        </button>
-        <button
-          type="button"
-          className={`llama-toggle ${llamaRunning ? "llama-toggle--on" : "llama-toggle--off"}`}
-          role="switch"
-          aria-checked={llamaRunning}
-          aria-label="Toggle llama server"
-          onClick={() => void toggleLlama()}
-          disabled={llamaBusy}
-          title={llamaRunning ? "Llama server: On" : "Llama server: Off"}
-        >
-          <span className="llama-toggle__label">Llama</span>
-          <span className="llama-toggle__track">
-            <span className="llama-toggle__thumb" />
-          </span>
-        </button>
-        {headerBusy ? (
-          <>
-            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-[#38BDF8]" aria-hidden />
-            <span className="muted">{headerBusyLabel ?? "Running..."}</span>
-          </>
-        ) : (
-          <span className="muted">Ready</span>
-        )}
-      </div>
-      {workerPanelOpen ? (
-        <div className="w-full rounded border border-[#2A3441] bg-[#0B1016] p-3 text-xs">
-          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-            <div className="text-sm font-semibold text-slate-200">Worker Control Center</div>
-            <div className="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                className="shell-link px-2 py-1"
-                disabled={workerBusy}
-                onClick={() => void runWorkerAction("Starting all lanes", "start_all_lanes")}
-              >
-                Start All
-              </button>
-              <button
-                type="button"
-                className="shell-link px-2 py-1"
-                disabled={workerBusy}
-                onClick={() => void runWorkerAction("Restarting all lanes", "restart_all_lanes")}
-              >
-                Restart All
-              </button>
-              <button
-                type="button"
-                className="shell-link px-2 py-1"
-                disabled={workerBusy}
-                onClick={() => void runWorkerAction("Stopping all lanes", "stop_all_lanes")}
-              >
-                Stop All
-              </button>
-              <button
-                type="button"
-                className="shell-link px-2 py-1"
-                disabled={workerBusy}
-                onClick={() => void refreshLlamaStatus()}
-              >
-                Refresh
-              </button>
-            </div>
-          </div>
-
-          <div className="mb-3 grid gap-2 md:grid-cols-4">
-            {(["split", "analysis", "writing", "all"] as const).map((lane) => {
-              const running = Boolean(laneStatus[lane]?.running);
-              const pid = laneStatus[lane]?.pid;
-              return (
-                <div key={lane} className="rounded border border-[#24303d] bg-[#0E141C] px-2 py-1.5">
-                  <div className="flex items-center justify-between">
-                    <span className="font-medium text-slate-200">{lane}</span>
-                    <span className={running ? "text-emerald-300" : "text-slate-400"}>
-                      {running ? "online" : "offline"}
-                    </span>
-                  </div>
-                  <div className="mt-1 text-[11px] text-slate-400">pid: {pid ?? "-"}</div>
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="grid gap-2 md:grid-cols-3">
-            {(["split", "analysis", "writing"] as const).map((lane) => {
-              const stats = laneStats(lane);
-              const running = Boolean(laneStatus[lane]?.running);
-              return (
-                <div key={lane} className="rounded border border-[#24303d] bg-[#0F141B] p-2.5">
-                  <div className="mb-2 flex items-center justify-between">
-                    <span className="text-sm font-medium text-slate-200">{lane}</span>
-                    <span
-                      className={`rounded px-2 py-0.5 text-[11px] ${
-                        running ? "bg-emerald-500/15 text-emerald-300" : "bg-slate-500/15 text-slate-400"
-                      }`}
-                    >
-                      {running ? "running" : "stopped"}
-                    </span>
-                  </div>
-
-                  <div className="mb-2 grid grid-cols-3 gap-1.5 text-[11px]">
-                    <div className="rounded border border-[#2A3441] bg-[#111927] px-1.5 py-1 text-center">
-                      <div className="muted">READY</div>
-                      <div className="font-medium text-slate-200">{stats.ready}</div>
-                    </div>
-                    <div className="rounded border border-[#2A3441] bg-[#111927] px-1.5 py-1 text-center">
-                      <div className="muted">RUN</div>
-                      <div className="font-medium text-slate-200">{stats.running}</div>
-                    </div>
-                    <div className="rounded border border-[#2A3441] bg-[#111927] px-1.5 py-1 text-center">
-                      <div className="muted">FAIL</div>
-                      <div className={stats.failed > 0 ? "font-medium text-rose-300" : "font-medium text-slate-200"}>{stats.failed}</div>
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-3 gap-1.5">
-                    <button
-                      type="button"
-                      className="shell-link px-2 py-1"
-                      disabled={workerBusy}
-                      onClick={() => void runWorkerAction(`Starting ${lane} lane`, "start_lane", lane)}
-                    >
-                      Start
-                    </button>
-                    <button
-                      type="button"
-                      className="shell-link px-2 py-1"
-                      disabled={workerBusy}
-                      onClick={() => void runWorkerAction(`Restarting ${lane} lane`, "restart_lane", lane)}
-                    >
-                      Restart
-                    </button>
-                    <button
-                      type="button"
-                      className="shell-link px-2 py-1"
-                      disabled={workerBusy}
-                      onClick={() => void runWorkerAction(`Stopping ${lane} lane`, "stop_lane", lane)}
-                    >
-                      Stop
-                    </button>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
-      {workerError ? <div className="w-full text-xs text-[#ff9f9f]">{workerError}</div> : null}
-      {llamaError ? <div className="w-full text-xs text-[#ff9f9f]">{llamaError}</div> : null}
+    <div className="app-context-bar" aria-label="Workspace context">
+      <span className="app-context-bar__crumb">Novel Lab</span>
+      <span className="app-context-bar__slash">/</span>
+      <span>{areaLabel}</span>
+      <span className="app-context-bar__slash">/</span>
+      <span>{chapter}</span>
+      <span className="status-pill status-pill--partial">Context Partial</span>
+      <span className="status-pill status-pill--other">Worker Idle</span>
+      <span className="status-pill status-pill--other">Draft Saved</span>
     </div>
   );
 }

--- a/apps/studio/src/features/scenes/components/WriteTabClient.tsx
+++ b/apps/studio/src/features/scenes/components/WriteTabClient.tsx
@@ -37,6 +37,7 @@ export default function WriteTabClient({ storySlug }: { storySlug: string }) {
       pendingChapterProse={state.pendingChapterProse}
       onAutoWriteComplete={state.handleAutoWriteComplete}
       stagingData={state.stagingData}
+      v3Draft={state.v3Draft}
       onSaveChapterDraft={state.saveChapterDraft}
       onResplitChapter={state.resplitChapter}
     />

--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
@@ -1,0 +1,119 @@
+import { useState, type MouseEvent as ReactMouseEvent } from "react";
+import type { ContextReadiness, ContextReadinessLabel } from "@/features/scenes/components/writeTab/types";
+
+type InspectorTab = "Progress" | "Context" | "Issues" | "Memory" | "Versions";
+
+type ArtifactInspectorRailProps = {
+  readiness: ContextReadiness;
+  continuityQueued: boolean;
+};
+
+const readinessLabels: Record<ContextReadiness, ContextReadinessLabel> = {
+  proceed: "Context Clean",
+  degraded: "Context Partial",
+  blocked: "Context Blocked",
+};
+
+const workflowSteps = [
+  ["WritingContext", "Done", "Minimum viable context met"],
+  ["Draft", "Done", "Document artifact available when prose exists"],
+  ["Continuity", "Waiting", "Run after edit"],
+  ["Approval", "Locked", "Requires validation"],
+  ["Memory", "Locked", "Approved revision only"],
+] as const;
+
+function readinessClass(readiness: ContextReadiness): string {
+  if (readiness === "proceed") return "status-pill status-pill--clean";
+  if (readiness === "blocked") return "status-pill status-pill--blocked";
+  return "status-pill status-pill--partial";
+}
+
+function ProgressSummary({ continuityQueued }: { continuityQueued: boolean }) {
+  return (
+    <div className="inspector-summary-list">
+      {workflowSteps.map(([label, status, note]) => (
+        <div key={label} className="inspector-summary-row">
+          <span className={`workflow-dot workflow-dot--${status === "Done" ? "done" : status === "Locked" ? "locked" : continuityQueued ? "active" : "pending"}`} />
+          <div>
+            <strong>{label}</strong>
+            <p>{status === "Waiting" && continuityQueued ? "Running" : status} · {note}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TabPreview({ tab, continuityQueued }: { tab: InspectorTab; continuityQueued: boolean }) {
+  if (tab === "Progress") return <ProgressSummary continuityQueued={continuityQueued} />;
+  if (tab === "Context") {
+    return (
+      <div className="inspector-card-grid">
+        {["Intent: Clean", "Immediate continuity: Clean", "Active characters: Partial", "Open threads: Clean", "Forbidden reveals: Watch"].map((item) => (
+          <div key={item} className="inspector-mini-card">{item}</div>
+        ))}
+      </div>
+    );
+  }
+  if (tab === "Issues") {
+    return (
+      <div className="inspector-stack">
+        {["Forbidden reveal risk · Medium", "Relationship state uncertain · Low", "Timeline anchor missing · Low"].map((item) => (
+          <div key={item} className="inspector-note">{item}</div>
+        ))}
+      </div>
+    );
+  }
+  if (tab === "Memory") {
+    return (
+      <div className="inspector-stack">
+        {["fact candidate · Draft-only", "character state change · Needs review", "open thread · Can promote after approval"].map((item) => (
+          <div key={item} className="inspector-note">{item}</div>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="inspector-stack">
+      {["AI generated draft", "Human edit draft · rev_003", "Continuity checked draft", "Approved revision", "Export snapshot"].map((item) => (
+        <div key={item} className="inspector-note">{item}</div>
+      ))}
+    </div>
+  );
+}
+
+export default function ArtifactInspectorRail({ readiness, continuityQueued }: ArtifactInspectorRailProps) {
+  const [inspectorWidth, setInspectorWidth] = useState(308);
+  const [activeTab, setActiveTab] = useState<InspectorTab>("Progress");
+
+  const startResize = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = inspectorWidth;
+    const onMove = (moveEvent: MouseEvent) => setInspectorWidth(Math.min(380, Math.max(260, startWidth - (moveEvent.clientX - startX))));
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
+
+  return (
+    <aside className="artifact-inspector" style={{ width: inspectorWidth }} aria-label="Artifact inspector">
+      <div className="inspector-resize-handle" onMouseDown={startResize} aria-hidden />
+      <div className="inspector-topline">
+        <span className={readinessClass(readiness)}>{readinessLabels[readiness]}</span>
+        <span className="muted">2 warnings</span>
+      </div>
+      <div className="inspector-tabs" role="tablist">
+        {(["Progress", "Context", "Issues", "Memory", "Versions"] as InspectorTab[]).map((tab) => (
+          <button key={tab} type="button" className={tab === activeTab ? "shell-link shell-link--active px-2 py-1 text-xs" : "shell-link px-2 py-1 text-xs"} onClick={() => setActiveTab(tab)}>
+            {tab}
+          </button>
+        ))}
+      </div>
+      <TabPreview tab={activeTab} continuityQueued={continuityQueued} />
+    </aside>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from "react";
+import ArtifactInspectorRail from "@/features/scenes/components/writeTab/ArtifactInspectorRail";
+import type { ArtifactKind, ContextReadiness } from "@/features/scenes/components/writeTab/types";
+
+type ArtifactSurfaceProps = {
+  chapterTitle: string;
+  draftKey: string;
+  draftText: string;
+  hasChapter: boolean;
+  readiness: ContextReadiness;
+  continuityQueued: boolean;
+  onOpenAutoWrite: () => void;
+  onQueueContinuity: () => void;
+  onSaveDraft: (text: string) => Promise<void>;
+};
+
+function artifactKindLabel(kind: ArtifactKind): string {
+  if (kind === "document") return "Document Artifact";
+  if (kind === "analysis") return "Analysis Artifact";
+  if (kind === "review") return "Review Artifact";
+  if (kind === "memory") return "Memory Candidates";
+  if (kind === "publish_preview") return "Publish Preview";
+  return "Operations Artifact";
+}
+
+function ArtifactHeader({
+  chapterTitle,
+  hasDraft,
+  continuityQueued,
+  onQueueContinuity,
+}: {
+  chapterTitle: string;
+  hasDraft: boolean;
+  continuityQueued: boolean;
+  onQueueContinuity: () => void;
+}) {
+  return (
+    <header className="artifact-header">
+      <div>
+        <div className="artifact-kicker">{artifactKindLabel("document")}</div>
+        <div className="flex flex-wrap items-center gap-2">
+          <h2>{chapterTitle}</h2>
+          <span className="status-pill status-pill--drafting">{hasDraft ? "Draft" : "No Draft"}</span>
+        </div>
+        <div className="muted mt-1 flex flex-wrap items-center gap-2 text-xs">
+          <span>rev_003</span>
+          <span>{hasDraft ? "Saved 18s ago" : "Waiting for artifact"}</span>
+        </div>
+      </div>
+      <div className="artifact-actions">
+        <button type="button" className="primary-action px-3 py-2 text-xs" onClick={onQueueContinuity}>
+          {continuityQueued ? "Continuity running" : "Run continuity check"}
+        </button>
+        <button type="button" className="locked-action px-3 py-2 text-xs" disabled title="Requires continuity validation">
+          Approve revision
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function ArtifactTabs() {
+  return (
+    <div className="artifact-tabs" role="tablist" aria-label="Artifact modes">
+      {["Read", "Edit", "Analyze", "Review", "Approve"].map((tab) => (
+        <button key={tab} type="button" className={tab === "Edit" ? "shell-link shell-link--active px-3 py-1 text-xs" : "shell-link px-3 py-1 text-xs"}>
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function EmptyArtifact({ hasChapter, onOpenAutoWrite }: { hasChapter: boolean; onOpenAutoWrite: () => void }) {
+  return (
+    <div className="artifact-empty">
+      <div>
+        <div className="artifact-empty__title">{hasChapter ? "No draft artifact yet" : "No chapter selected"}</div>
+        <p>
+          {hasChapter
+            ? "Create a draft or paste prose before reviewing, validating, or approving this chapter."
+            : "Choose a chapter, create one, or ask Novel Lab what to write next."}
+        </p>
+      </div>
+      <div className="artifact-empty__actions">
+        <button type="button" className="primary-action px-4 py-2 text-sm" onClick={onOpenAutoWrite} disabled={!hasChapter}>
+          Create draft
+        </button>
+        <button type="button" className="shell-link px-4 py-2 text-sm">
+          Run readiness check
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DocumentArtifact({ initialText, onSaveDraft }: { initialText: string; onSaveDraft: (text: string) => Promise<void> }) {
+  const [draftText, setDraftText] = useState(initialText);
+  const paragraphs = useMemo(() => draftText.split(/\n{2,}/).map((part) => part.trim()).filter(Boolean), [draftText]);
+
+  return (
+    <div className="document-artifact">
+      <textarea className="document-editor" value={draftText} onChange={(event) => setDraftText(event.target.value)} aria-label="Editable chapter draft artifact" />
+      <div className="document-preview" aria-hidden>
+        {paragraphs.slice(0, 6).map((paragraph, index) => (
+          <div key={`${paragraph.slice(0, 16)}-${index}`} className={`document-block ${index === 1 ? "document-block--selected" : ""}`}>
+            <span className="document-handle">::</span>
+            <p>{paragraph}</p>
+            {index === 2 ? <span className="document-comment">comment</span> : null}
+            {index === 1 ? <span className="mini-toolbar">Rewrite · Expand · Analyze</span> : null}
+          </div>
+        ))}
+      </div>
+      <div className="document-footer">
+        <button type="button" className="shell-link px-3 py-1.5 text-xs" onClick={() => void onSaveDraft(draftText)}>
+          Save draft
+        </button>
+        <span className="muted text-xs">Draft text remains non-canon until approval.</span>
+      </div>
+    </div>
+  );
+}
+
+export default function ArtifactSurface(props: ArtifactSurfaceProps) {
+  const hasDraft = props.draftText.trim().length > 0;
+
+  return (
+    <section className="artifact-workspace" aria-label="Active artifact workspace">
+      <div className="artifact-main">
+        <ArtifactHeader
+          chapterTitle={props.chapterTitle}
+          hasDraft={hasDraft}
+          continuityQueued={props.continuityQueued}
+          onQueueContinuity={props.onQueueContinuity}
+        />
+        {hasDraft ? <ArtifactTabs /> : null}
+        {hasDraft ? (
+          <DocumentArtifact key={props.draftKey} initialText={props.draftText} onSaveDraft={props.onSaveDraft} />
+        ) : (
+          <EmptyArtifact hasChapter={props.hasChapter} onOpenAutoWrite={props.onOpenAutoWrite} />
+        )}
+      </div>
+      <ArtifactInspectorRail readiness={props.readiness} continuityQueued={props.continuityQueued} />
+    </section>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -1,0 +1,161 @@
+import type { CommandId, CommandTaskCard } from "@/features/scenes/components/writeTab/types";
+
+type CommandWorkStreamProps = {
+  chapterId: string;
+  hasDraft: boolean;
+  continuityQueued: boolean;
+  composerValue: string;
+  commandMenuOpen: boolean;
+  onComposerValueChange: (value: string) => void;
+  onCommandMenuOpenChange: (value: boolean) => void;
+  onOpenAutoWrite: () => void;
+  onQueueContinuity: () => void;
+};
+
+const primaryCommands: Array<{ id: CommandId; description: string }> = [
+  { id: "/write chapter", description: "Create or continue the active chapter draft" },
+  { id: "/analyze chapter", description: "Inspect continuity, context, and risks" },
+  { id: "/rewrite selection", description: "Rewrite selected prose in the active artifact" },
+  { id: "/continue from cursor", description: "Continue from the document cursor" },
+  { id: "/check continuity", description: "Find canon, timeline, and reveal issues" },
+];
+
+const moreCommands: Array<{ id: CommandId; description: string }> = [
+  { id: "/extract memory", description: "Preview draft-only memory candidates" },
+  { id: "/review chapter", description: "Open review checklist and scoring" },
+  { id: "/approve draft", description: "Locked until validation passes" },
+  { id: "/publish preview", description: "Preview approved reader-facing output" },
+];
+
+function statusLabel(status: CommandTaskCard["status"]): string {
+  if (status === "running") return "Running";
+  if (status === "completed") return "Completed";
+  if (status === "blocked") return "Blocked";
+  return "Ready";
+}
+
+function SlashCommandMenu({ onSelect }: { onSelect: (command: string) => void }) {
+  return (
+    <div className="slash-menu" role="menu" aria-label="Slash commands">
+      <div className="slash-menu__section">Primary commands</div>
+      {primaryCommands.map((command) => (
+        <button key={command.id} type="button" className="slash-menu-row" onClick={() => onSelect(command.id)}>
+          <span className="font-mono text-xs">{command.id}</span>
+          <span className="muted text-xs">{command.description}</span>
+        </button>
+      ))}
+      <details className="slash-menu-more">
+        <summary>More</summary>
+        <div className="mt-1 space-y-1">
+          {moreCommands.map((command) => (
+            <button key={command.id} type="button" className="slash-menu-row slash-menu-row--muted" onClick={() => onSelect(command.id)}>
+              <span className="font-mono text-xs">{command.id}</span>
+              <span className="muted text-xs">{command.description}</span>
+            </button>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function TaskCard({ task }: { task: CommandTaskCard }) {
+  return (
+    <article className={`work-task-card work-task-card--${task.status}`}>
+      <div className="work-task-card__meta">
+        <span className="font-mono text-xs">{task.command}</span>
+        <span>{statusLabel(task.status)}</span>
+      </div>
+      <div className="work-task-card__title">{task.title}</div>
+      <p>{task.detail}</p>
+      {task.cta ? <button type="button">{task.cta}</button> : null}
+    </article>
+  );
+}
+
+export default function CommandWorkStream(props: CommandWorkStreamProps) {
+  const showSlashMenu = props.commandMenuOpen || props.composerValue.trimStart().startsWith("/");
+  const chapterCommand = props.chapterId ? `/write chapter ${props.chapterId}` : "/write chapter";
+  const tasks: CommandTaskCard[] = [
+    {
+      id: "draft",
+      command: chapterCommand,
+      title: props.hasDraft ? "Draft artifact is open" : "No draft artifact yet",
+      status: props.chapterId ? "completed" : "blocked",
+      detail: props.chapterId
+        ? "Novel Lab will keep generated prose out of the command stream. The editable artifact lives on the right."
+        : "Choose or create a chapter, then run a writing command.",
+      cta: props.hasDraft ? "Review artifact" : "Create draft",
+    },
+    {
+      id: "continuity",
+      command: "/check continuity",
+      title: props.continuityQueued ? "Continuity check queued" : "Continuity validation is waiting",
+      status: props.continuityQueued ? "running" : "idle",
+      detail: props.continuityQueued
+        ? "Checking canon, timeline anchors, and forbidden reveal constraints."
+        : "Run validation after the document edit pass. Approval remains locked until this completes.",
+      cta: props.continuityQueued ? "Open progress" : "Run check",
+    },
+  ];
+
+  return (
+    <section className="work-stream" aria-label="Command work stream">
+      <div className="work-stream__scroll">
+        <div className="work-stream__intro">
+          <div className="work-stream__eyebrow">Current work</div>
+          <h1>Write and validate this chapter</h1>
+          <p>Give Novel Lab a command, then review the resulting artifact on the right.</p>
+        </div>
+
+        <div className="work-message work-message--user">
+          <div className="work-message__label">You</div>
+          <div className="font-mono text-sm">{chapterCommand} with slow tension and no full reveal</div>
+        </div>
+
+        <div className="work-task-list">
+          {tasks.map((task) => (
+            <TaskCard key={task.id} task={task} />
+          ))}
+        </div>
+      </div>
+
+      <div className="work-composer-wrap">
+        {showSlashMenu ? (
+          <SlashCommandMenu
+            onSelect={(command) => {
+              props.onComposerValueChange(`${command} `);
+              props.onCommandMenuOpenChange(false);
+            }}
+          />
+        ) : null}
+        <form
+          className="work-composer"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (props.composerValue.includes("/check continuity")) props.onQueueContinuity();
+            if (props.composerValue.includes("/write chapter")) props.onOpenAutoWrite();
+          }}
+        >
+          <button
+            type="button"
+            className="work-composer__menu"
+            aria-label="Open command menu"
+            onClick={() => props.onCommandMenuOpenChange(!props.commandMenuOpen)}
+          >
+            /
+          </button>
+          <input
+            value={props.composerValue}
+            onChange={(event) => props.onComposerValueChange(event.target.value)}
+            placeholder="Ask Novel Lab to write, analyze, revise..."
+            aria-label="Novel Lab command composer"
+          />
+          <button type="submit" className="primary-action px-4 py-2 text-sm">
+            Run
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -1,0 +1,187 @@
+import { useMemo, useState } from "react";
+import AutoWriteWizard from "@/features/scenes/components/writeTab/AutoWriteWizard";
+import ArtifactSurface from "@/features/scenes/components/writeTab/ArtifactSurface";
+import CommandWorkStream from "@/features/scenes/components/writeTab/CommandWorkStream";
+import type {
+  ChapterSceneItem,
+  ContextReadiness,
+  CurrentVersion,
+  SceneItem,
+} from "@/features/scenes/components/writeTab/types";
+
+type DraftSource = {
+  key: string;
+  text: string;
+};
+
+type NovelLabWorkspaceProps = {
+  storySlug: string;
+  chapterIds: string[];
+  scene: SceneItem | null;
+  current: CurrentVersion | null;
+  loadingScenes: boolean;
+  loadingDetail: boolean;
+  error: string | null;
+  selectedChapterId: string;
+  onChapterIdChange: (id: string) => void;
+  chapterScenes: ChapterSceneItem[];
+  loadingChapter: boolean;
+  onCreateNewChapter: () => Promise<void>;
+  showAutoWrite: boolean;
+  setShowAutoWrite: (value: boolean) => void;
+  pendingChapterProse: { id: string; prose: string } | null;
+  stagingData: { user_prose: string; llm_prose: string; status: string } | null;
+  v3Draft: { full_text: string; status: string; virtual_scenes: unknown[] } | null;
+  onAutoWriteComplete: (prose: string) => Promise<void>;
+  onSaveChapterDraft: (prose: string) => Promise<void>;
+};
+
+function getChapterTitle(chapterId: string): string {
+  return chapterId ? `Chapter ${chapterId}` : "No chapter selected";
+}
+
+function storyLabelFromSlug(storySlug: string): string {
+  return storySlug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ") || "Current story";
+}
+
+function buildDraftSource(props: NovelLabWorkspaceProps): DraftSource {
+  if (props.pendingChapterProse?.id === props.selectedChapterId) {
+    return { key: `pending-${props.selectedChapterId}`, text: props.pendingChapterProse.prose };
+  }
+  if (props.stagingData?.user_prose) return { key: `staging-user-${props.selectedChapterId}`, text: props.stagingData.user_prose };
+  if (props.v3Draft?.full_text) return { key: `v3-${props.selectedChapterId}`, text: props.v3Draft.full_text };
+
+  const sceneText = props.chapterScenes.map((item) => item.text_content).filter(Boolean).join("\n\n");
+  if (sceneText) return { key: `scenes-${props.selectedChapterId}-${props.chapterScenes.length}`, text: sceneText };
+  if (props.current?.text_content) return { key: `scene-${props.current.id}`, text: props.current.text_content };
+
+  return {
+    key: `empty-${props.selectedChapterId || "none"}`,
+    text: "",
+  };
+}
+
+function NavigationPanel(
+  props: Pick<NovelLabWorkspaceProps, "storySlug" | "chapterIds" | "loadingScenes" | "selectedChapterId" | "onChapterIdChange" | "onCreateNewChapter">
+) {
+  const visibleChapters = props.chapterIds.length ? props.chapterIds : [props.selectedChapterId].filter(Boolean);
+  const storyLabel = storyLabelFromSlug(props.storySlug);
+
+  return (
+    <aside className="novel-lab-nav" aria-label="Story navigation">
+      <div className="novel-lab-story-card">
+        <div className="novel-lab-cover" aria-hidden />
+        <div>
+          <div className="text-sm font-semibold">{storyLabel}</div>
+          <div className="muted text-xs">{props.chapterIds.length ? `${props.chapterIds.length} chapters` : "No chapters loaded"}</div>
+          <div className="mt-2 text-xs text-[var(--accent)]">{props.selectedChapterId || "No chapter"}</div>
+        </div>
+      </div>
+
+      <nav className="space-y-1 text-sm" aria-label="Workspace views">
+        {["Shelf", "Write", "Artifacts", "Memory", "Reviews", "Reader", "Publish"].map((item) => (
+          <div key={item} className={`novel-lab-nav-row ${item === "Write" ? "novel-lab-nav-row--active" : ""}`}>
+            <span aria-hidden>{item.slice(0, 1)}</span>
+            <span>{item}</span>
+          </div>
+        ))}
+      </nav>
+
+      <div className="space-y-2">
+        <div className="muted text-xs uppercase tracking-wide">Chapters</div>
+        {props.loadingScenes ? <div className="muted text-xs">Loading chapters...</div> : null}
+        {visibleChapters.length ? (
+          visibleChapters.map((chapterId) => (
+            <button
+              key={chapterId}
+              type="button"
+              className={`novel-lab-chapter-row ${chapterId === props.selectedChapterId ? "novel-lab-chapter-row--selected" : ""}`}
+              onClick={() => props.onChapterIdChange(chapterId)}
+            >
+              <span>{getChapterTitle(chapterId)}</span>
+              <span>{chapterId === props.selectedChapterId ? "Drafting" : "Not started"}</span>
+            </button>
+          ))
+        ) : (
+          <div className="quiet-empty-state p-3 text-xs">No chapters yet.</div>
+        )}
+        <button type="button" className="shell-link w-full px-3 py-2 text-xs" onClick={() => void props.onCreateNewChapter()}>
+          New chapter
+        </button>
+      </div>
+
+      <details className="novel-lab-operations">
+        <summary>Operations</summary>
+        <div className="mt-2 space-y-1">
+          {["Pipeline", "Settings"].map((item) => (
+            <div key={item} className="novel-lab-nav-row novel-lab-nav-row--secondary">
+              <span aria-hidden>{item.slice(0, 1)}</span>
+              <span>{item}</span>
+            </div>
+          ))}
+        </div>
+      </details>
+    </aside>
+  );
+}
+
+export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
+  const [continuityQueued, setContinuityQueued] = useState(false);
+  const [composerValue, setComposerValue] = useState(props.selectedChapterId ? `/write chapter ${props.selectedChapterId} ` : "");
+  const [commandMenuOpen, setCommandMenuOpen] = useState(false);
+  const draftSource = useMemo(() => buildDraftSource(props), [props]);
+  const chapterTitle = props.selectedChapterId ? `${getChapterTitle(props.selectedChapterId)} Draft` : "No chapter selected";
+  const readiness: ContextReadiness = "degraded";
+
+  return (
+    <>
+      <main className="novel-lab-workspace">
+        <NavigationPanel
+          storySlug={props.storySlug}
+          chapterIds={props.chapterIds}
+          loadingScenes={props.loadingScenes}
+          selectedChapterId={props.selectedChapterId}
+          onChapterIdChange={props.onChapterIdChange}
+          onCreateNewChapter={props.onCreateNewChapter}
+        />
+        <CommandWorkStream
+          chapterId={props.selectedChapterId}
+          hasDraft={draftSource.text.trim().length > 0}
+          continuityQueued={continuityQueued}
+          composerValue={composerValue}
+          commandMenuOpen={commandMenuOpen}
+          onComposerValueChange={setComposerValue}
+          onCommandMenuOpenChange={setCommandMenuOpen}
+          onOpenAutoWrite={() => props.setShowAutoWrite(true)}
+          onQueueContinuity={() => setContinuityQueued(true)}
+        />
+        <ArtifactSurface
+          chapterTitle={chapterTitle}
+          draftKey={draftSource.key}
+          draftText={draftSource.text}
+          hasChapter={Boolean(props.selectedChapterId)}
+          readiness={readiness}
+          continuityQueued={continuityQueued}
+          onOpenAutoWrite={() => props.setShowAutoWrite(true)}
+          onQueueContinuity={() => setContinuityQueued(true)}
+          onSaveDraft={props.onSaveChapterDraft}
+        />
+      </main>
+
+      {props.error ? <div className="mx-2 mt-2 rounded border border-[var(--danger)]/40 p-3 text-sm text-[var(--danger)]">{props.error}</div> : null}
+      {props.loadingDetail || props.loadingChapter ? <div className="mx-2 mt-2 muted text-xs">Loading current chapter artifact...</div> : null}
+      {props.showAutoWrite && props.selectedChapterId ? (
+        <AutoWriteWizard
+          storySlug={props.storySlug}
+          chapterId={props.selectedChapterId}
+          onComplete={props.onAutoWriteComplete}
+          onClose={() => props.setShowAutoWrite(false)}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/WriteTabView.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/WriteTabView.tsx
@@ -1,7 +1,5 @@
-import type { CurrentVersion, DockTab, SceneItem } from "@/features/scenes/components/writeTab/types";
-import TriPanelLayout from "@/components/layout/TriPanelLayout";
-import WriteDockPanel from "@/features/scenes/components/writeTab/WriteDockPanel";
-import WriteTabCenterPanel from "@/features/scenes/components/writeTab/WriteTabCenterPanel";
+import type { ChapterSceneItem, CurrentVersion, DockTab, SceneItem } from "@/features/scenes/components/writeTab/types";
+import NovelLabWorkspace from "@/features/scenes/components/writeTab/NovelLabWorkspace";
 
 type WriteTabViewProps = {
   storySlug: string;
@@ -24,7 +22,7 @@ type WriteTabViewProps = {
   selectedChapterId: string;
   onChapterIdChange: (id: string) => void;
   viewMode: "scene" | "chapter";
-  chapterScenes: any[];
+  chapterScenes: ChapterSceneItem[];
   loadingChapter: boolean;
   onCreateNewChapter: () => Promise<void>;
   onUnlockScene: () => Promise<void>;
@@ -32,94 +30,34 @@ type WriteTabViewProps = {
   setShowAutoWrite: (v: boolean) => void;
   pendingChapterProse: { id: string; prose: string } | null;
   stagingData: { user_prose: string; llm_prose: string; status: string } | null;
+  v3Draft: { full_text: string; status: string; virtual_scenes: unknown[] } | null;
   onAutoWriteComplete: (prose: string) => Promise<void>;
   onSaveChapterDraft: (prose: string) => Promise<void>;
   onResplitChapter: (prose: string) => Promise<void>;
 };
 
-export default function WriteTabView({
-  storySlug,
-  scenes,
-  chapterIds,
-  sceneId,
-  onSceneIdChange,
-  scene,
-  current,
-  loadingScenes,
-  loadingDetail,
-  error,
-  dockTab,
-  onDockTabChange,
-  ghostSuggestionReady,
-  seedPrompt,
-  onCommitted,
-  onGhostSuggestionReadyChange,
-  selectedChapterId,
-  onChapterIdChange,
-  viewMode,
-  chapterScenes,
-  loadingChapter,
-  onCreateNewChapter,
-  onUnlockScene,
-  showAutoWrite,
-  setShowAutoWrite,
-  pendingChapterProse,
-  stagingData,
-  onAutoWriteComplete,
-  onSaveChapterDraft,
-  onResplitChapter,
-}: WriteTabViewProps) {
+export default function WriteTabView(props: WriteTabViewProps) {
   return (
-    <main className="p-1">
-      <TriPanelLayout
-        center={
-          <WriteTabCenterPanel
-            storySlug={storySlug}
-            scenes={scenes}
-            chapterIds={chapterIds}
-            sceneId={sceneId}
-            onSceneIdChange={onSceneIdChange}
-            scene={scene}
-            current={current}
-            loadingScenes={loadingScenes}
-            loadingDetail={loadingDetail}
-            error={error}
-            seedPrompt={seedPrompt}
-            onCommitted={onCommitted}
-            onGhostSuggestionReadyChange={onGhostSuggestionReadyChange}
-            selectedChapterId={selectedChapterId}
-            onChapterIdChange={onChapterIdChange}
-            viewMode={viewMode}
-            chapterScenes={chapterScenes}
-            loadingChapter={loadingChapter}
-            onCreateNewChapter={onCreateNewChapter}
-            onUnlockScene={onUnlockScene}
-            showAutoWrite={showAutoWrite}
-            setShowAutoWrite={setShowAutoWrite}
-            pendingChapterProse={pendingChapterProse}
-            stagingData={stagingData}
-            onAutoWriteComplete={onAutoWriteComplete}
-            onSaveChapterDraft={onSaveChapterDraft}
-            onResplitChapter={onResplitChapter}
-          />
-        }
-        right={
-          <WriteDockPanel
-            scene={scene}
-            current={current}
-            dockTab={dockTab}
-            onDockTabChange={onDockTabChange}
-            ghostSuggestionReady={ghostSuggestionReady}
-          />
-        }
-        leftMode="hidden"
-        rightMode="pinned"
-        leftTitle="Navigator"
-        centerTitle="Write"
-        rightTitle="Context"
-        rightTabletWidthClass="w-96 min-w-96"
-        rightDesktopWidthClass="w-96 min-w-96"
-      />
-    </main>
+    <NovelLabWorkspace
+      storySlug={props.storySlug}
+      chapterIds={props.chapterIds}
+      scene={props.scene}
+      current={props.current}
+      loadingScenes={props.loadingScenes}
+      loadingDetail={props.loadingDetail}
+      error={props.error}
+      selectedChapterId={props.selectedChapterId}
+      onChapterIdChange={props.onChapterIdChange}
+      chapterScenes={props.chapterScenes}
+      loadingChapter={props.loadingChapter}
+      onCreateNewChapter={props.onCreateNewChapter}
+      showAutoWrite={props.showAutoWrite}
+      setShowAutoWrite={props.setShowAutoWrite}
+      pendingChapterProse={props.pendingChapterProse}
+      stagingData={props.stagingData}
+      v3Draft={props.v3Draft}
+      onAutoWriteComplete={props.onAutoWriteComplete}
+      onSaveChapterDraft={props.onSaveChapterDraft}
+    />
   );
 }

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -15,7 +15,45 @@ export type CurrentVersion = {
   text_content: string | null;
 };
 
+export type ChapterSceneItem = {
+  id: number;
+  idx: number;
+  title: string | null;
+  status: string;
+  text_content: string;
+};
+
 export type DockTab = "actions" | "context" | "assist" | "report";
+
+export type ContextReadiness = "proceed" | "degraded" | "blocked";
+
+export type ContextReadinessLabel = "Context Clean" | "Context Partial" | "Context Blocked";
+
+export type ArtifactKind = "document" | "analysis" | "review" | "memory" | "publish_preview" | "operations";
+
+export type CommandTaskStatus = "idle" | "running" | "completed" | "blocked";
+
+export type CommandTaskCard = {
+  id: string;
+  command: string;
+  title: string;
+  status: CommandTaskStatus;
+  detail: string;
+  cta?: string;
+};
+
+export type CommandId =
+  | "/write chapter"
+  | "/analyze chapter"
+  | "/rewrite selection"
+  | "/continue from cursor"
+  | "/check continuity"
+  | "/extract memory"
+  | "/review chapter"
+  | "/approve draft"
+  | "/publish preview"
+  | "/status"
+  | "/split";
 
 export type HeaderContextPayload = {
   chapterLabel: string | null;

--- a/docs/architecture/conversational-command-mvp-map.md
+++ b/docs/architecture/conversational-command-mvp-map.md
@@ -1,0 +1,103 @@
+# Conversational Command MVP Map
+
+Issue: #38
+Status: Planning contract
+Last updated: 2026-05-03
+
+## Purpose
+
+This document maps the first Novel Lab commands to existing `novel-ai` workflows or explicit missing contracts. The command plane is a workflow entrypoint. It does not execute raw database actions and does not replace artifact, editor, memory, review, or operations surfaces.
+
+Related contract: `docs/architecture/conversational-command-orchestrator.md`.
+
+## MVP Commands
+
+| Command | User intent | Owner surface | Result artifact | Approval gate |
+|---|---|---|---|---|
+| `/write chapter` | Generate or continue a chapter draft. | `POST /api/stories/[slug]/chapters/[chapterId]/auto-write` and current AutoWrite/V3 flow where available. | `document` draft artifact. | Draft-only until continuity validation and approval. |
+| `/analyze chapter` | Inspect current chapter context, continuity, and risks. | Existing analysis/writing snapshot and context inspector contracts; exact public route remains a missing-contract note if not exposed. | `analysis` artifact. | Read-only. |
+| `/rewrite selection` | Rewrite selected prose in the active artifact. | Existing scene rewrite and Muse prose helpers can inform behavior; document-selection rewrite needs future editor contract. | `document` artifact update. | Draft write only; cannot approve. |
+| `/continue from cursor` | Continue prose from the editor cursor. | Existing Muse/prose streaming can inform behavior; cursor continuation against document blocks is future editor scope. | `document` artifact update. | Draft write only; cannot approve. |
+| `/check continuity` | Find canon, timeline, forbidden reveal, and relationship issues. | `WritingContext` assembler/debug plus continuity issue surfaces from V3 ledger/rollup. | `analysis` or Issues inspector artifact. | Required before approval in the first UI slice. |
+| `/extract memory` | Preview memory candidates from the active draft. | #12 promotion contract and current ledger/rollup outputs. | `memory` candidate artifact. | Draft-only until approved revision exists. |
+| `/review chapter` | Open review checklist and scoring for current chapter. | Current review APIs and review panel concepts. | `review` artifact. | Human review action only. |
+| `/approve draft` | Approve current document revision. | Future document approval endpoint from #5 boundary. | Approved `document` revision. | Locked until continuity validation passes. |
+| `/publish preview` | Preview reader-facing output. | Future publish/export adapter. | `publish_preview` artifact. | Requires approved revision/export state. |
+| `/status` | Show current workflow, worker, and artifact state. | Existing worker/job/status APIs and Operations surface. | `operations` artifact. | Read-only. |
+| `/split` | Split imported source or chapter draft into scenes. | Ingest split APIs and split-draft approval flow. | `operations` or analysis artifact. | Split draft approval remains human-gated. |
+
+## Default UI Prioritization
+
+Primary slash menu commands:
+
+1. `/write chapter`
+2. `/analyze chapter`
+3. `/rewrite selection`
+4. `/continue from cursor`
+5. `/check continuity`
+
+Commands under `More`:
+
+- `/extract memory`
+- `/review chapter`
+- `/approve draft`
+- `/publish preview`
+- `/status`
+- `/split`
+
+## Command-Specific Rules
+
+### `/write chapter`
+
+- Required inputs: `story_slug`, `chapter_id`, user intent or approved chapter goal.
+- Safe default: write against the selected chapter only.
+- Uses the existing chapter-first generation path where available.
+- Produces an editable document artifact wrapping the generated draft.
+- Must show `Context Clean`, `Context Partial`, or `Context Blocked` from `WritingContext` readiness.
+- Must not update canon, promote memory, publish, or reader-facing output.
+
+### `/check continuity`
+
+- Required inputs: active artifact reference and chapter id.
+- Result goes to the artifact inspector `Issues` or `Progress` state.
+- Can unlock approval only after a future implementation defines pass/fail validation output.
+- Until that implementation exists, the UI presents `Run continuity check` as the next action and keeps approval locked.
+
+### `/approve draft`
+
+- Required inputs: approved document revision candidate and validation result.
+- Current status: missing backend implementation contract.
+- UI behavior: visible but disabled/locked while continuity validation is pending.
+- Must create an approved revision before memory extraction, reader output, or publish preview can consume the prose.
+
+### `/extract memory`
+
+- Draft behavior: preview candidates only, tagged `Draft-only`.
+- Approved behavior: after document approval, extraction can create promotion candidates under #12.
+- Must not silently promote memory.
+
+### `/status`
+
+- Reads current job, worker, artifact, save, and context state.
+- Result belongs in Operations/status artifact or compact header pills.
+- Must not expose raw logs by default.
+
+## Inspector Handoff
+
+| Result | Inspector tab |
+|---|---|
+| WritingContext progress | `Progress` |
+| Context readiness and source state | `Context` |
+| Continuity, reveal, timeline, or relationship warnings | `Issues` |
+| Draft-only or promotion-ready memory candidates | `Memory` |
+| AI draft, human draft, checked draft, approved revision, export snapshot | `Versions` |
+
+The inspector is attached to the right artifact workspace and may be resized horizontally on desktop.
+
+## Missing Contracts To Track
+
+- Document revision approval endpoint and durable storage remain future #5 implementation work.
+- Cursor-aware document rewrite and continuation require editor block/range references.
+- Continuity validation pass/fail output must be made stable before approval can unlock.
+- Publish preview requires approved document/export state.
+- Memory promotion requires #12 implementation; this MVP may only show draft-only candidate previews.

--- a/docs/architecture/conversational-command-orchestrator.md
+++ b/docs/architecture/conversational-command-orchestrator.md
@@ -1,0 +1,134 @@
+# Conversational Command Orchestrator Contract
+
+Issue: #37
+Status: Planning contract
+Last updated: 2026-05-03
+
+## Purpose
+
+This contract defines the Novel Lab command workspace boundary. The command plane captures user intent and produces typed workflow requests; deterministic application code validates and executes those requests through existing APIs and worker tasks. The command plane is not the document output surface and is not a raw database or worker console.
+
+## Ownership Model
+
+| Layer | Owns | Must not own |
+|---|---|---|
+| Command plane | Slash commands, natural-language task intent, compact command events, plan proposals, and status summaries. | Long prose output, canon truth, direct database mutation, raw payload inspection. |
+| Orchestrator | Validation, approval gates, lifecycle state, trace records, owner API/task selection, and result references. | Autonomous model execution or unchecked state transitions. |
+| Artifact workspace | Document drafts, analysis artifacts, review artifacts, memory candidate artifacts, publish previews, and operations/status artifacts. | Command parsing or hidden memory promotion. |
+| Inspector | Progress, context, issues, memory, versions, source traces, and degraded/block reasons for the active artifact. | Raw logs as the default writer-facing experience. |
+
+## Command Request
+
+The first contract shape is semantic. It can be represented as TypeScript later, but this document is the source of truth for the initial implementation.
+
+```ts
+type CommandRequest = {
+  input_mode: "slash" | "natural_language";
+  raw_text: string;
+  command_id?: CommandId;
+  story_slug: string;
+  chapter_id?: string;
+  selection_ref?: string;
+  artifact_ref?: string;
+  user_intent: string;
+};
+```
+
+`CommandId` for the first workspace slice:
+
+- `/write chapter`
+- `/analyze chapter`
+- `/rewrite selection`
+- `/continue from cursor`
+- `/check continuity`
+- `/extract memory`
+- `/review chapter`
+- `/approve draft`
+- `/publish preview`
+- `/status`
+- `/split`
+
+The UI should show the most relevant commands first: `/write chapter`, `/analyze chapter`, `/rewrite selection`, `/continue from cursor`, and `/check continuity`. Lower-frequency commands may live under `More`.
+
+## Tool Registry Contract
+
+Every model-callable workflow action must be registered before it can execute.
+
+Required registry fields:
+
+- `id`: stable internal tool id.
+- `command_ids`: slash commands or intents that may request it.
+- `owner`: API route, worker task, or missing-contract note.
+- `input_summary`: required input fields and safe defaults.
+- `output_summary`: result references and artifact handoff target.
+- `approval_requirement`: `none`, `confirm`, `required`, or `locked_until_validation`.
+- `side_effect_level`: `read_only`, `draft_write`, `canon_affecting`, `publish_affecting`, `destructive`.
+- `trace_fields`: intent, payload summary, owner path, status, reason codes, result ref, and approval decision.
+
+The model may propose a tool call or plan, but the orchestrator must validate the registry entry and approval state before execution.
+
+## Lifecycle States
+
+Command runs use one of these states:
+
+| State | Meaning |
+|---|---|
+| `proposed` | Parsed intent exists, execution has not started. |
+| `waiting_approval` | Human approval is required before execution. |
+| `running` | Owner API/task is active. |
+| `degraded` | Work can continue with explicit reduced context or fallback. |
+| `blocked` | Work cannot continue until a required condition is fixed. |
+| `failed` | Execution failed with a reason code. |
+| `done` | Execution completed and returned a result reference. |
+| `cancelled` | User or system stopped the run. |
+
+Context readiness labels are UI-friendly names for the `WritingContext` outcomes:
+
+| UI label | Contract outcome |
+|---|---|
+| `Context Clean` | `proceed` |
+| `Context Partial` | `degraded` |
+| `Context Blocked` | `blocked` |
+
+Do not use `Context Ready` for this workspace because it hides degraded and blocked states.
+
+## Artifact Handoff
+
+Every successful command must produce or update an artifact reference.
+
+| Artifact kind | Example source | Primary owner |
+|---|---|---|
+| `document` | `/write chapter`, `/continue from cursor`, `/rewrite selection` | Right artifact editor |
+| `analysis` | `/analyze chapter`, `/check continuity` | Analysis/Issues inspector |
+| `review` | `/review chapter` | Review artifact |
+| `memory` | `/extract memory` | Memory candidate artifact |
+| `publish_preview` | `/publish preview` | Publish preview |
+| `operations` | `/status`, failed/blocked worker runs | Operations/status artifact |
+
+For `/write chapter`, the result is an editable document artifact wrapping the generated chapter draft. It is draft-only until validation and approval. It must not feed canon memory, reader output, or publishing directly.
+
+## Approval Gates
+
+Approval gates are explicit:
+
+- `Approve revision` is locked until continuity validation passes or a future override contract is approved.
+- Draft editor revisions cannot promote memory.
+- Memory extraction may preview draft-only candidates but cannot promote them until an approved revision exists.
+- Reader and publish surfaces consume approved document/export state, not raw AI drafts.
+- Destructive operations, DB reset, publish, canon mutation, and memory promotion require explicit human approval.
+
+## Trace Requirements
+
+Each command run trace must include:
+
+- raw input and normalized intent;
+- selected command/tool and rejected alternatives when relevant;
+- story/chapter/artifact scope;
+- owner API or task path;
+- payload hash or safe summary;
+- lifecycle state and reason codes;
+- approval requirement and decision;
+- result artifact reference;
+- degraded, blocked, or failure metadata.
+
+The trace exists so command-driven workflows remain inspectable without putting raw JSON or logs into the writer's primary workspace.

--- a/docs/architecture/ui-information-architecture.md
+++ b/docs/architecture/ui-information-architecture.md
@@ -30,6 +30,8 @@ Reference inputs:
 - `docs/architecture/document-editor-boundary.md` owns future editor document approval and export source-of-truth.
 - `docs/architecture/post-write-memory-promotion-flow.md` owns post-write memory candidate promotion.
 - `docs/architecture/story-memory-contract.md` owns memory truth boundaries.
+- `docs/architecture/conversational-command-orchestrator.md` owns Novel Lab command intent, typed workflow requests, artifact handoff, approval gates, and command trace semantics.
+- `docs/architecture/conversational-command-mvp-map.md` maps the first slash commands to existing workflows or explicit missing contracts.
 
 ## Surface Map
 
@@ -96,7 +98,19 @@ Classification keys:
 
 ## Simplified Write Surface
 
-The first simplified Write surface should have four stable zones.
+The first simplified Write surface should become the Novel Lab command artifact workspace. It keeps a chapter-first writing loop while separating command work, artifact work, and inspector state.
+
+The workspace has three stable global zones:
+
+| Zone | Job | Must not do |
+|---|---|---|
+| Left navigation | Select story, chapter, and product surface. | Execute tasks or show raw pipeline diagnostics. |
+| Center work stream | Capture commands, task progress, result summaries, next-action CTAs, and the bottom composer. | Display long generated prose, stay as a permanent command palette, or show raw diagnostics. |
+| Right artifact workspace | Show the active artifact, editable chapter draft, review actions, and attached inspector. | Parse commands, silently approve/promote memory, or own global navigation. |
+
+Slash commands are invoked from the center composer by typing `/` or opening the command menu. They should not render as a static command list when the author is idle. The right artifact workspace owns a resizable inspector with `Progress`, `Context`, `Issues`, `Memory`, and `Versions` tabs, but the default view summarizes state and expands details on demand.
+
+The previous simplified Write surface can still be interpreted as four internal responsibilities.
 
 | Zone | Primary content | Secondary content | Hidden or moved |
 |---|---|---|---|
@@ -121,9 +135,15 @@ Select chapter
 
 Write readiness display:
 
-- `proceed`: show concise confidence, selected continuity source, and primary write action.
-- `degraded`: show degraded reason codes and a conservative recommendation before write starts.
-- `blocked`: show blocker reason codes and the exact surface that can resolve them, such as Memory conflict review or Operations job recovery.
+- `proceed`: render `Context Clean`, show concise confidence, selected continuity source, and primary write action.
+- `degraded`: render `Context Partial`, show degraded reason codes and a conservative recommendation before write starts.
+- `blocked`: render `Context Blocked`, show blocker reason codes and the exact surface that can resolve them, such as Memory conflict review or Operations job recovery.
+
+Approval display rule:
+
+- `Run continuity check` is the enabled primary action while validation is pending.
+- `Approve revision` is visible but locked/disabled until continuity validation passes or an approved override contract exists.
+- The generated chapter draft remains draft-only until approval; it must not feed memory, reader, or publish output directly.
 
 Fallback display rule:
 


### PR DESCRIPTION
﻿## Summary
- Rebuilds the Write route as a Codex-like Novel Lab command workbench: left chapter navigation, center command/task stream, right artifact plus inspector.
- Simplifies the global app header into one compact context bar and keeps `/` as the Novel Lab default entrypoint.
- Adds UI-only command/artifact/inspector components and documents the corrected command/artifact ownership model.

## Behavior
- Slash commands are hidden until `/` or the composer command button is invoked.
- The center stream shows command intent, task progress, and next actions only; long prose stays in the right artifact surface.
- `Run continuity check` is the enabled primary action while validation is pending; `Approve revision` remains locked.
- Empty artifact states no longer render a large blank editor.

## Verification
- `cd /home/danh/novel-ai/apps/studio && npm run typecheck`
- `cd /home/danh/novel-ai/apps/studio && npx eslint src/components/AppShell.tsx src/features/scenes/components/writeTab/NovelLabWorkspace.tsx src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/ArtifactSurface.tsx src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx src/features/scenes/components/writeTab/WriteTabView.tsx src/features/scenes/components/writeTab/types.ts`
- `cd /home/danh/novel-ai/apps/studio && npm run build`
- `curl -I http://localhost:3000/?chapter_id=ch01` returned `HTTP/1.1 200 OK`

Closes #39
