### PR TITLE
Add reader preview handoff from artifacts

### DIFF
--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
@@ -253,11 +253,15 @@ function ApproveArtifact({
   gate,
   storySlug,
   chapterId,
+  hasReadableArtifact,
 }: {
   gate: ApprovalGate;
   storySlug: string;
   chapterId: string;
+  hasReadableArtifact: boolean;
 }) {
+  const readerHref = hasReadableArtifact ? `/read/${encodeURIComponent(storySlug)}/${encodeURIComponent(chapterId)}` : null;
+
   return (
     <div className="document-artifact p-4">
       <div className="grid gap-3 text-sm">
@@ -269,6 +273,18 @@ function ApproveArtifact({
         <Link href={`/stories/${encodeURIComponent(storySlug)}/reviews`} className="shell-link w-fit px-3 py-2 text-xs">
           Open reviews
         </Link>
+        {readerHref ? (
+          <Link href={readerHref} className="shell-link w-fit px-3 py-2 text-xs">
+            Reader preview
+          </Link>
+        ) : (
+          <button type="button" className="shell-link w-fit px-3 py-2 text-xs" disabled title="Create a readable chapter draft before opening reader preview.">
+            Reader preview unavailable
+          </button>
+        )}
+        <button type="button" className="locked-action w-fit px-3 py-2 text-xs" disabled title="Publish preparation needs a durable approval and publishing workflow before it can be enabled.">
+          Publish unavailable
+        </button>
         {chapterId ? <span className="muted text-xs">Active chapter: {chapterId}</span> : null}
       </div>
     </div>
@@ -307,6 +323,7 @@ function ArtifactModePanel({
         gate={gate}
         storySlug={storySlug}
         chapterId={chapterId}
+        hasReadableArtifact={draftText.trim().length > 0 && Boolean(chapterId)}
       />
     );
   }

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -92,7 +92,7 @@ function NavigationPanel(
   const visibleChapters = props.chapterIds.length ? props.chapterIds : [props.selectedChapterId].filter(Boolean);
   const storyLabel = storyLabelFromSlug(props.storySlug);
   const storyBase = `/stories/${encodeURIComponent(props.storySlug)}`;
-  const readerHref = props.selectedChapterId ? `/read/${encodeURIComponent(props.storySlug)}/${encodeURIComponent(props.selectedChapterId)}` : null;
+  const readerHref = props.selectedChapterId && props.hasDraft ? `/read/${encodeURIComponent(props.storySlug)}/${encodeURIComponent(props.selectedChapterId)}` : null;
   const workspaceLinks = [
     { label: "Shelf", href: "/shelf" },
     { label: "Write", href: `${storyBase}/write`, active: true },


### PR DESCRIPTION
## Summary
- show Reader preview from the artifact approval handoff only when the active chapter has readable draft text
- route preview to the existing `/read/[slug]/[chapter]` route
- hide the left-nav Reader link until the workspace has a readable draft
- keep publish explicitly unavailable instead of mutating story publish state from the artifact surface

## Verification
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/ArtifactSurface.tsx src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
- npm run build
- git diff --check
- smoke: HEAD /stories/default/write -> 200 on local dev server
- smoke: HEAD /read/default/ch01 -> 200 on local dev server

Closes #58