### PR TITLE
Hydrate CHAPTER_WRITE_V3 prompts with memory

### DIFF
--- a/services/memory-bridge/worker_chapter_writer.py
+++ b/services/memory-bridge/worker_chapter_writer.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 import json
 import os
+import time
 from typing import Any, Dict, Optional
 from worker_common import call_llm_json
+from worker_ingest_repo import (
+    insert_agent_context_snapshot,
+    insert_agent_prompt_hydration_trace,
+    insert_agent_run_trace,
+)
+from worker_narrative_handlers import (
+    _estimate_tokens,
+    assemble_prompt_layers,
+    build_memory_prompt_block,
+    retrieve_semantic_memories,
+)
 
 VALID_PREFLIGHT_STATUSES = {"proceed", "degraded", "blocked"}
 REQUIRED_CONTEXT_SECTIONS = {
@@ -67,6 +79,33 @@ def _compact_fact_list(items: Any, *, limit: int = 8) -> list[str]:
         elif item:
             out.append(str(item).strip())
     return [line for line in out if line]
+
+def _memory_query_text(
+    chapter_goal: str,
+    working_set: Dict[str, Any],
+    writing_context: Optional[Dict[str, Any]],
+) -> str:
+    if isinstance(writing_context, dict):
+        intent = writing_context.get("intent") or {}
+        immediate = writing_context.get("immediate_continuity") or {}
+        current = writing_context.get("current_state") or {}
+        parts = [
+            chapter_goal,
+            json.dumps(intent, ensure_ascii=False, sort_keys=True),
+            json.dumps(immediate, ensure_ascii=False, sort_keys=True),
+            json.dumps(current, ensure_ascii=False, sort_keys=True),
+        ]
+        return "\n".join(str(part or "") for part in parts).strip()
+
+    anchor = working_set.get("anchor", {}) if isinstance(working_set, dict) else {}
+    active = working_set.get("active_state", {}) if isinstance(working_set, dict) else {}
+    meso = working_set.get("meso_context", {}) if isinstance(working_set, dict) else {}
+    return "\n".join([
+        str(chapter_goal or ""),
+        json.dumps(anchor, ensure_ascii=False, sort_keys=True),
+        json.dumps(active, ensure_ascii=False, sort_keys=True),
+        json.dumps(meso, ensure_ascii=False, sort_keys=True),
+    ]).strip()
 
 def _render_writing_context_block(
     writing_context: Optional[Dict[str, Any]],
@@ -141,6 +180,7 @@ def generate_chapter_v3(
     writing_context: Optional[Dict[str, Any]] = None,
     writing_context_preflight: Optional[Dict[str, Any]] = None,
     writing_context_debug: Optional[Dict[str, Any]] = None,
+    task: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Core Chapter Writer V3 logic.
@@ -157,12 +197,29 @@ def generate_chapter_v3(
     writing_context_block = _render_writing_context_block(writing_context, writing_context_preflight)
     working_set_block = _render_working_set_compatibility_block(working_set, context_mode)
     fallback_metadata = _fallback_metadata(context_mode)
+    memory_query = _memory_query_text(chapter_goal, working_set, writing_context)
+    hydration_error = None
+    try:
+        semantic = retrieve_semantic_memories(
+            conn,
+            story_id=story_id,
+            chapter_id=chapter_id,
+            agent_name="CHAPTER_WRITE_V3",
+            query_text=memory_query,
+        )
+    except Exception as err:
+        semantic = {"items": []}
+        hydration_error = f"SEMANTIC_MEMORY_UNAVAILABLE:{str(err)[:160]}"
+    memory_items = semantic.get("items") or []
+    memory_block = build_memory_prompt_block(memory_items)
 
-    prompt = f"""You are a master novelist writing a long-form fiction chapter.
+    default_prompt = f"""You are a master novelist writing a long-form fiction chapter.
 
 {writing_context_block}
 
 {working_set_block}
+
+{memory_block}
 
 CHAPTER OBJECTIVE:
 {chapter_goal}
@@ -178,6 +235,52 @@ Return JSON:
   "notes": "Internal thoughts on continuity"
 }}
 """
+    template_vars = {
+        "chapter_goal": chapter_goal,
+        "writing_context_block": writing_context_block,
+        "working_set_block": working_set_block,
+        "memory_block": memory_block,
+    }
+    try:
+        assembled = assemble_prompt_layers(
+            conn,
+            story_id=story_id,
+            chapter_id=chapter_id,
+            agent_name="CHAPTER_WRITE_V3",
+            task_id=int((task or {}).get("id") or 0),
+            default_prompt=default_prompt,
+            template_vars=template_vars,
+            style_block=memory_block,
+        )
+    except Exception as err:
+        assembled = {
+            "prompt": default_prompt,
+            "prompt_version_id": None,
+            "assignment": None,
+            "experiment_id": None,
+            "agent_profile_id": None,
+            "equipment_snapshot": {"layers": {"fallback": True}},
+        }
+        hydration_error = hydration_error or f"PROMPT_HYDRATION_UNAVAILABLE:{str(err)[:160]}"
+    prompt = assembled["prompt"]
+    context_snapshot_id = None
+    if task:
+        context_snapshot_id = insert_agent_context_snapshot(
+            conn,
+            story_id=story_id,
+            chapter_id=chapter_id,
+            snapshot_payload={
+                "chapter_goal": chapter_goal,
+                "writing_context_preflight": writing_context_preflight,
+                "writing_context_debug": writing_context_debug,
+                "working_set_keys": sorted(list(working_set.keys())) if isinstance(working_set, dict) else [],
+                "memory_ids": [m.get("id") for m in memory_items],
+                "hydration_error": hydration_error,
+                "prompt_version_id": assembled.get("prompt_version_id"),
+                "agent_profile_id": assembled.get("agent_profile_id"),
+                "equipment_snapshot": assembled.get("equipment_snapshot") or {},
+            },
+        )
 
     messages = [
         {"role": "system", "content": "You are a professional novelist specializing in high-consistency long-form fiction."},
@@ -185,12 +288,14 @@ Return JSON:
     ]
 
     # Chapter writing takes a lot of tokens
+    started = time.time()
     response = call_llm_json(
         messages,
         max_tokens=4000,
         temperature=0.75,
         timeout_sec=300 # 5 minutes for full chapter
     )
+    latency_ms = int((time.time() - started) * 1000)
 
     if not isinstance(response, dict):
         response = {"prose": str(response), "error": "NON_JSON_LLM_RESPONSE"}
@@ -205,6 +310,78 @@ Return JSON:
             writing_context_debug.get("assembler_version")
             if isinstance(writing_context_debug, dict)
             else None
+        )
+        response["metadata"]["prompt_version_id"] = assembled.get("prompt_version_id")
+        response["metadata"]["agent_profile_id"] = assembled.get("agent_profile_id")
+        response["metadata"]["memory_ids"] = [m.get("id") for m in memory_items]
+        response["metadata"]["memory_hits"] = len(memory_items)
+        response["metadata"]["prompt_assignment"] = assembled.get("assignment")
+        response["metadata"]["experiment_id"] = assembled.get("experiment_id")
+        response["metadata"]["hydration_error"] = hydration_error
+
+    if task:
+        run_trace_id = insert_agent_run_trace(
+            conn,
+            task=task,
+            agent_name="CHAPTER_WRITE_V3",
+            status="DONE",
+            input_payload={
+                "chapter_goal": chapter_goal,
+                "memory_ids": [m.get("id") for m in memory_items],
+                "writing_context_mode": context_mode,
+                "hydration_error": hydration_error,
+            },
+            output_payload={
+                "prose_chars": len(str(response.get("prose") or "")),
+                "scene_markers": response.get("scene_markers") if isinstance(response.get("scene_markers"), list) else [],
+                "metadata": response.get("metadata") if isinstance(response.get("metadata"), dict) else {},
+            },
+            model_name="llm_json",
+            prompt_version_id=assembled.get("prompt_version_id"),
+            agent_profile_id=assembled.get("agent_profile_id"),
+            equipment_snapshot_json=assembled.get("equipment_snapshot") or {},
+            context_snapshot_id=context_snapshot_id,
+            latency_ms=latency_ms,
+            quality_json={
+                "memory_hits": len(memory_items),
+                "memory_ids": [m.get("id") for m in memory_items],
+                "writing_context_mode": context_mode,
+                "prompt_assignment": assembled.get("assignment"),
+                "experiment_id": assembled.get("experiment_id"),
+                "hydration_error": hydration_error,
+            },
+        )
+        insert_agent_prompt_hydration_trace(
+            conn,
+            run_trace_id=run_trace_id,
+            task=task,
+            agent_name="CHAPTER_WRITE_V3",
+            prompt_version_id=assembled.get("prompt_version_id"),
+            context_snapshot_id=context_snapshot_id,
+            hydration_inputs_json={
+                "context_snapshot_id": context_snapshot_id,
+                "memory_ids": [m.get("id") for m in memory_items],
+                "prompt_assignment": assembled.get("assignment"),
+                "experiment_id": assembled.get("experiment_id"),
+                "hydration_error": hydration_error,
+            },
+            hydration_render_steps_json={
+                "layer_flags": (assembled.get("equipment_snapshot") or {}).get("layers") or {},
+                "template_keys": sorted(list(template_vars.keys())),
+            },
+            hydration_output_text=prompt,
+            llm_request_meta_json={
+                "provider_call": "call_llm_json",
+                "task_family": "chapter_write_v3",
+                "temperature": 0.75,
+                "max_tokens": 4000,
+                "timeout_sec": 300,
+            },
+            tokens_prompt_base=_estimate_tokens(prompt),
+            tokens_memory_injected=_estimate_tokens(memory_block),
+            tokens_rules_injected=0,
+            tokens_feedback_injected=0,
+            tokens_truncated=0,
         )
 
     return response

--- a/services/memory-bridge/worker_task_handlers.py
+++ b/services/memory-bridge/worker_task_handlers.py
@@ -2052,6 +2052,7 @@ def process_chapter_write_v3_task(conn, task: Dict[str, Any]) -> None:
         writing_context,
         writing_context_preflight,
         writing_context_debug,
+        task,
     )
 
     prose = llm_response.get("prose")


### PR DESCRIPTION
## Summary
- Hydrate `CHAPTER_WRITE_V3` prompts through the existing Python agent prompt/profile helper path.
- Retrieve bounded semantic memory for `CHAPTER_WRITE_V3` using the existing narrative memory retrieval behavior.
- Persist prompt/memory/profile metadata into chapter writer result metadata plus agent context/run/hydration traces.
- Keep prompt/profile/memory lookup failures non-blocking through explicit `hydration_error` fallback metadata.

Closes #88.

## Verification
- `python3 -m py_compile services/memory-bridge/worker_chapter_writer.py services/memory-bridge/worker_task_handlers.py services/memory-bridge/worker_narrative_handlers.py`
- Manual monkeypatch proof for `generate_chapter_v3` with memory items, without memory items, and with memory/profile fallback errors.
- `git diff --check`
- Confirmed changed files do not introduce `NARRATIVE_*` dispatch references.

## Notes
- No DB schema changes.
- No Studio UI changes.
- No generation route/dispatch changes.
- Legacy `NARRATIVE_*` handlers are unchanged.
