### PR TITLE
Bind artifact inspector diagnostics

### DIFF
--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
@@ -16,6 +16,8 @@ export type ArtifactInspectorDiagnostics = {
   hasChapter: boolean;
   hasDraft: boolean;
   draftWordCount: number;
+  currentVersionNo: number | null;
+  currentVersionKind: string | null;
   gateLabel: string;
   gateDetail: string;
   canApprove: boolean;
@@ -149,9 +151,11 @@ function IssuesPreview({
 }
 
 function MemoryPreview({ diagnostics }: { diagnostics: ArtifactInspectorDiagnostics }) {
-  const memoryItems = diagnostics.canApprove
-    ? ["Draft can enter reviewer approval before memory extraction.", "Memory candidates unlock after an approved revision."]
-    : ["Memory extraction is locked until approval is available.", diagnostics.gateDetail];
+  const memoryItems = [
+    "Memory diagnostics unavailable in this inspector.",
+    "Use the story Memory workspace for retrieval, conflicts, and extraction review.",
+    diagnostics.gateDetail,
+  ];
   return (
     <div className="inspector-stack">
       {memoryItems.map((item) => (
@@ -163,6 +167,7 @@ function MemoryPreview({ diagnostics }: { diagnostics: ArtifactInspectorDiagnost
 
 function VersionsPreview({ diagnostics, continuityQueued }: { diagnostics: ArtifactInspectorDiagnostics; continuityQueued: boolean }) {
   const versionItems = [
+    diagnostics.currentVersionNo !== null ? `Current version v${diagnostics.currentVersionNo} · ${diagnostics.currentVersionKind ?? "unknown"}` : "No current scene version",
     diagnostics.hasDraft ? `Current draft · ${diagnostics.draftWordCount} words` : "No draft version",
     continuityQueued ? "Continuity check queued" : "Continuity check not running",
     diagnostics.canApprove ? "Approval candidate ready" : `Approval locked · ${diagnostics.gateLabel}`,

--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
@@ -9,6 +9,8 @@ type ArtifactSurfaceProps = {
   storySlug: string;
   chapterId: string;
   chapterTitle: string;
+  currentVersionNo: number | null;
+  currentVersionKind: string | null;
   draftKey: string;
   draftText: string;
   hasChapter: boolean;
@@ -69,6 +71,8 @@ function buildInspectorDiagnostics(args: {
   activeMode: ArtifactMode;
   chapterId: string;
   chapterTitle: string;
+  currentVersionNo: number | null;
+  currentVersionKind: string | null;
   draftText: string;
   gate: ApprovalGate;
   hasChapter: boolean;
@@ -81,6 +85,8 @@ function buildInspectorDiagnostics(args: {
     hasChapter: args.hasChapter,
     hasDraft: args.hasDraft,
     draftWordCount: wordCount(args.draftText),
+    currentVersionNo: args.currentVersionNo,
+    currentVersionKind: args.currentVersionKind,
     gateLabel: args.gate.label,
     gateDetail: args.gate.detail,
     canApprove: args.gate.canApprove,
@@ -320,6 +326,8 @@ export default function ArtifactSurface(props: ArtifactSurfaceProps) {
     activeMode,
     chapterId: props.chapterId,
     chapterTitle: props.chapterTitle,
+    currentVersionNo: props.currentVersionNo,
+    currentVersionKind: props.currentVersionKind,
     draftText: props.draftText,
     gate,
     hasChapter: props.hasChapter,

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -187,13 +187,46 @@ function NavigationPanel(
   );
 }
 
+function workspaceColumns(isArtifactVisible: boolean): string {
+  return `236px 1fr ${isArtifactVisible ? "minmax(520px, 1.18fr)" : "320px"}`;
+}
+
+function selectedChapterTitle(selectedChapterId: string): string {
+  return selectedChapterId ? `${getChapterTitle(selectedChapterId)} Draft` : "No chapter selected";
+}
+
+function WorkspaceStatusMessages({ error, loadingDetail, loadingChapter }: Pick<NovelLabWorkspaceProps, "error" | "loadingDetail" | "loadingChapter">) {
+  return (
+    <>
+      {error ? <div className="mx-2 mt-2 rounded border border-[var(--danger)]/40 p-3 text-sm text-[var(--danger)]">{error}</div> : null}
+      {loadingDetail || loadingChapter ? <div className="mx-2 mt-2 muted text-xs">Loading current chapter artifact...</div> : null}
+    </>
+  );
+}
+
+function WorkspaceAutoWriteModal(
+  props: Pick<NovelLabWorkspaceProps, "storySlug" | "selectedChapterId" | "showAutoWrite" | "onAutoWriteComplete" | "setShowAutoWrite">
+) {
+  if (!props.showAutoWrite || !props.selectedChapterId) return null;
+  return (
+    <AutoWriteWizard
+      storySlug={props.storySlug}
+      chapterId={props.selectedChapterId}
+      onComplete={props.onAutoWriteComplete}
+      onClose={() => props.setShowAutoWrite(false)}
+    />
+  );
+}
+
 export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
   const { isArtifactVisible } = useStory();
   const [continuityQueued, setContinuityQueued] = useState(false);
   const [composerValue, setComposerValue] = useState(props.selectedChapterId ? `/write chapter ${props.selectedChapterId} ` : "");
   const [commandMenuOpen, setCommandMenuOpen] = useState(false);
   const draftSource = useMemo(() => buildDraftSource(props), [props]);
-  const chapterTitle = props.selectedChapterId ? `${getChapterTitle(props.selectedChapterId)} Draft` : "No chapter selected";
+  const chapterTitle = selectedChapterTitle(props.selectedChapterId);
+  const hasDraft = draftSource.text.trim().length > 0;
+  const loadingWorkspace = props.loadingScenes || props.loadingDetail || props.loadingChapter;
   const readiness: ContextReadiness = "degraded";
 
   return (
@@ -201,7 +234,7 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
       <main
         className="novel-lab-workspace"
         style={{
-          gridTemplateColumns: `236px 1fr ${isArtifactVisible ? "minmax(520px, 1.18fr)" : "320px"}`,
+          gridTemplateColumns: workspaceColumns(isArtifactVisible),
         }}
       >
         <NavigationPanel
@@ -211,15 +244,15 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
           selectedChapterId={props.selectedChapterId}
           onChapterIdChange={props.onChapterIdChange}
           onCreateNewChapter={props.onCreateNewChapter}
-          hasDraft={draftSource.text.trim().length > 0}
-          loadingWorkspace={props.loadingScenes || props.loadingDetail || props.loadingChapter}
+          hasDraft={hasDraft}
+          loadingWorkspace={loadingWorkspace}
           continuityQueued={continuityQueued}
           readiness={readiness}
         />
         <CommandWorkStream
           storySlug={props.storySlug}
           chapterId={props.selectedChapterId}
-          hasDraft={draftSource.text.trim().length > 0}
+          hasDraft={hasDraft}
           continuityQueued={continuityQueued}
           composerValue={composerValue}
           commandMenuOpen={commandMenuOpen}
@@ -232,6 +265,8 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
           storySlug={props.storySlug}
           chapterId={props.selectedChapterId}
           chapterTitle={chapterTitle}
+          currentVersionNo={props.current?.version_no ?? null}
+          currentVersionKind={props.current?.kind ?? null}
           draftKey={draftSource.key}
           draftText={draftSource.text}
           hasChapter={Boolean(props.selectedChapterId)}
@@ -244,16 +279,14 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
         />
       </main>
 
-      {props.error ? <div className="mx-2 mt-2 rounded border border-[var(--danger)]/40 p-3 text-sm text-[var(--danger)]">{props.error}</div> : null}
-      {props.loadingDetail || props.loadingChapter ? <div className="mx-2 mt-2 muted text-xs">Loading current chapter artifact...</div> : null}
-      {props.showAutoWrite && props.selectedChapterId ? (
-        <AutoWriteWizard
-          storySlug={props.storySlug}
-          chapterId={props.selectedChapterId}
-          onComplete={props.onAutoWriteComplete}
-          onClose={() => props.setShowAutoWrite(false)}
-        />
-      ) : null}
+      <WorkspaceStatusMessages error={props.error} loadingDetail={props.loadingDetail} loadingChapter={props.loadingChapter} />
+      <WorkspaceAutoWriteModal
+        storySlug={props.storySlug}
+        selectedChapterId={props.selectedChapterId}
+        showAutoWrite={props.showAutoWrite}
+        onAutoWriteComplete={props.onAutoWriteComplete}
+        setShowAutoWrite={props.setShowAutoWrite}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- pass current scene version number/kind into artifact inspector diagnostics
- show real current version data in the Versions tab when available
- replace memory candidate assumptions with an honest unavailable state pointing to the Memory workspace
- split small NovelLabWorkspace helpers to keep changed-file lint clean without behavior changes

## Verification
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx src/features/scenes/components/writeTab/ArtifactSurface.tsx src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
- npm run build
- git diff --check
- smoke: HEAD /stories/default/write -> 200 on local dev server

Closes #57