### PR TITLE
feat: add 9Router LLM provider

### DIFF
--- a/apps/studio/.env.example
+++ b/apps/studio/.env.example
@@ -11,6 +11,11 @@ LLM_API_KEY=local
 # LLM_MODEL=qwen/qwen3-32b
 # LLM_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
 # LLM_MODEL=openai/gpt-oss-120b
+# Optional local 9Router profile. Run 9Router separately, then copy the API key
+# from http://localhost:20128/dashboard. The OpenAI-compatible API base is:
+# LLM_API_BASE=http://localhost:20128/v1
+# LLM_API_KEY=9router_dashboard_key
+# LLM_MODEL=kr/claude-sonnet-4.5
 LLM_MAX_TOKENS=512
 LLAMA_CONTEXT=16384
 WORKER_FLOW_LANE=all

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -259,6 +259,13 @@ Thực thể chính:
 - `LLM_API_KEY`
 - `LLM_MAX_TOKENS` (optional; conservative output cap for local/provider testing)
 - Runtime UI override: `.runtime/llm-provider.json` (local-only, ignored by Git, takes precedence over `LLM_*` env vars)
+- Local 9Router option:
+  - Run 9Router separately; Studio does not manage that process.
+  - Dashboard: `http://localhost:20128/dashboard`
+  - OpenAI-compatible API base: `http://localhost:20128/v1`
+  - Copy the dashboard API key into Studio Controls -> LLM Provider, choose `9Router`, keep or edit the model, save, then run the provider health check.
+  - `npm run doctor:llm -- --dry-run` should show the runtime source, base URL, model, and redacted API key before any request is sent.
+  - If health check fails, verify that 9Router is running, the dashboard API key is present, and the selected model is available in the 9Router dashboard.
 - `WRITING_V2_PRODUCTION` (optional, default `1`; set `0` to disable `/stories/[slug]/chapters/*` AutoWrite v2 plan/execute/status endpoints during rollout/rollback)
 - `WRITING_COOL_OFF_SECONDS` (optional, default `2`; controls cool-off between `NARRATIVE_*` tasks for chapter writing)
 - `LLAMA_MANUAL_ONLY` (optional, default `1`; when enabled, `/ingest/worker` API will not start/stop llama-server and expects manual terminal operation)

--- a/apps/studio/scripts/doctor_llm.mjs
+++ b/apps/studio/scripts/doctor_llm.mjs
@@ -43,6 +43,13 @@ function validateBaseUrl(value) {
   if (!/^https?:\/\//i.test(value)) throw new Error("LLM_API_BASE must start with http:// or https://");
 }
 
+function inferProviderFromBaseUrl(value) {
+  if (String(value || "").includes("api.groq.com")) return "groq";
+  if (String(value || "").includes("localhost:20128") || String(value || "").includes("127.0.0.1:20128")) return "9router";
+  if (String(value || "").includes("localhost") || String(value || "").includes("127.0.0.1")) return "local";
+  return "custom_openai_compatible";
+}
+
 function runtimeProviderPath() {
   return path.resolve(process.cwd(), "../../.runtime/llm-provider.json");
 }
@@ -82,9 +89,10 @@ async function main() {
   const model = runtimeProvider?.model || String(process.env.LLM_MODEL || "local-model");
   const maxTokens = runtimeProvider?.maxTokens || Number(process.env.LLM_MAX_TOKENS || 64);
   const healthMaxTokens = Math.min(Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : 64, 64);
+  const provider = runtimeProvider?.provider || inferProviderFromBaseUrl(base);
 
   console.log("[doctor:llm] source:", runtimeProvider?.source || (process.env.LLM_API_BASE ? "env" : "default"));
-  if (runtimeProvider?.provider) console.log("[doctor:llm] provider:", runtimeProvider.provider);
+  console.log("[doctor:llm] provider:", provider);
   console.log("[doctor:llm] base:", formatBaseForLog(base));
   console.log("[doctor:llm] model:", model);
   console.log("[doctor:llm] api_key:", redact(apiKey));

--- a/apps/studio/src/features/llm/llmProviderProfiles.ts
+++ b/apps/studio/src/features/llm/llmProviderProfiles.ts
@@ -1,4 +1,4 @@
-export type LlmProviderKind = "local" | "groq" | "custom_openai_compatible";
+export type LlmProviderKind = "local" | "groq" | "9router" | "custom_openai_compatible";
 
 export type LlmProviderConfig = {
   provider: LlmProviderKind;
@@ -27,6 +27,7 @@ export type LlmHealthResult = {
 export const LLM_PROVIDER_LABELS: Record<LlmProviderKind, string> = {
   local: "Local API",
   groq: "Groq",
+  "9router": "9Router",
   custom_openai_compatible: "Custom API",
 };
 
@@ -40,6 +41,7 @@ export const GROQ_MODEL_OPTIONS = [
 
 export const LOCAL_DEFAULT_BASE_URL = "http://localhost:8080/v1";
 export const GROQ_DEFAULT_BASE_URL = "https://api.groq.com/openai/v1";
+export const NINE_ROUTER_DEFAULT_BASE_URL = "http://localhost:20128/v1";
 
 const DEFAULT_MAX_TOKENS = 512;
 
@@ -64,6 +66,16 @@ export function defaultLlmProviderConfig(provider: LlmProviderKind): LlmProvider
     };
   }
 
+  if (provider === "9router") {
+    return {
+      provider,
+      baseUrl: NINE_ROUTER_DEFAULT_BASE_URL,
+      model: "kr/claude-sonnet-4.5",
+      apiKey: "",
+      maxTokens: DEFAULT_MAX_TOKENS,
+    };
+  }
+
   return {
     provider,
     baseUrl: LOCAL_DEFAULT_BASE_URL,
@@ -74,7 +86,7 @@ export function defaultLlmProviderConfig(provider: LlmProviderKind): LlmProvider
 }
 
 export function isLlmProviderKind(value: unknown): value is LlmProviderKind {
-  return value === "local" || value === "groq" || value === "custom_openai_compatible";
+  return value === "local" || value === "groq" || value === "9router" || value === "custom_openai_compatible";
 }
 
 export function redactApiKey(value: string | undefined): string {

--- a/apps/studio/src/features/llm/server/llmProviderRuntime.ts
+++ b/apps/studio/src/features/llm/server/llmProviderRuntime.ts
@@ -27,6 +27,13 @@ export function getRuntimeProviderPath(): string {
   return path.join(getRuntimeDir(), "llm-provider.json");
 }
 
+function inferProviderFromBaseUrl(baseUrl: string): LlmProviderKind {
+  if (baseUrl.includes("api.groq.com")) return "groq";
+  if (baseUrl.includes("localhost:20128") || baseUrl.includes("127.0.0.1:20128")) return "9router";
+  if (baseUrl.includes("localhost") || baseUrl.includes("127.0.0.1")) return "local";
+  return "custom_openai_compatible";
+}
+
 function envProviderConfig(): LlmProviderConfig | null {
   const baseUrl = normalizeBaseUrl(process.env.LLM_API_BASE ?? "");
   const model = String(process.env.LLM_MODEL ?? "").trim();
@@ -34,14 +41,8 @@ function envProviderConfig(): LlmProviderConfig | null {
   if (!baseUrl && !model && !apiKey) return null;
   if (!/^https?:\/\//i.test(baseUrl)) return null;
 
-  const provider = baseUrl.includes("api.groq.com")
-    ? "groq"
-    : baseUrl.includes("localhost") || baseUrl.includes("127.0.0.1")
-      ? "local"
-      : "custom_openai_compatible";
-
   return {
-    provider,
+    provider: inferProviderFromBaseUrl(baseUrl),
     baseUrl,
     model,
     apiKey,


### PR DESCRIPTION
## Summary
- Adds `9Router` as a first-class Studio LLM provider profile.
- Defaults 9Router to `http://localhost:20128/v1` with an editable model value.
- Infers 9Router from local `:20128` env base URLs and shows the provider in `doctor:llm` output.
- Documents dashboard/API base/API key setup in README and `.env.example`.

## Verification
- `npm run typecheck`
- `npx eslint src/features/llm/llmProviderProfiles.ts src/features/llm/server/llmProviderRuntime.ts src/features/llm/components/LlmProviderSelector.tsx scripts/doctor_llm.mjs`
- `LLM_API_BASE=http://localhost:20128/v1 LLM_MODEL=kr/claude-sonnet-4.5 LLM_API_KEY=test_9router_key npm run doctor:llm -- --dry-run`
- `npm run build`
- `git diff --check`

## Notes
- I did not run a live 9Router health request because that requires a running local 9Router instance and dashboard API key.
- Existing Local API, Groq, and Custom API options are preserved.

Closes #77
Closes #78
Closes #79
