### PR TITLE
Add Groq LLM provider profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Nếu bạn muốn hiểu nhanh theo góc nhìn business, xem thêm [docs/operat
 - Knowledge / retrieval: Neo4j 5, Qdrant 1.13
 - Worker / pipeline: Python 3.12, psycopg2
 - Infrastructure: Docker Compose, Grafana
-- LLM integration: OpenAI-compatible API endpoint qua `LLM_API_BASE` (mặc định `http://localhost:8080/v1`)
+- LLM integration: OpenAI-compatible API endpoint qua `LLM_API_BASE` (mặc định `http://localhost:8080/v1`; Groq/dev provider setup ở [docs/operations/llm-providers.md](./docs/operations/llm-providers.md))
 
 ## Mục tiêu của repo
 
@@ -149,6 +149,7 @@ Lưu ý:
 * Không nên chạy `npm run dev` cùng lúc với `grafana` nếu cả hai cùng dùng cổng `3000`
 * `infra/docker-compose.yml` không tự động apply migration DB, vì vậy vẫn cần setup schema trước
 * LLM server không nằm trong repo này; `novel-studio` container mong chờ một endpoint tại `host.docker.internal:8080`
+* Nếu không muốn chạy local llama-server, có thể dùng Groq hoặc provider OpenAI-compatible khác bằng `LLM_API_BASE`, `LLM_API_KEY`, và `LLM_MODEL`; xem [LLM Provider Profiles](./docs/operations/llm-providers.md)
 
 ## Biến môi trường
 
@@ -167,6 +168,7 @@ Những biến quan trọng nhất:
 | `LLM_API_BASE` | Có | Base URL của OpenAI-compatible endpoint |
 | `LLM_MODEL` | Có | Tên model mặc định |
 | `LLM_API_KEY` | Có | API key hoặc token local |
+| `LLM_MAX_TOKENS` | Tùy chọn | Conservative output cap for local/provider testing |
 | `HISTORIAN_MCP_BASE_URL` | Nên có | Địa chỉ bridge cho external historian adapters |
 | `HISTORIAN_QDRANT_ENABLED` | Tùy chọn | Bật semantic retrieval từ Qdrant |
 | `HISTORIAN_NEO4J_ENABLED` | Tùy chọn | Bật graph retrieval từ Neo4j |
@@ -179,6 +181,7 @@ Những biến quan trọng nhất:
 Lưu ý:
 
 * `.env.example` trong `apps/studio/` là nguồn tham chiếu đầy đủ cho local setup
+* Không commit API key thật. Với Groq/free-tier, bắt đầu bằng `LLM_MAX_TOKENS=512` và dùng `npm run doctor:llm -- --dry-run` trước khi gọi API thật
 * Khi chạy `qdrant + neo4j + historian-mcp-bridge`, hãy bật `HISTORIAN_QDRANT_ENABLED=1` và `HISTORIAN_NEO4J_ENABLED=1`
 * Nếu không có LLM server, các tính năng ingest/split/write/muse sẽ không hoạt động đầy đủ
 

--- a/apps/studio/.env.example
+++ b/apps/studio/.env.example
@@ -2,6 +2,16 @@ DATABASE_URL=postgresql://novel:novelpass@localhost:5433/novel
 LLM_API_BASE=http://localhost:8080/v1
 LLM_MODEL=qwen2.5-7b
 LLM_API_KEY=local
+# Optional OpenAI-compatible Groq free/developer-tier profile for local testing.
+# Do not commit real API keys. Groq rate limits are model-specific and may change.
+# Start with low max_tokens before running full chapter generation.
+# LLM_API_BASE=https://api.groq.com/openai/v1
+# LLM_API_KEY=gsk_xxxxxxxxxxxxxxxxx
+# LLM_MODEL=llama-3.1-8b-instant
+# LLM_MODEL=qwen/qwen3-32b
+# LLM_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
+# LLM_MODEL=openai/gpt-oss-120b
+LLM_MAX_TOKENS=512
 LLAMA_CONTEXT=16384
 WORKER_FLOW_LANE=all
 HISTORIAN_MCP_BASE_URL=http://localhost:8090

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -174,6 +174,7 @@ Refactor direction for large modules:
 ### LLM streaming
 
 - `POST /api/pipeline/draft/stream` (proxy SSE tới `LLM_API_BASE`)
+- `npm run doctor:llm` checks the configured OpenAI-compatible LLM endpoint with a tiny JSON-only request.
 - `POST /api/muse/stream` (Ghost Muse SSE, mode `bullets|block`)
 - `POST /api/muse/chat/compress` (Chapter compress, JSON strict non-stream, soft limit 350KB)
 - `POST /api/muse/chat/synthesis` (Muse Chat synthesis, JSON strict non-stream)
@@ -251,6 +252,7 @@ Thực thể chính:
 - `LLM_API_BASE`
 - `LLM_MODEL`
 - `LLM_API_KEY`
+- `LLM_MAX_TOKENS` (optional; conservative output cap for local/provider testing)
 - `WRITING_V2_PRODUCTION` (optional, default `1`; set `0` to disable `/stories/[slug]/chapters/*` AutoWrite v2 plan/execute/status endpoints during rollout/rollback)
 - `WRITING_COOL_OFF_SECONDS` (optional, default `2`; controls cool-off between `NARRATIVE_*` tasks for chapter writing)
 - `LLAMA_MANUAL_ONLY` (optional, default `1`; when enabled, `/ingest/worker` API will not start/stop llama-server and expects manual terminal operation)
@@ -280,6 +282,7 @@ Run:
 ```bash
 npm install
 npm run dev
+npm run doctor:llm -- --dry-run
 npm run doctor:split-maturity -- --story <story_slug>
 npm run doctor:split-maturity -- --story <story_slug> --process-legacy
 npm run doctor:split-feedback-insights -- --story <story_slug> --days 30

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -10,6 +10,7 @@
     "lint:line-budgets": "node scripts/check_line_budgets.mjs",
     "typecheck": "tsc --noEmit",
     "doctor:pipeline": "node scripts/doctor_pipeline.mjs",
+    "doctor:llm": "node scripts/doctor_llm.mjs",
     "doctor:memory-bridge": "node scripts/doctor_memory_bridge.mjs",
     "doctor:ingest-validate": "node scripts/doctor_ingest_validate.mjs",
     "doctor:ingest-validate-matrix": "node scripts/doctor_ingest_validate_matrix.mjs",

--- a/apps/studio/scripts/doctor_llm.mjs
+++ b/apps/studio/scripts/doctor_llm.mjs
@@ -1,0 +1,116 @@
+import { existsSync, readFileSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const verbose = args.has("--verbose");
+
+function loadEnvFile(path) {
+  if (!existsSync(path)) return;
+  const lines = readFileSync(path, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+    const index = trimmed.indexOf("=");
+    const key = trimmed.slice(0, index).trim();
+    let value = trimmed.slice(index + 1).trim();
+    if (
+      (value.startsWith("\"") && value.endsWith("\"")) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+function redact(value) {
+  if (!value) return "<missing>";
+  if (value === "local") return "local";
+  if (value.length <= 8) return "***";
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function parseJsonFromText(text) {
+  const trimmed = String(text || "").trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const match = trimmed.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error(`LLM response was not JSON: ${trimmed.slice(0, 120)}`);
+    return JSON.parse(match[0]);
+  }
+}
+
+async function main() {
+  loadEnvFile(".env.local");
+  loadEnvFile(".env");
+
+  const base = String(process.env.LLM_API_BASE || "").replace(/\/+$/, "");
+  const apiKey = String(process.env.LLM_API_KEY || "");
+  const model = String(process.env.LLM_MODEL || "");
+  const maxTokens = Number(process.env.LLM_MAX_TOKENS || 64);
+  const healthMaxTokens = Math.min(Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : 64, 64);
+
+  if (!base) throw new Error("LLM_API_BASE is required");
+  if (!model) throw new Error("LLM_MODEL is required");
+  if (!apiKey) throw new Error("LLM_API_KEY is required");
+
+  console.log("[doctor:llm] base:", base);
+  console.log("[doctor:llm] model:", model);
+  console.log("[doctor:llm] api_key:", redact(apiKey));
+  console.log("[doctor:llm] max_tokens:", healthMaxTokens);
+
+  if (dryRun) {
+    console.log("[doctor:llm] dry_run=true; request not sent");
+    return;
+  }
+
+  const body = {
+    model,
+    messages: [
+      {
+        role: "user",
+        content: "Return JSON only: {\"ok\": true, \"provider\": \"configured\"}",
+      },
+    ],
+    temperature: 0,
+    max_tokens: healthMaxTokens,
+  };
+
+  const startedAt = performance.now();
+  const res = await fetch(`${base}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const latencyMs = Math.round(performance.now() - startedAt);
+  const text = await res.text();
+
+  if (!res.ok) {
+    const hint =
+      res.status === 429
+        ? "Rate limited. Reduce max_tokens, wait for reset, or switch model/provider."
+        : "Check LLM_API_BASE, LLM_API_KEY, LLM_MODEL, and provider availability.";
+    throw new Error(`LLM health check failed: status=${res.status} latency_ms=${latencyMs} hint=${hint} body=${text.slice(0, 500)}`);
+  }
+
+  const json = JSON.parse(text);
+  const content = json?.choices?.[0]?.message?.content;
+  const parsed = parseJsonFromText(content);
+  if (parsed?.ok !== true) {
+    throw new Error(`LLM JSON response missing ok=true: ${JSON.stringify(parsed)}`);
+  }
+
+  console.log("[doctor:llm] status:", res.status);
+  console.log("[doctor:llm] latency_ms:", latencyMs);
+  console.log("[doctor:llm] response:", verbose ? content : JSON.stringify(parsed));
+}
+
+main().catch((err) => {
+  console.error("[doctor:llm] failed:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Tai lieu duoc nhom theo taxonomy de de tim va giam trung lap.
 - Business Handbook:
   - [system-business-handbook.md](./operations/specs/system-business-handbook.md)
 - Operations Specs:
+  - [llm-providers.md](./operations/llm-providers.md)
   - [pipeline-first-ia-spec.md](./operations/specs/pipeline-first-ia-spec.md)
   - [agent-governance-ux-evolution-v1.md](./operations/specs/agent-governance-ux-evolution-v1.md)
 - Implementation & Rollout:

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -1,0 +1,182 @@
+# LLM Provider Profiles
+
+This document defines local/development LLM provider setup for OpenAI-compatible endpoints. It does not introduce paid billing, database-stored API keys, or a new provider lock-in.
+
+## Existing Contract
+
+The Studio and worker code already use these environment variables:
+
+```env
+LLM_API_BASE=http://localhost:8080/v1
+LLM_API_KEY=local
+LLM_MODEL=qwen2.5-7b
+LLM_MAX_TOKENS=512
+```
+
+Any provider that exposes an OpenAI-compatible `/chat/completions` endpoint can be tested through this shape.
+
+## Groq Free/Developer Profile
+
+Groq can be used for low-cost local testing because it exposes an OpenAI-compatible API.
+
+```env
+LLM_API_BASE=https://api.groq.com/openai/v1
+LLM_API_KEY=gsk_xxxxxxxxxxxxxxxxx
+LLM_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
+LLM_MAX_TOKENS=512
+```
+
+Do not commit real API keys. Keep `LLM_MAX_TOKENS` small for first tests and only opt into full chapter generation manually.
+
+Groq limits are model-specific and may change. Check the Groq console before relying on the values below.
+
+| Model | RPM | RPD | TPM | TPD | Use |
+|---|---:|---:|---:|---:|---|
+| `llama-3.1-8b-instant` | 30 | 14.4K | 6K | 500K | Frequent plumbing tests |
+| `qwen/qwen3-32b` | 60 | 1K | 6K | 500K | General writing pipeline tests |
+| `meta-llama/llama-4-scout-17b-16e-instruct` | 30 | 1K | 30K | 500K | Context-heavy tests |
+| `openai/gpt-oss-120b` | 30 | 1K | 8K | 200K | Reasoning spot checks |
+| `llama-3.3-70b-versatile` | 30 | 1K | 12K | 100K | Prose/reasoning spot checks |
+
+Definitions:
+
+- `RPM`: requests per minute.
+- `RPD`: requests per day.
+- `TPM`: tokens per minute.
+- `TPD`: tokens per day.
+
+## Model Selection Policy
+
+### Phase 1: Pipeline Plumbing
+
+Use `llama-3.1-8b-instant`.
+
+Purpose:
+
+- Health check.
+- API connectivity.
+- Task dispatch.
+- JSON schema parsing.
+- Retry behavior.
+- Short output tests.
+
+Suggested `max_tokens`: `512-1000`.
+
+### Phase 2: General Writing Pipeline Tests
+
+Use `qwen/qwen3-32b`.
+
+Purpose:
+
+- Planning JSON.
+- Short prose generation.
+- Ledger extraction.
+- Memory candidate extraction.
+- Basic continuity audit.
+
+Suggested `max_tokens`: `800-1500`.
+
+### Phase 3: Context-Heavy Tests
+
+Use `meta-llama/llama-4-scout-17b-16e-instruct`.
+
+Purpose:
+
+- `WritingContext` assembler tests.
+- Larger context windows.
+- Chapter planning with more memory.
+- Continuity validation with bigger prompts.
+
+Suggested `max_tokens`: `1200-2500`.
+
+### Phase 4: Reasoning Spot Checks
+
+Use `openai/gpt-oss-120b` or `llama-3.3-70b-versatile`.
+
+Purpose:
+
+- Hard planning cases.
+- Conflict reasoning.
+- Canon contradiction tests.
+- `chapter_ledger` extraction quality checks.
+- Prose quality comparison.
+
+These models can hit free-tier limits faster. Do not use them for high-volume loops.
+
+## Suggested Fallback Order
+
+```text
+1. meta-llama/llama-4-scout-17b-16e-instruct
+2. qwen/qwen3-32b
+3. llama-3.1-8b-instant
+4. openai/gpt-oss-120b
+5. llama-3.3-70b-versatile
+```
+
+## Health Check
+
+Run from `apps/studio`:
+
+```bash
+npm run doctor:llm
+```
+
+For a no-network config check:
+
+```bash
+npm run doctor:llm -- --dry-run
+```
+
+The doctor sends a tiny JSON-only request:
+
+```json
+{
+  "model": "$LLM_MODEL",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Return JSON only: {\"ok\": true, \"provider\": \"configured\"}"
+    }
+  ],
+  "temperature": 0,
+  "max_tokens": 64
+}
+```
+
+It prints provider base, model, redacted key, status, latency, and parsed JSON. It must not run full chapter generation.
+
+## Rate-Limit Troubleshooting
+
+If the provider returns `429`, identify which limit is likely responsible:
+
+- `RPM`: too many requests per minute.
+- `RPD`: too many requests per day.
+- `TPM`: too many input/output tokens per minute.
+- `TPD`: too many input/output tokens per day.
+
+If TPM is exceeded:
+
+- Reduce prompt size.
+- Reduce `LLM_MAX_TOKENS`.
+- Use `meta-llama/llama-4-scout-17b-16e-instruct` when larger TPM is needed.
+
+If RPD is exceeded:
+
+- Switch to another model/provider.
+- Wait for reset.
+- Reduce test loop frequency.
+
+If output JSON is invalid:
+
+- Lower temperature.
+- Use strict JSON-only prompting.
+- Keep `max_tokens` low for health checks, but raise it if valid JSON is being truncated.
+
+## Non-Goals
+
+- Do not add paid billing integration.
+- Do not store provider API keys in the database.
+- Do not hardcode Groq as the only provider.
+- Do not remove existing OpenAI-compatible provider support.
+- Do not change writing pipeline behavior in provider setup docs.
+- Do not run full chapter generation in health-check scripts.


### PR DESCRIPTION
﻿## Summary
- Adds Groq/OpenAI-compatible local provider guidance and model selection policy for development testing.
- Adds `npm run doctor:llm` with a low-token JSON-only health check and `--dry-run` mode.
- Documents rate-limit terms, 429 troubleshooting, safe token caps, and no-key-commit guidance.

## Verification
- `cd /home/danh/novel-ai/apps/studio && npm run doctor:llm -- --dry-run`
- `cd /home/danh/novel-ai/apps/studio && npm run typecheck`
- `cd /home/danh/novel-ai/apps/studio && npx eslint scripts/doctor_llm.mjs`
- `cd /home/danh/novel-ai/apps/studio && npm run build`
- `cd /home/danh/novel-ai && git diff --check`

Closes #41
