### PR TITLE
Prefer chapter_draft in write readers

### DIFF
--- a/apps/studio/src/features/scenes/components/writeTab/ChapterReader.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ChapterReader.tsx
@@ -15,8 +15,12 @@ type ChapterReaderProps = {
     stagingData: { user_prose: string; llm_prose: string; status: string } | null;
     onSave: (prose: string) => Promise<void>;
     onResplit: (prose: string) => Promise<void>;
-    v3Draft?: { full_text: string; status: string; virtual_scenes: any[] } | null;
+    v3Draft?: { full_text: string; status: string; virtual_scenes: unknown[] } | null;
 };
+
+function firstReadableProse(values: Array<string | null | undefined>): string {
+    return values.map((value) => String(value || "").trim()).find(Boolean) || "";
+}
 
 export default function ChapterReader({ chapterId, items, pendingProse, stagingData, onSave, onResplit, v3Draft }: ChapterReaderProps) {
     const [viewingDraft, setViewingDraft] = useState((stagingData || v3Draft) && items.length === 0);
@@ -27,13 +31,19 @@ export default function ChapterReader({ chapterId, items, pendingProse, stagingD
     const isThisPending = pendingProse?.id === chapterId;
     const effectivePendingProse = isThisPending ? pendingProse?.prose : null;
 
-    // Unified prose logic: Priority: Pending > V3 Draft > Staging > Scenes Joined
-    const displayProse = (
-        effectivePendingProse ||
-        (viewingDraft && v3Draft ? v3Draft.full_text : null) ||
-        (viewingDraft && stagingData ? (stagingData.user_prose || stagingData.llm_prose) : null) ||
-        (items.length > 0 ? items.map(s => s.text_content).join("\n\n") : (v3Draft?.full_text || stagingData?.user_prose || stagingData?.llm_prose))
-    ) || "";
+    // Bridge order: pending > author staging edit > V3 draft > legacy generated staging > scenes.
+    const sceneProse = items.length > 0 ? items.map(s => s.text_content).filter(Boolean).join("\n\n") : "";
+    const draftProse = firstReadableProse([
+        stagingData?.user_prose,
+        v3Draft?.full_text,
+        stagingData?.llm_prose,
+    ]);
+    const displayProse = firstReadableProse([
+        effectivePendingProse,
+        viewingDraft ? draftProse : null,
+        sceneProse,
+        draftProse,
+    ]);
 
     const startEditing = () => {
         setLocalProse(displayProse);
@@ -144,9 +154,9 @@ export default function ChapterReader({ chapterId, items, pendingProse, stagingD
                         onChange={(e) => setLocalProse(e.target.value)}
                         placeholder="Write your chapter content here..."
                     />
-                ) : effectivePendingProse || (stagingData && stagingData.user_prose) || (v3Draft && viewingDraft) ? (
+                ) : effectivePendingProse || (viewingDraft && draftProse) || (!items.length && draftProse) ? (
                     <div className="text-slate-200 whitespace-pre-wrap text-[17px] leading-relaxed tracking-wide font-serif border-l-2 border-[#9de5dc]/20 pl-6 py-2">
-                        {effectivePendingProse || (viewingDraft && v3Draft ? v3Draft.full_text : stagingData?.user_prose)}
+                        {displayProse}
                     </div>
                 ) : items.length > 0 ? (
                     showScenes ? (

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -56,6 +56,7 @@ function buildDraftSource(props: NovelLabWorkspaceProps): DraftSource {
   }
   if (props.stagingData?.user_prose) return { key: `staging-user-${props.selectedChapterId}`, text: props.stagingData.user_prose };
   if (props.v3Draft?.full_text) return { key: `v3-${props.selectedChapterId}`, text: props.v3Draft.full_text };
+  if (props.stagingData?.llm_prose) return { key: `staging-llm-${props.selectedChapterId}`, text: props.stagingData.llm_prose };
 
   const sceneText = props.chapterScenes.map((item) => item.text_content).filter(Boolean).join("\n\n");
   if (sceneText) return { key: `scenes-${props.selectedChapterId}-${props.chapterScenes.length}`, text: sceneText };

--- a/apps/studio/src/features/scenes/server/scenesApiService.ts
+++ b/apps/studio/src/features/scenes/server/scenesApiService.ts
@@ -441,9 +441,8 @@ export async function getFullChapterResponse(storySlug: string, chapterId: strin
   const staging = stagingRes.rows[0] || null;
 
   // --- V3 BRIDGE START ---
-  // If no V2 scenes, check for V3 ChapterDraft
   let v3Draft = null;
-  if (rows.length === 0 && (process.env.V3_BRIDGE_ENABLED !== "0")) {
+  if (process.env.V3_BRIDGE_ENABLED !== "0") {
     const draftRes = await pool.query<{ full_text: string; status: string }>(
       `SELECT full_text, status FROM public.chapter_draft
        WHERE story_id = $1 AND chapter_id = $2
@@ -458,20 +457,21 @@ export async function getFullChapterResponse(storySlug: string, chapterId: strin
         virtual_scenes: virtualScenes
       };
 
-      // Map virtual scenes to items for legacy UI compatibility
-      const items = virtualScenes.map(v => ({
-        id: -1,
-        idx: v.idx,
-        title: v.title,
-        status: v.status,
-        text_content: v.text_content
-      }));
+      if (rows.length === 0) {
+        const items = virtualScenes.map(v => ({
+          id: -1,
+          idx: v.idx,
+          title: v.title,
+          status: v.status,
+          text_content: v.text_content
+        }));
 
-      return NextResponse.json({
-        items,
-        staging,
-        v3_draft: v3Draft
-      });
+        return NextResponse.json({
+          items,
+          staging,
+          v3_draft: v3Draft
+        });
+      }
     }
   }
   // --- V3 BRIDGE END ---
@@ -481,13 +481,15 @@ export async function getFullChapterResponse(storySlug: string, chapterId: strin
   if (staging) {
     return NextResponse.json({
       items: rows, // Allow scenes even if staging exists
-      staging
+      staging,
+      v3_draft: v3Draft
     });
   }
 
   return NextResponse.json({
     items: rows,
-    staging: null
+    staging: null,
+    v3_draft: v3Draft
   });
 }
 

--- a/apps/studio/src/features/story/server/storyApiService.ts
+++ b/apps/studio/src/features/story/server/storyApiService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { NextRequest, NextResponse } from "next/server";
 import { pool } from "@/server/db/pool";
 import { createStory, listStories, type StoryStatus } from "@/features/scenes/server/workflow/repoStory";
@@ -149,6 +150,15 @@ export async function getStoryChaptersResponse(slug: string): Promise<NextRespon
            st.updated_at::text AS updated_at
          FROM public.narrative_chapter_staging st
          WHERE st.story_id = $1
+         UNION
+         SELECT
+           cd.story_id,
+           cd.chapter_id::text AS chapter_id,
+           0::int AS scene_count,
+           0::int AS first_scene_idx,
+           cd.updated_at::text AS updated_at
+         FROM public.chapter_draft cd
+         WHERE cd.story_id = $1
          UNION
          SELECT
            sc.story_id,
@@ -402,6 +412,11 @@ export async function getStoryChapterReadResponse(slug: string, chapterId: strin
        WHERE st.story_id = $1
        GROUP BY st.chapter_id
        UNION
+       SELECT cd.chapter_id::text AS chapter_id
+       FROM public.chapter_draft cd
+       WHERE cd.story_id = $1
+       GROUP BY cd.chapter_id
+       UNION
        SELECT sc.chapter_id::text AS chapter_id
        FROM public.story_chapter sc
        WHERE sc.story_id = $1
@@ -457,6 +472,36 @@ export async function getStoryChapterReadResponse(slug: string, chapterId: strin
   }));
 
   if (scenes.length === 0) {
+    const draftRes = await pool.query<{ full_text: string | null }>(
+      `SELECT full_text
+       FROM public.chapter_draft
+       WHERE story_id = $1
+         AND chapter_id::text = $2
+       ORDER BY version_no DESC
+       LIMIT 1`,
+      [story.id, chapterId]
+    );
+    const chapterDraftProse = (draftRes.rows[0]?.full_text || "").trim();
+    if (chapterDraftProse) {
+      return NextResponse.json({
+        ok: true,
+        story: { slug, title: story.title },
+        chapter_id: chapterId,
+        prev_chapter_id,
+        next_chapter_id,
+        all_chapters,
+        scenes: [
+          {
+            id: 0,
+            idx: 1,
+            title: "Draft",
+            text_content: chapterDraftProse,
+          },
+        ],
+        source: "chapter_draft",
+      });
+    }
+
     const stagingRes = await pool.query<{ user_prose: string | null; llm_prose: string | null }>(
       `SELECT user_prose, llm_prose
        FROM public.narrative_chapter_staging


### PR DESCRIPTION
## Summary
- Document bridge read order on #84 before implementation.
- Prefer explicit author staging edits, then canonical `chapter_draft.full_text`, then legacy generated staging, then scene-version text in the Write workspace reader surfaces.
- Return `v3_draft` from the full chapter API even when split scene rows exist, so the UI can still expose the V3 draft view.
- Include `chapter_draft` chapters and fallback prose in reader APIs while preserving staging and source-doc compatibility.

Closes #84.

## Read order
1. Pending in-memory chapter prose for the active Write session.
2. `narrative_chapter_staging.user_prose` author edit.
3. Latest `chapter_draft.full_text` V3 generated prose.
4. `narrative_chapter_staging.llm_prose` legacy generated prose.
5. `narrative_scene` + `narrative_scene_version` scene text.
6. Reader-only stable `source_doc.raw_text` fallback.

## Verification
- `npm run typecheck`
- `npx eslint src/features/scenes/components/writeTab/NovelLabWorkspace.tsx src/features/scenes/components/writeTab/ChapterReader.tsx src/features/scenes/server/scenesApiService.ts src/features/story/server/storyApiService.ts` passes with existing warnings only, zero errors
- `npm run build`
- `git diff --check`

## Notes
- No DB schema changes.
- No generation runtime changes.
- No publish-flow behavior changes.
