### PR TITLE
Add runtime LLM provider selector

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -174,7 +174,9 @@ Refactor direction for large modules:
 ### LLM streaming
 
 - `POST /api/pipeline/draft/stream` (proxy SSE tới `LLM_API_BASE`)
-- `npm run doctor:llm` checks the configured OpenAI-compatible LLM endpoint with a tiny JSON-only request.
+- `GET/PUT/POST /api/llm/provider` reads, updates, and health-checks the local runtime LLM provider.
+- Top-bar `Controls` includes the local/dev LLM provider selector: Local API, Groq, or Custom OpenAI-compatible API.
+- `npm run doctor:llm` checks the active OpenAI-compatible LLM endpoint with a tiny JSON-only request.
 - `POST /api/muse/stream` (Ghost Muse SSE, mode `bullets|block`)
 - `POST /api/muse/chat/compress` (Chapter compress, JSON strict non-stream, soft limit 350KB)
 - `POST /api/muse/chat/synthesis` (Muse Chat synthesis, JSON strict non-stream)
@@ -253,6 +255,7 @@ Thực thể chính:
 - `LLM_MODEL`
 - `LLM_API_KEY`
 - `LLM_MAX_TOKENS` (optional; conservative output cap for local/provider testing)
+- Runtime UI override: `.runtime/llm-provider.json` (local-only, ignored by Git, takes precedence over `LLM_*` env vars)
 - `WRITING_V2_PRODUCTION` (optional, default `1`; set `0` to disable `/stories/[slug]/chapters/*` AutoWrite v2 plan/execute/status endpoints during rollout/rollback)
 - `WRITING_COOL_OFF_SECONDS` (optional, default `2`; controls cool-off between `NARRATIVE_*` tasks for chapter writing)
 - `LLAMA_MANUAL_ONLY` (optional, default `1`; when enabled, `/ingest/worker` API will not start/stop llama-server and expects manual terminal operation)

--- a/apps/studio/scripts/doctor_llm.mjs
+++ b/apps/studio/scripts/doctor_llm.mjs
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
 import { performance } from "node:perf_hooks";
 
 const args = new Set(process.argv.slice(2));
@@ -31,6 +32,35 @@ function redact(value) {
   return `${value.slice(0, 4)}...${value.slice(-4)}`;
 }
 
+function formatBaseForLog(value) {
+  if (!value) return "<missing>";
+  if (!/^https?:\/\//i.test(value)) return "<invalid-url>";
+  return value;
+}
+
+function validateBaseUrl(value) {
+  if (!value) throw new Error("LLM_API_BASE is required");
+  if (!/^https?:\/\//i.test(value)) throw new Error("LLM_API_BASE must start with http:// or https://");
+}
+
+function runtimeProviderPath() {
+  return path.resolve(process.cwd(), "../../.runtime/llm-provider.json");
+}
+
+function loadRuntimeProvider() {
+  const file = runtimeProviderPath();
+  if (!existsSync(file)) return null;
+  const parsed = JSON.parse(readFileSync(file, "utf8"));
+  return {
+    provider: String(parsed.provider || "custom_openai_compatible"),
+    base: String(parsed.baseUrl || "").replace(/\/+$/, ""),
+    apiKey: String(parsed.apiKey || ""),
+    model: String(parsed.model || ""),
+    maxTokens: Number(parsed.maxTokens || 64),
+    source: "runtime",
+  };
+}
+
 function parseJsonFromText(text) {
   const trimmed = String(text || "").trim();
   try {
@@ -46,20 +76,23 @@ async function main() {
   loadEnvFile(".env.local");
   loadEnvFile(".env");
 
-  const base = String(process.env.LLM_API_BASE || "").replace(/\/+$/, "");
-  const apiKey = String(process.env.LLM_API_KEY || "");
-  const model = String(process.env.LLM_MODEL || "");
-  const maxTokens = Number(process.env.LLM_MAX_TOKENS || 64);
+  const runtimeProvider = loadRuntimeProvider();
+  const base = runtimeProvider?.base || String(process.env.LLM_API_BASE || "http://localhost:8080/v1").replace(/\/+$/, "");
+  const apiKey = runtimeProvider?.apiKey || String(process.env.LLM_API_KEY || "local");
+  const model = runtimeProvider?.model || String(process.env.LLM_MODEL || "local-model");
+  const maxTokens = runtimeProvider?.maxTokens || Number(process.env.LLM_MAX_TOKENS || 64);
   const healthMaxTokens = Math.min(Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : 64, 64);
 
-  if (!base) throw new Error("LLM_API_BASE is required");
-  if (!model) throw new Error("LLM_MODEL is required");
-  if (!apiKey) throw new Error("LLM_API_KEY is required");
-
-  console.log("[doctor:llm] base:", base);
+  console.log("[doctor:llm] source:", runtimeProvider?.source || (process.env.LLM_API_BASE ? "env" : "default"));
+  if (runtimeProvider?.provider) console.log("[doctor:llm] provider:", runtimeProvider.provider);
+  console.log("[doctor:llm] base:", formatBaseForLog(base));
   console.log("[doctor:llm] model:", model);
   console.log("[doctor:llm] api_key:", redact(apiKey));
   console.log("[doctor:llm] max_tokens:", healthMaxTokens);
+
+  validateBaseUrl(base);
+  if (!model) throw new Error("LLM_MODEL is required");
+  if (!apiKey) throw new Error("LLM_API_KEY is required");
 
   if (dryRun) {
     console.log("[doctor:llm] dry_run=true; request not sent");

--- a/apps/studio/src/app/api/llm/provider/route.ts
+++ b/apps/studio/src/app/api/llm/provider/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getActiveLlmProviderConfig, runLlmProviderHealthCheck, writeRuntimeProviderConfig } from "@/features/llm/server/llmProviderRuntime";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const { redacted } = await getActiveLlmProviderConfig();
+  return NextResponse.json({ provider: redacted });
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const provider = await writeRuntimeProviderConfig(body);
+    return NextResponse.json({ provider });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : "LLM_PROVIDER_SAVE_FAILED" }, { status: 400 });
+  }
+}
+
+export async function POST() {
+  const { config } = await getActiveLlmProviderConfig();
+  const health = await runLlmProviderHealthCheck(config);
+  return NextResponse.json({ health }, { status: health.ok ? 200 : 502 });
+}

--- a/apps/studio/src/features/llm/components/LlmProviderSelector.tsx
+++ b/apps/studio/src/features/llm/components/LlmProviderSelector.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  defaultLlmProviderConfig,
+  GROQ_MODEL_OPTIONS,
+  LLM_PROVIDER_LABELS,
+  type LlmHealthResult,
+  type LlmProviderConfig,
+  type LlmProviderKind,
+  type RedactedLlmProviderConfig,
+} from "../llmProviderProfiles";
+
+type ProviderResponse = {
+  provider?: RedactedLlmProviderConfig;
+  error?: string;
+};
+
+type HealthResponse = {
+  health?: LlmHealthResult;
+  error?: string;
+};
+
+type ProviderForm = LlmProviderConfig & {
+  apiKeyInput: string;
+};
+
+function formFromProvider(provider: RedactedLlmProviderConfig | null): ProviderForm {
+  const defaults = defaultLlmProviderConfig(provider?.provider ?? "local");
+  return {
+    provider: provider?.provider ?? defaults.provider,
+    baseUrl: provider?.baseUrl ?? defaults.baseUrl,
+    model: provider?.model ?? defaults.model,
+    apiKey: "",
+    apiKeyInput: "",
+    maxTokens: provider?.maxTokens ?? defaults.maxTokens,
+  };
+}
+
+function useLlmProviderForm() {
+  const [provider, setProvider] = useState<RedactedLlmProviderConfig | null>(null);
+  const [form, setForm] = useState<ProviderForm>(() => formFromProvider(null));
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [health, setHealth] = useState<LlmHealthResult | null>(null);
+
+  async function loadProvider() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/llm/provider", { cache: "no-store" });
+      const json = (await res.json()) as ProviderResponse;
+      if (!res.ok || !json.provider) throw new Error(json.error ?? "LOAD_FAILED");
+      setProvider(json.provider);
+      setForm(formFromProvider(json.provider));
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "LOAD_FAILED");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadProvider();
+  }, []);
+
+  function selectProvider(next: LlmProviderKind) {
+    const defaults = defaultLlmProviderConfig(next);
+    setHealth(null);
+    setMessage(null);
+    setForm({ ...defaults, apiKey: "", apiKeyInput: "" });
+  }
+
+  async function saveProvider() {
+    setSaving(true);
+    setMessage(null);
+    setHealth(null);
+    try {
+      const res = await fetch("/api/llm/provider", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: form.provider,
+          baseUrl: form.baseUrl,
+          model: form.model,
+          apiKey: form.apiKeyInput,
+          maxTokens: form.maxTokens,
+        }),
+      });
+      const json = (await res.json()) as ProviderResponse;
+      if (!res.ok || !json.provider) throw new Error(json.error ?? "SAVE_FAILED");
+      setProvider(json.provider);
+      setForm({ ...formFromProvider(json.provider), apiKeyInput: "" });
+      setMessage("Saved runtime provider.");
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "SAVE_FAILED");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function checkProvider() {
+    setChecking(true);
+    setMessage(null);
+    setHealth(null);
+    try {
+      const res = await fetch("/api/llm/provider", { method: "POST" });
+      const json = (await res.json()) as HealthResponse;
+      if (!json.health) throw new Error(json.error ?? "HEALTH_CHECK_FAILED");
+      setHealth(json.health);
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "HEALTH_CHECK_FAILED");
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return { provider, form, setForm, loading, saving, checking, message, health, selectProvider, saveProvider, checkProvider };
+}
+
+function ProviderFields({
+  form,
+  setForm,
+  provider,
+  selectProvider,
+}: {
+  form: ProviderForm;
+  setForm: React.Dispatch<React.SetStateAction<ProviderForm>>;
+  provider: RedactedLlmProviderConfig | null;
+  selectProvider: (next: LlmProviderKind) => void;
+}) {
+  const modelOptions = useMemo(() => (form.provider === "groq" ? GROQ_MODEL_OPTIONS : []), [form.provider]);
+
+  return (
+    <div className="grid gap-2">
+      <select
+        className="shell-control px-2 py-1.5 text-xs"
+        value={form.provider}
+        onChange={(event) => selectProvider(event.target.value as LlmProviderKind)}
+      >
+        {(Object.keys(LLM_PROVIDER_LABELS) as LlmProviderKind[]).map((kind) => (
+          <option key={kind} value={kind}>
+            {LLM_PROVIDER_LABELS[kind]}
+          </option>
+        ))}
+      </select>
+      <input
+        className="shell-control px-2 py-1.5 text-xs"
+        value={form.baseUrl}
+        placeholder="OpenAI-compatible base URL"
+        onChange={(event) => setForm((prev) => ({ ...prev, baseUrl: event.target.value }))}
+      />
+      <ModelInput form={form} modelOptions={modelOptions} setForm={setForm} />
+      <div className="grid grid-cols-[1fr_76px] gap-2">
+        <input
+          className="shell-control px-2 py-1.5 text-xs"
+          value={form.apiKeyInput}
+          type="password"
+          placeholder={provider?.hasApiKey ? "Keep existing key" : "API key"}
+          onChange={(event) => setForm((prev) => ({ ...prev, apiKeyInput: event.target.value }))}
+        />
+        <input
+          className="shell-control px-2 py-1.5 text-xs"
+          value={form.maxTokens}
+          type="number"
+          min={64}
+          max={4000}
+          onChange={(event) => setForm((prev) => ({ ...prev, maxTokens: Number(event.target.value) }))}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ModelInput({
+  form,
+  modelOptions,
+  setForm,
+}: {
+  form: ProviderForm;
+  modelOptions: readonly string[];
+  setForm: React.Dispatch<React.SetStateAction<ProviderForm>>;
+}) {
+  if (modelOptions.length === 0) {
+    return (
+      <input
+        className="shell-control px-2 py-1.5 text-xs"
+        value={form.model}
+        placeholder="model"
+        onChange={(event) => setForm((prev) => ({ ...prev, model: event.target.value }))}
+      />
+    );
+  }
+
+  return (
+    <select
+      className="shell-control px-2 py-1.5 text-xs"
+      value={form.model}
+      onChange={(event) => setForm((prev) => ({ ...prev, model: event.target.value }))}
+    >
+      {modelOptions.map((model) => (
+        <option key={model} value={model}>
+          {model}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function getSourceLabel(source: RedactedLlmProviderConfig["source"] | undefined): string {
+  if (source === "runtime") return "Runtime";
+  if (source === "env") return "Env";
+  return "Default";
+}
+
+function getHealthColor(status: LlmHealthResult["status"] | undefined): string {
+  if (status === "ok") return "text-[#8ef2d5]";
+  if (status === "rate_limited") return "text-amber-200";
+  return "text-red-300";
+}
+
+function ProviderSummary({
+  loading,
+  provider,
+}: {
+  loading: boolean;
+  provider: RedactedLlmProviderConfig | null;
+}) {
+  if (loading) return <div className="muted">Loading...</div>;
+  return <div className="muted">{`${getSourceLabel(provider?.source)} · ${provider?.apiKeyPreview ?? "<missing>"}`}</div>;
+}
+
+export function LlmProviderSelector() {
+  const state = useLlmProviderForm();
+  const { provider, form, setForm, loading, saving, checking, message, health } = state;
+  const healthColor = getHealthColor(health?.status);
+
+  return (
+    <div className="my-1 border-y border-[#223247] py-2 text-xs">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div>
+          <div className="font-medium text-[#d9e7f7]">LLM Provider</div>
+          <ProviderSummary loading={loading} provider={provider} />
+        </div>
+        <button
+          type="button"
+          className="rounded border border-[#2a3441] px-2 py-1 text-[#cfe7ff] hover:bg-[#162236]"
+          onClick={state.checkProvider}
+          disabled={loading || checking}
+        >
+          {checking ? "Checking" : "Check"}
+        </button>
+      </div>
+
+      <ProviderFields form={form} provider={provider} selectProvider={state.selectProvider} setForm={setForm} />
+      <button
+        type="button"
+        className="mt-2 w-full rounded-md border border-[#2f5b58] bg-[#133a37] px-2 py-1.5 text-left text-[#8ef2d5] disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={state.saveProvider}
+        disabled={saving || loading}
+      >
+        {saving ? "Saving provider..." : "Save runtime provider"}
+      </button>
+
+      {health && (
+        <div className={`mt-2 ${healthColor}`}>
+          {health.status}: {health.message}
+          {typeof health.latencyMs === "number" ? ` (${health.latencyMs}ms)` : ""}
+        </div>
+      )}
+      {message && <div className="mt-2 text-amber-200">{message}</div>}
+    </div>
+  );
+}

--- a/apps/studio/src/features/llm/llmProviderProfiles.ts
+++ b/apps/studio/src/features/llm/llmProviderProfiles.ts
@@ -1,0 +1,119 @@
+export type LlmProviderKind = "local" | "groq" | "custom_openai_compatible";
+
+export type LlmProviderConfig = {
+  provider: LlmProviderKind;
+  baseUrl: string;
+  model: string;
+  apiKey?: string;
+  maxTokens: number;
+};
+
+export type RedactedLlmProviderConfig = Omit<LlmProviderConfig, "apiKey"> & {
+  apiKeyPreview: string;
+  hasApiKey: boolean;
+  source: "runtime" | "env" | "default";
+};
+
+export type LlmHealthResult = {
+  ok: boolean;
+  status: "ok" | "failed" | "rate_limited";
+  latencyMs?: number;
+  provider: LlmProviderKind;
+  baseUrl: string;
+  model: string;
+  message: string;
+};
+
+export const LLM_PROVIDER_LABELS: Record<LlmProviderKind, string> = {
+  local: "Local API",
+  groq: "Groq",
+  custom_openai_compatible: "Custom API",
+};
+
+export const GROQ_MODEL_OPTIONS = [
+  "llama-3.1-8b-instant",
+  "qwen/qwen3-32b",
+  "meta-llama/llama-4-scout-17b-16e-instruct",
+  "openai/gpt-oss-120b",
+  "llama-3.3-70b-versatile",
+] as const;
+
+export const LOCAL_DEFAULT_BASE_URL = "http://localhost:8080/v1";
+export const GROQ_DEFAULT_BASE_URL = "https://api.groq.com/openai/v1";
+
+const DEFAULT_MAX_TOKENS = 512;
+
+export function defaultLlmProviderConfig(provider: LlmProviderKind): LlmProviderConfig {
+  if (provider === "groq") {
+    return {
+      provider,
+      baseUrl: GROQ_DEFAULT_BASE_URL,
+      model: "llama-3.1-8b-instant",
+      apiKey: "",
+      maxTokens: DEFAULT_MAX_TOKENS,
+    };
+  }
+
+  if (provider === "custom_openai_compatible") {
+    return {
+      provider,
+      baseUrl: "",
+      model: "",
+      apiKey: "",
+      maxTokens: DEFAULT_MAX_TOKENS,
+    };
+  }
+
+  return {
+    provider,
+    baseUrl: LOCAL_DEFAULT_BASE_URL,
+    model: "local-model",
+    apiKey: "local",
+    maxTokens: DEFAULT_MAX_TOKENS,
+  };
+}
+
+export function isLlmProviderKind(value: unknown): value is LlmProviderKind {
+  return value === "local" || value === "groq" || value === "custom_openai_compatible";
+}
+
+export function redactApiKey(value: string | undefined): string {
+  if (!value) return "<missing>";
+  if (value === "local") return "local";
+  if (value.length <= 8) return "***";
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+export function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+export function normalizeMaxTokens(value: unknown, fallback = DEFAULT_MAX_TOKENS): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(Math.max(Math.round(parsed), 64), 4000);
+}
+
+export function validateLlmProviderConfig(config: LlmProviderConfig): string | null {
+  if (!isLlmProviderKind(config.provider)) return "Invalid provider.";
+  if (!config.baseUrl) return "Base URL is required.";
+  if (!/^https?:\/\//i.test(config.baseUrl)) return "Base URL must start with http:// or https://.";
+  if (!config.model.trim()) return "Model is required.";
+  if (!Number.isFinite(config.maxTokens) || config.maxTokens <= 0) return "Max tokens must be greater than zero.";
+  return null;
+}
+
+export function toRedactedLlmProviderConfig(
+  config: LlmProviderConfig,
+  source: RedactedLlmProviderConfig["source"]
+): RedactedLlmProviderConfig {
+  return {
+    provider: config.provider,
+    baseUrl: config.baseUrl,
+    model: config.model,
+    maxTokens: config.maxTokens,
+    apiKeyPreview: redactApiKey(config.apiKey),
+    hasApiKey: Boolean(config.apiKey),
+    source,
+  };
+}

--- a/apps/studio/src/features/llm/server/llmProviderRuntime.ts
+++ b/apps/studio/src/features/llm/server/llmProviderRuntime.ts
@@ -1,0 +1,198 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+  defaultLlmProviderConfig,
+  isLlmProviderKind,
+  normalizeBaseUrl,
+  normalizeMaxTokens,
+  toRedactedLlmProviderConfig,
+  validateLlmProviderConfig,
+  type LlmHealthResult,
+  type LlmProviderConfig,
+  type LlmProviderKind,
+  type RedactedLlmProviderConfig,
+} from "../llmProviderProfiles";
+
+type RuntimeFileShape = Partial<LlmProviderConfig>;
+
+function getRuntimeDir(): string {
+  if (process.env.NOVEL_RUNTIME_DIR) return process.env.NOVEL_RUNTIME_DIR;
+  const cwd = process.cwd();
+  const repoRoot = cwd.replace(/\\/g, "/").endsWith("/apps/studio") ? path.resolve(cwd, "../..") : cwd;
+  return path.join(repoRoot, ".runtime");
+}
+
+export function getRuntimeProviderPath(): string {
+  return path.join(getRuntimeDir(), "llm-provider.json");
+}
+
+function envProviderConfig(): LlmProviderConfig | null {
+  const baseUrl = normalizeBaseUrl(process.env.LLM_API_BASE ?? "");
+  const model = String(process.env.LLM_MODEL ?? "").trim();
+  const apiKey = String(process.env.LLM_API_KEY ?? "");
+  if (!baseUrl && !model && !apiKey) return null;
+  if (!/^https?:\/\//i.test(baseUrl)) return null;
+
+  const provider = baseUrl.includes("api.groq.com")
+    ? "groq"
+    : baseUrl.includes("localhost") || baseUrl.includes("127.0.0.1")
+      ? "local"
+      : "custom_openai_compatible";
+
+  return {
+    provider,
+    baseUrl,
+    model,
+    apiKey,
+    maxTokens: normalizeMaxTokens(process.env.LLM_MAX_TOKENS, 512),
+  };
+}
+
+function normalizeRuntimeConfig(input: RuntimeFileShape, fallbackProvider: LlmProviderKind = "local"): LlmProviderConfig {
+  const provider = isLlmProviderKind(input.provider) ? input.provider : fallbackProvider;
+  const defaults = defaultLlmProviderConfig(provider);
+  return {
+    provider,
+    baseUrl: normalizeBaseUrl(String(input.baseUrl ?? defaults.baseUrl)),
+    model: String(input.model ?? defaults.model).trim(),
+    apiKey: typeof input.apiKey === "string" ? input.apiKey : defaults.apiKey,
+    maxTokens: normalizeMaxTokens(input.maxTokens, defaults.maxTokens),
+  };
+}
+
+export async function readRuntimeProviderConfig(): Promise<LlmProviderConfig | null> {
+  try {
+    const raw = await readFile(getRuntimeProviderPath(), "utf8");
+    const parsed = JSON.parse(raw) as RuntimeFileShape;
+    const config = normalizeRuntimeConfig(parsed);
+    const validationError = validateLlmProviderConfig(config);
+    if (validationError) throw new Error(`Invalid runtime LLM provider config: ${validationError}`);
+    return config;
+  } catch (err) {
+    const code = typeof err === "object" && err && "code" in err ? String((err as { code: unknown }).code) : "";
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function getActiveLlmProviderConfig(): Promise<{
+  config: LlmProviderConfig;
+  redacted: RedactedLlmProviderConfig;
+}> {
+  const runtimeConfig = await readRuntimeProviderConfig();
+  if (runtimeConfig) {
+    return { config: runtimeConfig, redacted: toRedactedLlmProviderConfig(runtimeConfig, "runtime") };
+  }
+
+  const envConfig = envProviderConfig();
+  if (envConfig) {
+    return { config: envConfig, redacted: toRedactedLlmProviderConfig(envConfig, "env") };
+  }
+
+  const defaultConfig = defaultLlmProviderConfig("local");
+  return { config: defaultConfig, redacted: toRedactedLlmProviderConfig(defaultConfig, "default") };
+}
+
+export async function writeRuntimeProviderConfig(input: RuntimeFileShape): Promise<RedactedLlmProviderConfig> {
+  const fallbackProvider = isLlmProviderKind(input.provider) ? input.provider : "local";
+  const current = await readRuntimeProviderConfig();
+  const providerChanged = Boolean(current && current.provider !== fallbackProvider);
+  const defaults = defaultLlmProviderConfig(fallbackProvider);
+  const merged = normalizeRuntimeConfig(
+    {
+      ...current,
+      ...input,
+      apiKey:
+        typeof input.apiKey === "string" && input.apiKey.length > 0
+          ? input.apiKey
+          : typeof current?.apiKey === "string" && !providerChanged
+            ? current.apiKey
+            : defaults.apiKey,
+    },
+    fallbackProvider
+  );
+  const validationError = validateLlmProviderConfig(merged);
+  if (validationError) throw new Error(validationError);
+
+  await mkdir(getRuntimeDir(), { recursive: true });
+  await writeFile(getRuntimeProviderPath(), `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 });
+  return toRedactedLlmProviderConfig(merged, "runtime");
+}
+
+export async function runLlmProviderHealthCheck(config: LlmProviderConfig): Promise<LlmHealthResult> {
+  const validationError = validateLlmProviderConfig(config);
+  if (validationError) {
+    return {
+      ok: false,
+      status: "failed",
+      provider: config.provider,
+      baseUrl: config.baseUrl,
+      model: config.model,
+      message: validationError,
+    };
+  }
+
+  if (!config.apiKey) {
+    return {
+      ok: false,
+      status: "failed",
+      provider: config.provider,
+      baseUrl: config.baseUrl,
+      model: config.model,
+      message: "API key is required for health checks.",
+    };
+  }
+
+  const startedAt = performance.now();
+  try {
+    const res = await fetch(`${config.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: config.model,
+        messages: [{ role: "user", content: "Return JSON only: {\"ok\": true, \"provider\": \"configured\"}" }],
+        temperature: 0,
+        max_tokens: Math.min(config.maxTokens, 64),
+      }),
+    });
+    const latencyMs = Math.round(performance.now() - startedAt);
+    const text = await res.text();
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status === 429 ? "rate_limited" : "failed",
+        latencyMs,
+        provider: config.provider,
+        baseUrl: config.baseUrl,
+        model: config.model,
+        message:
+          res.status === 429
+            ? "Rate limited. Reduce max_tokens, wait for reset, or switch model/provider."
+            : `Provider returned ${res.status}: ${text.slice(0, 180)}`,
+      };
+    }
+
+    return {
+      ok: true,
+      status: "ok",
+      latencyMs,
+      provider: config.provider,
+      baseUrl: config.baseUrl,
+      model: config.model,
+      message: "Health check passed.",
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: "failed",
+      provider: config.provider,
+      baseUrl: config.baseUrl,
+      model: config.model,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/studio/src/features/story/StorySelector.tsx
+++ b/apps/studio/src/features/story/StorySelector.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { createPortal } from "react-dom";
+import { LlmProviderSelector } from "@/features/llm/components/LlmProviderSelector";
 import { useStory } from "./StoryContext";
 
 type StoryItem = {
@@ -261,7 +262,7 @@ export default function StorySelector() {
 
         <details className="relative">
           <summary className={`shell-link cursor-pointer list-none px-2 py-1 ${disabledLinkClass}`}>Controls</summary>
-          <div className="absolute right-0 z-50 mt-1 min-w-[200px] rounded border border-[#2a3441] bg-[#0d1524] p-1 shadow-lg">
+          <div className="absolute right-0 z-50 mt-1 min-w-[320px] rounded border border-[#2a3441] bg-[#0d1524] p-2 shadow-lg">
             <button
               type="button"
               className="block w-full rounded px-2 py-1 text-left hover:bg-[#162236] disabled:pointer-events-none disabled:opacity-50"
@@ -270,6 +271,7 @@ export default function StorySelector() {
             >
               Language: {writingLanguage === "en" ? "English" : "Tiếng Việt"}
             </button>
+            <LlmProviderSelector />
             <button
               type="button"
               className="block w-full rounded px-2 py-1 text-left hover:bg-[#162236] disabled:pointer-events-none disabled:opacity-50"

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -15,6 +15,36 @@ LLM_MAX_TOKENS=512
 
 Any provider that exposes an OpenAI-compatible `/chat/completions` endpoint can be tested through this shape.
 
+## Runtime Provider Selector
+
+Studio exposes a local/dev provider selector in the top-bar `Controls` menu.
+
+Supported profiles:
+
+- `Local API`: OpenAI-compatible local endpoint, default `http://localhost:8080/v1`.
+- `Groq`: OpenAI-compatible Groq endpoint, default `https://api.groq.com/openai/v1`.
+- `Custom API`: any OpenAI-compatible provider.
+
+The selector writes a local override file:
+
+```text
+.runtime/llm-provider.json
+```
+
+This file is ignored by Git and may contain a real API key. Do not copy it into commits, issues, logs, or screenshots.
+
+Runtime override precedence:
+
+```text
+1. .runtime/llm-provider.json
+2. apps/studio/.env.local or apps/studio/.env
+3. Local API default
+```
+
+The browser never receives the raw stored API key from `GET /api/llm/provider`; it only receives a redacted preview. Health checks run server-side through `POST /api/llm/provider`.
+
+Local still uses the old OpenAI-compatible API path. It does not launch or call a llama binary directly.
+
 ## Groq Free/Developer Profile
 
 Groq can be used for low-cost local testing because it exposes an OpenAI-compatible API.
@@ -126,6 +156,8 @@ For a no-network config check:
 ```bash
 npm run doctor:llm -- --dry-run
 ```
+
+`doctor:llm` reads `.runtime/llm-provider.json` first when present, then falls back to `LLM_API_BASE`, `LLM_API_KEY`, `LLM_MODEL`, and `LLM_MAX_TOKENS`.
 
 The doctor sends a tiny JSON-only request:
 


### PR DESCRIPTION
## Summary
- add a server-side runtime LLM provider API for Local API, Groq, and custom OpenAI-compatible providers
- add a compact provider selector under Studio top-bar Controls
- make `doctor:llm` read `.runtime/llm-provider.json` before env vars and avoid logging invalid base URL values
- document runtime override precedence and provider selector behavior

Closes #43

## Verification
- `cd /home/danh/novel-ai/apps/studio && npm run typecheck`
- `cd /home/danh/novel-ai/apps/studio && npx eslint src/features/llm/llmProviderProfiles.ts src/features/llm/server/llmProviderRuntime.ts src/app/api/llm/provider/route.ts src/features/llm/components/LlmProviderSelector.tsx src/features/story/StorySelector.tsx scripts/doctor_llm.mjs`
- `cd /home/danh/novel-ai/apps/studio && LLM_API_BASE=http://localhost:8080/v1 LLM_API_KEY=local LLM_MODEL=local-model npm run doctor:llm -- --dry-run`
- `cd /home/danh/novel-ai/apps/studio && npm run build`
- `cd /home/danh/novel-ai && git diff --check`

## Notes
- Runtime provider state is local-only at `.runtime/llm-provider.json` and is ignored by Git.
- Raw stored API keys are never returned by `GET /api/llm/provider`; only a redacted preview is returned.
- Local still calls the OpenAI-compatible API endpoint, default `http://localhost:8080/v1`.