### PR TITLE
Add guided pipeline next-action rail

### DIFF
--- a/apps/studio/src/features/pipeline/components/NextActionRail.tsx
+++ b/apps/studio/src/features/pipeline/components/NextActionRail.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+import type { ContextReadiness } from "@/features/scenes/components/writeTab/types";
+
+type NextActionRailProps = {
+  storySlug: string;
+  hasChapter: boolean;
+  hasDraft: boolean;
+  continuityQueued: boolean;
+  readiness: ContextReadiness;
+  loading: boolean;
+};
+
+type RailStep = {
+  key: string;
+  label: string;
+  href: string;
+  status: "ready" | "current" | "waiting" | "blocked";
+};
+
+function storyHref(storySlug: string, suffix: string): string {
+  return `/stories/${encodeURIComponent(storySlug)}${suffix}`;
+}
+
+function primaryAction(props: NextActionRailProps): { label: string; detail: string; href: string } {
+  if (props.loading) {
+    return {
+      label: "Wait for workspace state",
+      detail: "Studio is loading chapter and draft state before choosing the next action.",
+      href: storyHref(props.storySlug, "/pipelines"),
+    };
+  }
+  if (!props.hasChapter) {
+    return {
+      label: "Add source material",
+      detail: "Start with ingest so the story has chapters, source text, and pipeline state.",
+      href: storyHref(props.storySlug, "/ingest"),
+    };
+  }
+  if (!props.hasDraft) {
+    return {
+      label: "Draft the chapter",
+      detail: "Use the write workspace once chapter state exists.",
+      href: storyHref(props.storySlug, "/write"),
+    };
+  }
+  if (props.continuityQueued || props.readiness === "blocked") {
+    return {
+      label: "Review validation",
+      detail: "A draft exists and validation needs review before approval.",
+      href: storyHref(props.storySlug, "/reviews"),
+    };
+  }
+  return {
+    label: "Check analysis and memory",
+    detail: "A draft exists. Review analysis and memory state before approval.",
+    href: storyHref(props.storySlug, "/analysis"),
+  };
+}
+
+function readyAfterChapter(props: NextActionRailProps): RailStep["status"] {
+  if (!props.hasChapter) return "waiting";
+  return props.hasDraft ? "ready" : "current";
+}
+
+function reviewStatus(props: NextActionRailProps): RailStep["status"] {
+  if (!props.hasDraft) return "waiting";
+  return props.continuityQueued || props.readiness === "blocked" ? "current" : "ready";
+}
+
+function approvalStatus(props: NextActionRailProps): RailStep["status"] {
+  if (!props.hasDraft) return "blocked";
+  if (props.readiness === "proceed") return "current";
+  return "waiting";
+}
+
+function buildSteps(props: NextActionRailProps): RailStep[] {
+  return [
+    {
+      key: "ingest",
+      label: "Ingest",
+      href: storyHref(props.storySlug, "/ingest"),
+      status: props.hasChapter ? "ready" : "current",
+    },
+    {
+      key: "analysis",
+      label: "Analysis",
+      href: storyHref(props.storySlug, "/analysis"),
+      status: readyAfterChapter(props),
+    },
+    {
+      key: "write",
+      label: "Write",
+      href: storyHref(props.storySlug, "/write"),
+      status: readyAfterChapter(props),
+    },
+    {
+      key: "review",
+      label: "Review",
+      href: storyHref(props.storySlug, "/reviews"),
+      status: reviewStatus(props),
+    },
+    {
+      key: "approval",
+      label: "Approval",
+      href: storyHref(props.storySlug, "/reviews"),
+      status: approvalStatus(props),
+    },
+  ];
+}
+
+function statusLabel(status: RailStep["status"]): string {
+  if (status === "current") return "Next";
+  if (status === "ready") return "Open";
+  if (status === "blocked") return "Blocked";
+  return "Wait";
+}
+
+export default function NextActionRail(props: NextActionRailProps) {
+  const action = primaryAction(props);
+  const steps = buildSteps(props);
+
+  return (
+    <section className="grid gap-3 border border-[var(--border-subtle)] bg-[var(--bg-surface-muted)] p-3 text-xs">
+      <div>
+        <div className="muted font-semibold uppercase tracking-[0.16em]">Next Action</div>
+        <Link href={action.href} className="primary-action mt-2 block px-3 py-2 text-center text-xs no-underline">
+          {action.label}
+        </Link>
+        <p className="mt-2 leading-5 text-[var(--text-secondary)]">{action.detail}</p>
+      </div>
+
+      <div className="grid gap-1" aria-label="Pipeline steps">
+        {steps.map((step) => (
+          <Link
+            key={step.key}
+            href={step.href}
+            className={`novel-lab-nav-row no-underline ${step.status === "current" ? "novel-lab-nav-row--active" : "novel-lab-nav-row--secondary"}`}
+          >
+            <span>{step.label}</span>
+            <span>{statusLabel(step.status)}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import NextActionRail from "@/features/pipeline/components/NextActionRail";
 import { useStory } from "@/features/story/StoryContext";
 import AutoWriteWizard from "@/features/scenes/components/writeTab/AutoWriteWizard";
 import ArtifactSurface from "@/features/scenes/components/writeTab/ArtifactSurface";
@@ -50,17 +51,28 @@ function storyLabelFromSlug(storySlug: string): string {
     .join(" ") || "Current story";
 }
 
-function buildDraftSource(props: NovelLabWorkspaceProps): DraftSource {
-  if (props.pendingChapterProse?.id === props.selectedChapterId) {
-    return { key: `pending-${props.selectedChapterId}`, text: props.pendingChapterProse.prose };
-  }
+function pendingDraftSource(props: NovelLabWorkspaceProps): DraftSource | null {
+  if (props.pendingChapterProse?.id !== props.selectedChapterId) return null;
+  return { key: `pending-${props.selectedChapterId}`, text: props.pendingChapterProse.prose };
+}
+
+function savedDraftSource(props: NovelLabWorkspaceProps): DraftSource | null {
   if (props.stagingData?.user_prose) return { key: `staging-user-${props.selectedChapterId}`, text: props.stagingData.user_prose };
   if (props.v3Draft?.full_text) return { key: `v3-${props.selectedChapterId}`, text: props.v3Draft.full_text };
   if (props.stagingData?.llm_prose) return { key: `staging-llm-${props.selectedChapterId}`, text: props.stagingData.llm_prose };
+  return null;
+}
 
+function sceneDraftSource(props: NovelLabWorkspaceProps): DraftSource | null {
   const sceneText = props.chapterScenes.map((item) => item.text_content).filter(Boolean).join("\n\n");
   if (sceneText) return { key: `scenes-${props.selectedChapterId}-${props.chapterScenes.length}`, text: sceneText };
   if (props.current?.text_content) return { key: `scene-${props.current.id}`, text: props.current.text_content };
+  return null;
+}
+
+function buildDraftSource(props: NovelLabWorkspaceProps): DraftSource {
+  const draftSource = pendingDraftSource(props) ?? savedDraftSource(props) ?? sceneDraftSource(props);
+  if (draftSource) return draftSource;
 
   return {
     key: `empty-${props.selectedChapterId || "none"}`,
@@ -69,7 +81,12 @@ function buildDraftSource(props: NovelLabWorkspaceProps): DraftSource {
 }
 
 function NavigationPanel(
-  props: Pick<NovelLabWorkspaceProps, "storySlug" | "chapterIds" | "loadingScenes" | "selectedChapterId" | "onChapterIdChange" | "onCreateNewChapter">
+  props: Pick<NovelLabWorkspaceProps, "storySlug" | "chapterIds" | "loadingScenes" | "selectedChapterId" | "onChapterIdChange" | "onCreateNewChapter"> & {
+    hasDraft: boolean;
+    loadingWorkspace: boolean;
+    continuityQueued: boolean;
+    readiness: ContextReadiness;
+  }
 ) {
   const { isArtifactVisible, setIsArtifactVisible } = useStory();
   const visibleChapters = props.chapterIds.length ? props.chapterIds : [props.selectedChapterId].filter(Boolean);
@@ -98,6 +115,15 @@ function NavigationPanel(
           <div className="mt-2 text-xs text-[var(--accent)]">{props.selectedChapterId || "No chapter"}</div>
         </div>
       </div>
+
+      <NextActionRail
+        storySlug={props.storySlug}
+        hasChapter={Boolean(props.selectedChapterId || props.chapterIds.length)}
+        hasDraft={props.hasDraft}
+        continuityQueued={props.continuityQueued}
+        readiness={props.readiness}
+        loading={props.loadingWorkspace}
+      />
 
       <nav className="space-y-1 text-sm" aria-label="Workspace views">
         {workspaceLinks.map((item) => (
@@ -185,6 +211,10 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
           selectedChapterId={props.selectedChapterId}
           onChapterIdChange={props.onChapterIdChange}
           onCreateNewChapter={props.onCreateNewChapter}
+          hasDraft={draftSource.text.trim().length > 0}
+          loadingWorkspace={props.loadingScenes || props.loadingDetail || props.loadingChapter}
+          continuityQueued={continuityQueued}
+          readiness={readiness}
         />
         <CommandWorkStream
           storySlug={props.storySlug}


### PR DESCRIPTION
## Summary
- add a state-aware next-action rail to the Novel Lab navigation
- route the primary recommendation through existing ingest, write, analysis, reviews, and pipelines pages
- derive rail state from existing chapter, draft, continuity, and readiness props without adding backend state

## Verification
- npm run typecheck
- npx eslint src/features/pipeline/components/NextActionRail.tsx src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
- npm run build
- git diff --check
- smoke: HEAD /stories/default/write -> 200 on local dev server
- smoke: HEAD /stories/default/ingest -> 200 on local dev server

Closes #52