### PR TITLE
Route chapter auto-write through CHAPTER_WRITE_V3

### DIFF
--- a/apps/studio/src/features/autowrite/server/narrativeTaskExecutor.ts
+++ b/apps/studio/src/features/autowrite/server/narrativeTaskExecutor.ts
@@ -3,6 +3,10 @@ import { NarrativeOrchestrator } from "@/features/scenes/server/workflow/steps/c
 import { advanceWritingPipeline } from "./writingPipelineService";
 import { buildStoryContextPack } from "@/features/guard/server/storyContextBuilder";
 
+/**
+ * Compatibility-only executor for legacy NARRATIVE_* jobs.
+ * New canonical chapter auto-write must enqueue CHAPTER_WRITE_V3 instead.
+ */
 export async function processNarrativeTask(taskId: number) {
     const client = await pool.connect();
     let jobId: number | undefined;
@@ -35,7 +39,7 @@ export async function processNarrativeTask(taskId: number) {
             keywords: plan.summary,
         });
 
-        let resultJson: any = {};
+        let resultJson: Record<string, unknown> = {};
 
         // 3. Dispatch by task_type
         if (task.task_type === 'NARRATIVE_START') {
@@ -82,11 +86,12 @@ export async function processNarrativeTask(taskId: number) {
             await advanceWritingPipeline(jobId, storyId);
         }
 
-    } catch (err: any) {
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
         console.error(`NarrativeTaskExecutor Error (Task ${taskId}):`, err);
         await client.query(
             `UPDATE public.ingest_task SET status = 'FAILED', result_json = $1 WHERE id = $2`,
-            [JSON.stringify({ error: err.message }), taskId]
+            [JSON.stringify({ error: message }), taskId]
         );
         if (jobId) {
             await client.query(`UPDATE public.ingest_job SET status = 'FAILED' WHERE id = $1`, [jobId]);

--- a/apps/studio/src/features/autowrite/server/narrativeWorkerService.ts
+++ b/apps/studio/src/features/autowrite/server/narrativeWorkerService.ts
@@ -5,6 +5,9 @@ let isPolling = false;
 
 /**
  * Polls for READY narrative tasks that are available to run.
+ *
+ * Compatibility-only path for legacy NARRATIVE_* jobs. Canonical chapter
+ * auto-write now enters through CHAPTER_WRITE_V3 and the Python worker.
  */
 export async function pollNarrativeQueue() {
     if (isPolling) return;

--- a/apps/studio/src/features/autowrite/server/writingPipelineService.ts
+++ b/apps/studio/src/features/autowrite/server/writingPipelineService.ts
@@ -16,8 +16,16 @@ import { assembleChapterWritingContext } from "./chapterWritingContextAssembler"
 export interface WritingPipelineConfig {
     storyId: number;
     instructions: string;
+    chapterId?: string;
     chapterNo?: number;
     targetWordCount?: number;
+    plan?: Record<string, unknown>;
+}
+
+function objectOrNull(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : null;
 }
 
 type ActiveCleanSnapshotRow = {
@@ -530,9 +538,13 @@ export async function enqueueChapterWriteV3(config: WritingPipelineConfig) {
     const client = await pool.connect();
     try {
         await client.query("BEGIN");
-        const chapterId = Number.isFinite(Number(config.chapterNo)) && Number(config.chapterNo) > 0
+        const explicitChapterId = String(config.chapterId || "").trim();
+        const chapterId = explicitChapterId || (Number.isFinite(Number(config.chapterNo)) && Number(config.chapterNo) > 0
             ? `ch${String(Math.floor(Number(config.chapterNo))).padStart(2, "0")}`
-            : "draft";
+            : "draft");
+        const plan = objectOrNull(config.plan);
+        const chapterOutputContract = objectOrNull(plan?.chapter_output_contract_v1);
+        const memoryRuntime = objectOrNull(plan?.memory_runtime_v5);
 
         // 1. Build WorkingSet
         const workingSet = await buildWorkingSet(client, config.storyId, chapterId);
@@ -558,6 +570,9 @@ export async function enqueueChapterWriteV3(config: WritingPipelineConfig) {
                     pipeline_type: "CHAPTER_WRITE_V3",
                     chapter_id: chapterId,
                     instructions: config.instructions,
+                    plan,
+                    chapter_output_contract_v1: chapterOutputContract,
+                    memory_runtime_v5: memoryRuntime,
                 }),
             ]
         );
@@ -574,6 +589,7 @@ export async function enqueueChapterWriteV3(config: WritingPipelineConfig) {
                 JSON.stringify({
                     chapter_id: chapterId,
                     chapter_goal: config.instructions,
+                    plan,
                     working_set: workingSet,
                     writing_context: assembledWritingContext.context,
                     writing_context_preflight: assembledWritingContext.preflight,

--- a/apps/studio/src/features/ingest/server/ingestWorkerService.ts
+++ b/apps/studio/src/features/ingest/server/ingestWorkerService.ts
@@ -36,7 +36,20 @@ async function getQueueMetrics() {
           CASE
             WHEN t.task_type IN ('CHAPTER_INGEST','CHAPTER_SPLIT_LLM','SCENE_CREATE','SPLIT_PROFILE_CORRECTION','CHAPTER_VALIDATE') THEN 'split'
             WHEN t.task_type IN ('WRITING_ANALYSIS') THEN 'analysis'
-            WHEN t.task_type IN ('WRITING_PLANNING','WRITING_PROSE','WRITING_CONTINUITY','WRITING_SUPERVISOR','NARRATIVE_START','NARRATIVE_STYLIST','NARRATIVE_CRITIC','NARRATIVE_REFINE','NARRATIVE_FINALIZE') THEN 'writing'
+            WHEN t.task_type IN (
+              'WRITING_PLANNING',
+              'WRITING_PROSE',
+              'WRITING_CONTINUITY',
+              'WRITING_SUPERVISOR',
+              'CHAPTER_WRITE_V3',
+              'CHAPTER_LEDGER_EXTRACT',
+              'MEMORY_ROLLUP_V3',
+              'NARRATIVE_START',
+              'NARRATIVE_STYLIST',
+              'NARRATIVE_CRITIC',
+              'NARRATIVE_REFINE',
+              'NARRATIVE_FINALIZE'
+            ) THEN 'writing'
             ELSE 'other'
           END AS lane,
           t.status
@@ -73,9 +86,9 @@ export async function getIngestWorkerResponse(): Promise<NextResponse> {
 
 export async function postIngestWorkerResponse(req: NextRequest): Promise<NextResponse> {
   let action = "start";
-  let body: any = {};
+  let body: Record<string, unknown> = {};
   try {
-    body = (await req.json()) as any;
+    body = (await req.json()) as Record<string, unknown>;
     action = typeof body?.action === "string" ? body.action.trim().toLowerCase() : "start";
   } catch {
     action = "start";

--- a/apps/studio/src/features/ingest/server/pipelineNodeConfig.ts
+++ b/apps/studio/src/features/ingest/server/pipelineNodeConfig.ts
@@ -32,6 +32,9 @@ export const RETRYABLE_NODE_KEYS = new Set([
   "CHAPTER_SPLIT_LLM",
   "SCENE_CREATE",
   "SPLIT_PROFILE_CORRECTION",
+  "CHAPTER_WRITE_V3",
+  "CHAPTER_LEDGER_EXTRACT",
+  "MEMORY_ROLLUP_V3",
   "NARRATIVE_START",
   "NARRATIVE_STYLIST",
   "NARRATIVE_CRITIC",
@@ -41,6 +44,9 @@ export const RETRYABLE_NODE_KEYS = new Set([
 
 export const NODE_TRACE_AGENT_MAP: Record<string, string[]> = {
   CHAPTER_SPLIT_LLM: ["SPLITTER", "SPLIT_CRITIC", "SUPERVISOR"],
+  CHAPTER_WRITE_V3: ["CHAPTER_WRITE_V3"],
+  CHAPTER_LEDGER_EXTRACT: ["CHAPTER_LEDGER_EXTRACT"],
+  MEMORY_ROLLUP_V3: ["MEMORY_ROLLUP_V3"],
   NARRATIVE_START: ["NARRATIVE_START"],
   NARRATIVE_STYLIST: ["NARRATIVE_STYLIST"],
   NARRATIVE_CRITIC: ["NARRATIVE_CRITIC"],
@@ -82,14 +88,20 @@ const FLOW_REGISTRY: Record<FlowType, FlowRegistry> = {
   AUTOWRITE: {
     flow_type: "AUTOWRITE",
     nodes: [
-      { key: "AUTOWRITE_GROUP", label: "Write Chapter", kind: "GROUP" },
-      { key: "NARRATIVE_START", label: "Start", kind: "TASK", group_key: "AUTOWRITE_GROUP" },
-      { key: "NARRATIVE_STYLIST", label: "Stylist", kind: "TASK", group_key: "AUTOWRITE_GROUP" },
-      { key: "NARRATIVE_CRITIC", label: "Critic", kind: "TASK", group_key: "AUTOWRITE_GROUP" },
-      { key: "NARRATIVE_REFINE", label: "Refine", kind: "TASK", group_key: "AUTOWRITE_GROUP" },
-      { key: "NARRATIVE_FINALIZE", label: "Finalize", kind: "TASK", group_key: "AUTOWRITE_GROUP" },
+      { key: "AUTOWRITE_V3_GROUP", label: "Write Chapter V3", kind: "GROUP" },
+      { key: "CHAPTER_WRITE_V3", label: "Chapter Write", kind: "TASK", group_key: "AUTOWRITE_V3_GROUP" },
+      { key: "CHAPTER_LEDGER_EXTRACT", label: "Ledger Extract", kind: "TASK", group_key: "AUTOWRITE_V3_GROUP" },
+      { key: "MEMORY_ROLLUP_V3", label: "Memory Rollup", kind: "TASK", group_key: "AUTOWRITE_V3_GROUP" },
+      { key: "AUTOWRITE_LEGACY_GROUP", label: "Legacy Narrative", kind: "GROUP" },
+      { key: "NARRATIVE_START", label: "Start", kind: "TASK", group_key: "AUTOWRITE_LEGACY_GROUP" },
+      { key: "NARRATIVE_STYLIST", label: "Stylist", kind: "TASK", group_key: "AUTOWRITE_LEGACY_GROUP" },
+      { key: "NARRATIVE_CRITIC", label: "Critic", kind: "TASK", group_key: "AUTOWRITE_LEGACY_GROUP" },
+      { key: "NARRATIVE_REFINE", label: "Refine", kind: "TASK", group_key: "AUTOWRITE_LEGACY_GROUP" },
+      { key: "NARRATIVE_FINALIZE", label: "Finalize", kind: "TASK", group_key: "AUTOWRITE_LEGACY_GROUP" },
     ],
     edges: [
+      { key: "E_CHAPTER_WRITE_TO_LEDGER", source: "CHAPTER_WRITE_V3", target: "CHAPTER_LEDGER_EXTRACT" },
+      { key: "E_LEDGER_TO_MEMORY_ROLLUP", source: "CHAPTER_LEDGER_EXTRACT", target: "MEMORY_ROLLUP_V3" },
       { key: "E_START_TO_STYLIST", source: "NARRATIVE_START", target: "NARRATIVE_STYLIST" },
       { key: "E_STYLIST_TO_CRITIC", source: "NARRATIVE_STYLIST", target: "NARRATIVE_CRITIC" },
       { key: "E_CRITIC_TO_REFINE", source: "NARRATIVE_CRITIC", target: "NARRATIVE_REFINE" },
@@ -97,8 +109,14 @@ const FLOW_REGISTRY: Record<FlowType, FlowRegistry> = {
     ],
     groups: [
       {
-        key: "AUTOWRITE_GROUP",
-        label: "Write Chapter",
+        key: "AUTOWRITE_V3_GROUP",
+        label: "Write Chapter V3",
+        node_keys: ["CHAPTER_WRITE_V3", "CHAPTER_LEDGER_EXTRACT", "MEMORY_ROLLUP_V3"],
+        collapsible: true,
+      },
+      {
+        key: "AUTOWRITE_LEGACY_GROUP",
+        label: "Legacy Narrative",
         node_keys: ["NARRATIVE_START", "NARRATIVE_STYLIST", "NARRATIVE_CRITIC", "NARRATIVE_REFINE", "NARRATIVE_FINALIZE"],
         collapsible: true,
       },
@@ -116,6 +134,7 @@ export function getFlowRegistry(flowType: FlowType): FlowRegistry {
 }
 
 export function pickFlowType(taskTypes: string[], hasReprocessHint: boolean): FlowType {
+  if (taskTypes.some((x) => x === "CHAPTER_WRITE_V3" || x === "CHAPTER_LEDGER_EXTRACT" || x === "MEMORY_ROLLUP_V3")) return "AUTOWRITE";
   if (taskTypes.some((x) => x.startsWith("NARRATIVE_"))) return "AUTOWRITE";
   if (taskTypes.includes("SPLIT_PROFILE_CORRECTION") || hasReprocessHint) return "REPROCESS_SPLIT";
   return "INGEST_SPLIT";
@@ -149,6 +168,12 @@ export function maxRetryAttempts(): number {
 
 export function nodeTimeoutSeconds(nodeKey: string): number {
   switch (nodeKey) {
+    case "CHAPTER_WRITE_V3":
+      return parsePositiveInt(process.env.LLM_TIMEOUT_CHAPTER_WRITE_V3_SECONDS, 300);
+    case "CHAPTER_LEDGER_EXTRACT":
+      return parsePositiveInt(process.env.LLM_TIMEOUT_CHAPTER_LEDGER_EXTRACT_SECONDS, 90);
+    case "MEMORY_ROLLUP_V3":
+      return parsePositiveInt(process.env.LLM_TIMEOUT_MEMORY_ROLLUP_V3_SECONDS, 90);
     case "NARRATIVE_START":
       return parsePositiveInt(process.env.LLM_TIMEOUT_NARRATIVE_START, 60);
     case "NARRATIVE_STYLIST":

--- a/apps/studio/src/features/scenes/server/scenesApiService.ts
+++ b/apps/studio/src/features/scenes/server/scenesApiService.ts
@@ -11,7 +11,6 @@ import { runIntake } from "@/features/scenes/server/workflow/steps/intake";
 import { runLock } from "@/features/scenes/server/workflow/steps/lock";
 import { runUnlock } from "@/features/scenes/server/workflow/steps/unlock";
 import { runChapterPlanning } from "@/features/scenes/server/workflow/steps/chapterPlanning";
-import { runChapterWriting } from "@/features/scenes/server/workflow/steps/chapterWriting";
 import { getScenesApiErrorMessage, getScenesApiStatusFromMessage } from "@/features/scenes/server/scenesApi/errorMapper";
 import {
   buildDraftPayload,
@@ -22,7 +21,7 @@ import {
   buildRewritePayload,
 } from "@/features/scenes/server/scenesApi/payloadBuilders";
 import { parseVirtualScenesFromText, VirtualScene } from "@/features/autowrite/server/virtualSceneProvider";
-import { invalidateDownstream } from "@/features/autowrite/server/writingPipelineService";
+import { enqueueChapterWriteV3, invalidateDownstream } from "@/features/autowrite/server/writingPipelineService";
 
 function isWritingV2ProductionEnabled(): boolean {
   const raw = (process.env.WRITING_V2_PRODUCTION ?? "1").trim().toLowerCase();
@@ -44,6 +43,45 @@ function buildChapterOutputContractV1(targetWords: number) {
 
 function parseWritingIntentMode(raw: unknown): "CONTINUE_CANON" | "RETCON_REWRITE" {
   return String(raw || "").trim().toUpperCase() === "RETCON_REWRITE" ? "RETCON_REWRITE" : "CONTINUE_CANON";
+}
+
+function chapterGoalFromPlan(plan: Record<string, unknown>, fallback: string): string {
+  const summary = typeof plan.summary === "string" ? plan.summary.trim() : "";
+  const title = typeof plan.title === "string" ? plan.title.trim() : "";
+  const text = fallback.trim() || summary || title;
+  return text || "Write the next chapter from the approved plan.";
+}
+
+function targetWordCountFromPlan(plan: Record<string, unknown>, fallback: number): number {
+  const contract = plan.chapter_output_contract_v1;
+  if (!contract || typeof contract !== "object" || Array.isArray(contract)) return fallback;
+  const wordRange = (contract as Record<string, unknown>).word_range;
+  if (!wordRange || typeof wordRange !== "object" || Array.isArray(wordRange)) return fallback;
+  const target = Number((wordRange as Record<string, unknown>).target);
+  return Number.isFinite(target) && target > 0 ? Math.floor(target) : fallback;
+}
+
+async function enqueueCanonicalChapterWriteV3(args: {
+  storyId: number;
+  chapterId: string;
+  plan: Record<string, unknown>;
+  userPrompt: string;
+  targetWordCount: number;
+}) {
+  const result = await enqueueChapterWriteV3({
+    storyId: args.storyId,
+    chapterId: args.chapterId,
+    instructions: chapterGoalFromPlan(args.plan, args.userPrompt),
+    targetWordCount: args.targetWordCount,
+    plan: args.plan,
+  });
+  return {
+    ok: true,
+    job_id: result.jobId,
+    chapter_id: result.chapterId,
+    status: "RUNNING",
+    task_type: "CHAPTER_WRITE_V3",
+  };
 }
 
 type QualityGateReportV1 = {
@@ -617,10 +655,12 @@ export async function postChapterAutoWriteResponse(req: NextRequest, storySlug: 
         final_review_ready: false,
       });
     }
-    const writingResult = await runChapterWriting(pool, {
+    const writingResult = await enqueueCanonicalChapterWriteV3({
       storyId,
       chapterId,
       plan: planResult.plan,
+      userPrompt,
+      targetWordCount,
     });
     console.info(
       "[writing.auto_write.accepted]",
@@ -628,6 +668,7 @@ export async function postChapterAutoWriteResponse(req: NextRequest, storySlug: 
         story_id: storyId,
         chapter_id: chapterId,
         job_id: writingResult.job_id ?? null,
+        task_type: writingResult.task_type,
         latency_ms: Date.now() - startedAt,
       })
     );
@@ -635,7 +676,8 @@ export async function postChapterAutoWriteResponse(req: NextRequest, storySlug: 
       ok: true,
       chapter_id: chapterId,
       job_id: writingResult.job_id ?? null,
-      status: "RUNNING",
+      status: writingResult.status,
+      task_type: writingResult.task_type,
       plan: planResult.plan,
       chapter_output_contract_v1:
         (planResult.plan && typeof planResult.plan === "object" && !Array.isArray(planResult.plan) && (planResult.plan as Record<string, unknown>).chapter_output_contract_v1)
@@ -679,10 +721,12 @@ export async function postChapterExecuteResponse(req: NextRequest, storySlug: st
     }
 
     const storyId = await resolveStoryIdForWrite(pool, storySlug);
-    const result = await runChapterWriting(pool, {
+    const result = await enqueueCanonicalChapterWriteV3({
       storyId,
       chapterId,
       plan,
+      userPrompt: "",
+      targetWordCount: targetWordCountFromPlan(plan, 1500),
     });
     console.info(
       "[writing.execute.accepted]",
@@ -690,7 +734,7 @@ export async function postChapterExecuteResponse(req: NextRequest, storySlug: st
         story_id: storyId,
         chapter_id: chapterId,
         job_id: result.job_id ?? null,
-        task_type: "NARRATIVE_START",
+        task_type: result.task_type,
         latency_ms: Date.now() - startedAt,
         llm_tokens: null,
       })
@@ -702,7 +746,7 @@ export async function postChapterExecuteResponse(req: NextRequest, storySlug: st
       "[writing.execute.failed]",
       JSON.stringify({
         chapter_id: chapterId,
-        task_type: "NARRATIVE_START",
+        task_type: "CHAPTER_WRITE_V3",
         latency_ms: Date.now() - startedAt,
         error: msg,
       })
@@ -733,7 +777,7 @@ export async function postChapterExecuteControlResponse(req: NextRequest, storyS
        FROM public.ingest_job
        WHERE id = $1
          AND story_id = $2
-         AND mode = 'AUTO_CHAPTER'
+         AND mode IN ('AUTO_CHAPTER', 'AUTO_CHAPTER_V3')
          AND COALESCE(config_json->>'chapter_id', '') = $3
        LIMIT 1`,
       [jobId, storyId, chapterId]
@@ -817,7 +861,9 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
       }>(
         `SELECT id, status, total_tasks, completed_tasks
          FROM public.ingest_job
-         WHERE id = $1 AND story_id = $2 AND mode = 'AUTO_CHAPTER'
+         WHERE id = $1
+           AND story_id = $2
+           AND mode IN ('AUTO_CHAPTER', 'AUTO_CHAPTER_V3')
          LIMIT 1`,
         [requestedJobId, storyId]
       )
@@ -830,7 +876,7 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         `SELECT id, status, total_tasks, completed_tasks
          FROM public.ingest_job
          WHERE story_id = $1
-           AND mode = 'AUTO_CHAPTER'
+           AND mode IN ('AUTO_CHAPTER', 'AUTO_CHAPTER_V3')
            AND COALESCE(config_json->>'chapter_id', '') = $2
          ORDER BY id DESC
          LIMIT 1`,
@@ -881,7 +927,16 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
       `SELECT id, seq_no, task_type, status, payload_json, result_json, error, updated_at::text AS updated_at
        FROM public.ingest_task
        WHERE job_id = $1
-         AND task_type IN ('NARRATIVE_START','NARRATIVE_STYLIST','NARRATIVE_CRITIC','NARRATIVE_REFINE','NARRATIVE_FINALIZE')
+         AND task_type IN (
+           'CHAPTER_WRITE_V3',
+           'CHAPTER_LEDGER_EXTRACT',
+           'MEMORY_ROLLUP_V3',
+           'NARRATIVE_START',
+           'NARRATIVE_STYLIST',
+           'NARRATIVE_CRITIC',
+           'NARRATIVE_REFINE',
+           'NARRATIVE_FINALIZE'
+         )
        ORDER BY seq_no ASC NULLS LAST, id ASC`,
       [job.id]
     ).catch(() => ({
@@ -911,12 +966,35 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
       [storyId, chapterId]
     );
     const staging = stagingRes.rows[0];
+    const draftRes = await pool.query<{
+      full_text: string | null;
+      status: string | null;
+      metadata_json: unknown;
+    }>(
+      `SELECT full_text, status, metadata_json
+       FROM public.chapter_draft
+       WHERE story_id = $1 AND chapter_id = $2
+       ORDER BY version_no DESC
+       LIMIT 1`,
+      [storyId, chapterId]
+    ).catch(() => ({
+      rowCount: 0,
+      rows: [] as Array<{
+        full_text: string | null;
+        status: string | null;
+        metadata_json: unknown;
+      }>,
+    }));
+    const draft = draftRes.rows[0] ?? null;
     const jobStatus = String(job.status || "").toUpperCase();
-    const prose = (staging?.llm_prose || "").trim();
+    const draftProse = (draft?.full_text || "").trim();
+    const stagingProse = (staging?.llm_prose || "").trim();
+    const prose = draftProse || stagingProse;
+    const proseSource = draftProse ? "chapter_draft.full_text" : stagingProse ? "narrative_chapter_staging.llm_prose" : null;
     const proseReady = jobStatus === "DONE" && prose.length > 0;
     const wordCount = proseReady ? prose.split(/\s+/).filter(Boolean).length : 0;
 
-    const planJson = staging?.plan_json && typeof staging.plan_json === "object" && !Array.isArray(staging.plan_json)
+    const stagingPlanJson = staging?.plan_json && typeof staging.plan_json === "object" && !Array.isArray(staging.plan_json)
       ? (staging.plan_json as Record<string, unknown>)
       : null;
     const jobConfigRes = await pool.query<{ config_json: unknown }>(
@@ -929,6 +1007,12 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
     const jobConfig = jobConfigRes.rows[0]?.config_json && typeof jobConfigRes.rows[0].config_json === "object" && !Array.isArray(jobConfigRes.rows[0].config_json)
       ? (jobConfigRes.rows[0].config_json as Record<string, unknown>)
       : {};
+    const jobPlanRaw = jobConfig?.plan;
+    const jobPlan =
+      jobPlanRaw && typeof jobPlanRaw === "object" && !Array.isArray(jobPlanRaw)
+        ? (jobPlanRaw as Record<string, unknown>)
+        : null;
+    const planJson = stagingPlanJson || jobPlan;
     const chapterOutputContractV1 =
       (planJson?.chapter_output_contract_v1 && typeof planJson.chapter_output_contract_v1 === "object" && !Array.isArray(planJson.chapter_output_contract_v1))
         ? (planJson.chapter_output_contract_v1 as Record<string, unknown>)
@@ -1057,11 +1141,6 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
     const resolutionStatus = typeof planJson?.resolution_status === "string" ? String(planJson.resolution_status) : null;
     const entityAssignments = Array.isArray(planJson?.entity_assignments) ? planJson?.entity_assignments : [];
 
-    const jobPlanRaw = jobConfig?.plan;
-    const jobPlan =
-      jobPlanRaw && typeof jobPlanRaw === "object" && !Array.isArray(jobPlanRaw)
-        ? (jobPlanRaw as Record<string, unknown>)
-        : null;
     const planningInputPackJson = {
       source: "PERSISTED_PLAN_AND_JOB_CONFIG",
       job_id: job.id,
@@ -1077,7 +1156,7 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         memoryRuntimeV5.evidence_refs && typeof memoryRuntimeV5.evidence_refs === "object"
           ? memoryRuntimeV5.evidence_refs
           : null,
-      plan_source: planJson ? "narrative_chapter_staging.plan_json" : jobPlan ? "ingest_job.config_json.plan" : "none",
+      plan_source: stagingPlanJson ? "narrative_chapter_staging.plan_json" : jobPlan ? "ingest_job.config_json.plan" : "none",
     } as Record<string, unknown>;
 
     const planningOutputJson =
@@ -1105,7 +1184,7 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         updated_at: row.updated_at,
       };
     });
-    const proseTaskTypes = new Set(["NARRATIVE_STYLIST", "NARRATIVE_CRITIC", "NARRATIVE_REFINE", "NARRATIVE_FINALIZE"]);
+    const proseTaskTypes = new Set(["CHAPTER_WRITE_V3", "NARRATIVE_STYLIST", "NARRATIVE_CRITIC", "NARRATIVE_REFINE", "NARRATIVE_FINALIZE"]);
     const reversedNarrativeTasks = [...narrativeTasks].reverse();
     const latestProseInputTask = reversedNarrativeTasks.find(
       (taskRow) => proseTaskTypes.has(String(taskRow.task_type || "").toUpperCase()) && !!taskRow.payload_json
@@ -1141,6 +1220,15 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         llm_prose: staging?.llm_prose ?? null,
         user_prose: staging?.user_prose ?? null,
       },
+      chapter_draft_output: {
+        draft_status: draft?.status ?? null,
+        prose_source: proseSource,
+        full_text: draft?.full_text ?? null,
+        metadata_json:
+          draft?.metadata_json && typeof draft.metadata_json === "object" && !Array.isArray(draft.metadata_json)
+            ? (draft.metadata_json as Record<string, unknown>)
+            : null,
+      },
     };
 
     return NextResponse.json({
@@ -1157,6 +1245,7 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         error: progress.latest_task_error,
       },
       staging_ready: proseReady,
+      prose_source: proseSource,
       prose: proseReady ? prose : "",
       word_count: wordCount,
       integrity_report: integrityReport,
@@ -1275,6 +1364,26 @@ export async function postChapterAutoWriteRetryResponse(req: NextRequest, storyS
       if (row?.plan_json && typeof row.plan_json === "object" && !Array.isArray(row.plan_json)) {
         plan = row.plan_json as Record<string, unknown>;
       }
+      if (!plan) {
+        const jobPlanRes = await pool.query<{ config_json: unknown }>(
+          `SELECT config_json
+           FROM public.ingest_job
+           WHERE story_id = $1
+             AND mode = 'AUTO_CHAPTER_V3'
+             AND config_json->>'pipeline_type' = 'CHAPTER_WRITE_V3'
+             AND COALESCE(config_json->>'chapter_id', '') = $2
+           ORDER BY id DESC
+           LIMIT 1`,
+          [storyId, chapterId]
+        );
+        const configJson = jobPlanRes.rows[0]?.config_json;
+        const jobConfig = configJson && typeof configJson === "object" && !Array.isArray(configJson)
+          ? (configJson as Record<string, unknown>)
+          : null;
+        if (jobConfig?.plan && typeof jobConfig.plan === "object" && !Array.isArray(jobConfig.plan)) {
+          plan = jobConfig.plan as Record<string, unknown>;
+        }
+      }
     }
     if (!plan) {
       const planResult = await runChapterPlanning(pool, {
@@ -1315,10 +1424,12 @@ export async function postChapterAutoWriteRetryResponse(req: NextRequest, storyS
       });
     }
 
-    const writingResult = await runChapterWriting(pool, {
+    const writingResult = await enqueueCanonicalChapterWriteV3({
       storyId,
       chapterId,
       plan,
+      userPrompt,
+      targetWordCount,
     });
 
     return NextResponse.json({
@@ -1326,7 +1437,8 @@ export async function postChapterAutoWriteRetryResponse(req: NextRequest, storyS
       mode: forceReplan ? "replan" : "refine",
       chapter_id: chapterId,
       job_id: writingResult.job_id ?? null,
-      status: "RUNNING",
+      status: writingResult.status,
+      task_type: writingResult.task_type,
       plan,
       chapter_output_contract_v1:
         (plan.chapter_output_contract_v1 && typeof plan.chapter_output_contract_v1 === "object" && !Array.isArray(plan.chapter_output_contract_v1))


### PR DESCRIPTION
## Summary
- Route canonical chapter auto-write, execute, and retry entrypoints through `CHAPTER_WRITE_V3` instead of `runChapterWriting` / `NARRATIVE_START`.
- Preserve existing status/control compatibility for both `AUTO_CHAPTER` and `AUTO_CHAPTER_V3` jobs.
- Surface V3 pipeline nodes in pipeline graph, retry metadata, and worker queue lane metrics.
- Mark the TypeScript `NARRATIVE_*` worker/executor as compatibility-only without deleting legacy code.

Closes #81.
Closes #82.

## Verification
- `npm run typecheck`
- `npx eslint src/features/scenes/server/scenesApiService.ts src/features/autowrite/server/writingPipelineService.ts src/features/ingest/server/pipelineNodeConfig.ts src/features/ingest/server/ingestWorkerService.ts src/features/autowrite/server/narrativeWorkerService.ts src/features/autowrite/server/narrativeTaskExecutor.ts` passes with existing warnings only, zero errors
- `npm run build`
- `git diff --check`

## Notes
- No DB schema, prompt template, or Python worker changes.
- Legacy `runChapterWriting` and `NARRATIVE_*` executor remain available for existing jobs only.
