### PR TITLE
docs: define Studio Chat Orchestration contract

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -335,12 +335,13 @@ Primary references:
 1. `docs/architecture/ui-information-architecture.md` (surface ownership and Write IA)
 2. `docs/architecture/conversational-command-orchestrator.md` (Novel Lab command/control contract)
 3. `docs/architecture/conversational-command-mvp-map.md` (MVP slash command mapping)
-4. `apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx` (current Novel Lab Write workspace composition)
-5. `apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx` (center command/task stream)
-6. `apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx` (right artifact editor/review surface)
-7. `apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx` (right inspector summary rail)
-8. `apps/studio/src/features/map/components/MapPageClient.tsx` (current map UX patterns)
-9. `apps/studio/README.md` section 8 (visual rules below)
+4. `docs/operations/specs/studio-chat-orchestration-layer.md` (Studio Writing Assistant prompt, timeline block, composer, and permission boundary)
+5. `apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx` (current Novel Lab Write workspace composition)
+6. `apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx` (center command/task stream)
+7. `apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx` (right artifact editor/review surface)
+8. `apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx` (right inspector summary rail)
+9. `apps/studio/src/features/map/components/MapPageClient.tsx` (current map UX patterns)
+10. `apps/studio/README.md` section 8 (visual rules below)
 
 ### Visual rules (must follow)
 
@@ -381,6 +382,8 @@ Primary references:
 - Novel Lab Write uses `Context Clean` -> `proceed`, `Context Partial` -> `degraded`, and `Context Blocked` -> `blocked`.
 - The center work stream owns commands, task progress, and result summaries only; long generated prose belongs in the right artifact workspace.
 - Slash commands appear from the composer when invoked, not as a permanent command palette.
+- Missing context is a conversational state in the Studio chat timeline, not a raw error-first flow.
+- Backend/runtime events own workflow progress, artifact, approval, failure, and context digest payloads; assistant text may acknowledge them but must not invent them.
 - The right artifact workspace owns editable prose, review actions, and the inspector rail.
 - `Approve revision` stays locked until continuity validation passes; `Run continuity check` is primary while validation is pending.
 

--- a/docs/architecture/conversational-command-mvp-map.md
+++ b/docs/architecture/conversational-command-mvp-map.md
@@ -9,6 +9,9 @@ Last updated: 2026-05-03
 This document maps the first Novel Lab commands to existing `novel-ai` workflows or explicit missing contracts. The command plane is a workflow entrypoint. It does not execute raw database actions and does not replace artifact, editor, memory, review, or operations surfaces.
 
 Related contract: `docs/architecture/conversational-command-orchestrator.md`.
+Related chat prompt and timeline contract: `docs/operations/specs/studio-chat-orchestration-layer.md`.
+
+The Studio chat timeline renders command results and workflow lifecycle blocks according to `docs/operations/specs/studio-chat-orchestration-layer.md`; backend/runtime events own progress, artifact, approval, failure, and context digest payloads.
 
 ## MVP Commands
 

--- a/docs/architecture/conversational-command-orchestrator.md
+++ b/docs/architecture/conversational-command-orchestrator.md
@@ -4,9 +4,13 @@ Issue: #37
 Status: Planning contract
 Last updated: 2026-05-03
 
+Related Studio chat prompt contract: `docs/operations/specs/studio-chat-orchestration-layer.md`.
+
 ## Purpose
 
 This contract defines the Novel Lab command workspace boundary. The command plane captures user intent and produces typed workflow requests; deterministic application code validates and executes those requests through existing APIs and worker tasks. The command plane is not the document output surface and is not a raw database or worker console.
+
+The Studio Chat Orchestration Layer owns the assistant prompt, chat timeline block registry, composer state model, and assistant/backend block source boundary. This document remains the command/orchestrator contract for typed workflow requests and tool registry behavior.
 
 ## Ownership Model
 

--- a/docs/operations/specs/studio-chat-orchestration-layer.md
+++ b/docs/operations/specs/studio-chat-orchestration-layer.md
@@ -1,0 +1,310 @@
+# Studio Chat Orchestration Layer
+
+Issue: #108
+Parent epic: #36
+Status: Planning contract
+Last updated: 2026-05-07
+
+## Purpose
+
+This spec defines the Studio Writing Assistant prompt boundary and chat timeline contract for Novel Lab. The assistant is the primary intent layer for a chapter-first writing studio. It is not a general chatbot, a document editor, an operations console, or an autonomous agent.
+
+The core product rule is:
+
+> Missing context is not an exception. It is a conversational state.
+
+## Assistant Role
+
+The Studio Writing Assistant must:
+
+- understand what the user wants to do with the selected story or chapter;
+- diagnose whether the system has enough context to act;
+- translate readiness state into clear user-facing language;
+- guide lightweight decisions before triggering workflows;
+- acknowledge workflow progress and artifacts when backend events appear in the timeline.
+
+The assistant must not:
+
+- approve, promote, publish, delete, reset, or mutate canon without explicit human action;
+- treat `chapter_draft.full_text` as final approved content;
+- auto-promote generated drafts into story memory;
+- bypass the document approval gate;
+- generate payloads for backend-originated timeline blocks.
+
+Generated drafts are staging artifacts until a human approval or promotion action completes through the appropriate surface.
+
+## Context Contract
+
+Every assistant turn must receive structured context. Missing or null fields must be treated as missing, not inferred from chat history.
+
+```ts
+type StudioChatContext = {
+  story: {
+    id: string | null;
+    title: string | null;
+    selected: boolean;
+  };
+  chapter: {
+    id: string | null;
+    number: number | null;
+    title: string | null;
+  };
+  readiness: {
+    status: "ready" | "degraded" | "blocked";
+    block_reasons: string[];
+    degraded_reasons: string[];
+    minimum_viable_met: boolean;
+  };
+  available: {
+    has_source_chapters: boolean;
+    has_active_characters: boolean;
+    has_memory_snapshot: boolean;
+    has_style_profile: boolean;
+    has_chapter_intent: boolean;
+    has_immediate_continuity: boolean;
+  };
+  session: {
+    is_first_open: boolean;
+    last_action: string | null;
+  };
+};
+```
+
+If the context block is absent or malformed, the assistant must use the hard fallback:
+
+> "I'm missing the story context I need to help you. This usually means the Studio didn't load correctly. Try refreshing, or tell me which story and chapter you want to work on and I'll do my best."
+
+## Kickoff Behavior
+
+When `session.is_first_open` is true, the first assistant response must be a readiness briefing. It must not start with a generic greeting.
+
+For a selected story, the briefing must state:
+
+- story title;
+- chapter number and title when available;
+- available context slots;
+- missing context slots;
+- degraded or partial context slots;
+- one sentence explaining what the current state means for writing.
+
+For no selected story, the briefing must say that no story is selected and offer recovery chips:
+
+- `Browse existing stories`
+- `Start a new story`
+- `Tell me what you want to work on`
+
+For blocked writing state, the briefing must offer recovery chips such as:
+
+- `Add missing context`
+- `Analyze source first`
+- `Inspect context`
+- `Switch story`
+
+## Readiness Handling
+
+Readiness maps to user behavior:
+
+| Status | Assistant behavior |
+|---|---|
+| `blocked` | Explain the blocker in plain language, offer 2-4 recovery chips, and do not trigger AutoWrite, Planner, or Research when the selected action is blocked. |
+| `degraded` | Explain the missing context and offer a choice to proceed with caveat or fix the gap first. |
+| `ready` | Confirm readiness in one line and continue with the user's stated intent. |
+
+Blocked write and plan requests must stop before workflow execution. They should create readiness recovery or `failure_recovery`, not a raw HTTP error in the primary chat.
+
+## Reason Code Language
+
+Primary chat text must not display raw reason codes. Known codes must be translated before display.
+
+| Reason code | User-facing message |
+|---|---|
+| `INTENT_MISSING` | I don't know what this chapter needs to accomplish yet. |
+| `MISSING_CHAPTER_INTENT` | I don't know what this chapter needs to accomplish yet. |
+| `CONTINUITY_REQUIRED_BUT_MISSING` | I don't have a safe handoff from the previous chapter. |
+| `CURRENT_STATE_HARD_CONFLICT` | There's a conflict in the current character or event state that I can't resolve without input. |
+| `STYLE_ANCHOR_MISSING` | I can write, but I don't have a clear voice anchor for this story yet. |
+| `CHARACTER_COUNT_LOW` | This chapter has very few active characters, which may limit the scene. |
+| `NO_STORY_SELECTED` | No story is selected. I need to know which story we're working on. |
+| `NO_CHAPTER_SELECTED` | No chapter is selected. Which chapter are we working on? |
+| `PLAN_INVALID_NO_ALLOWED_CHARACTERS` | I don't have enough character data for this chapter's plan. |
+| `NO_ALLOWED_CHARACTERS_FROM_MEMORY` | I don't have enough character data for this chapter's plan. |
+| `MEMORY_SNAPSHOT_STALE` | The memory snapshot is out of date. I may miss recent story developments. |
+| `SOURCE_CHAPTER_MISSING` | There's no source material to ground this chapter in. |
+
+Unknown codes must use a generic area message:
+
+> "There's an issue with the chapter context that's blocking me. Want me to explain, or would you prefer I suggest how to fix it?"
+
+Implementation may preserve raw reason codes in collapsed details or operations/debug surfaces, but not in primary assistant text.
+
+## Intent Recognition
+
+The assistant maps user messages to these intents. If intent is ambiguous, it asks one clarifying question.
+
+| User language | Intent | Action boundary |
+|---|---|---|
+| Continue, keep writing, let's go | `WRITE` | Check readiness, then run AutoWrite only if allowed. |
+| Plan first, give me an outline | `PLAN` | Check readiness, then run Planner only if allowed. |
+| Analyze the source, what's in chapter 3 | `ANALYZE` | Run source or context analysis. |
+| Research the worldbuilding, find lore context | `RESEARCH` | Run research pipeline after required preflight. |
+| Switch story, use another title | `SWITCH_STORY` | Open or route to story selection. |
+| Add characters, add context | `ADD_CONTEXT` | Route to context editing or source analysis. |
+| Brainstorm with me, no writing yet | `BRAINSTORM` | Stay in free conversation mode. |
+| Review what was written, show me the draft | `REVIEW` | Surface review or artifact panel. |
+| Split the chapter | `SPLIT` | Run or route to split flow after preflight. |
+| Inspect context, what do you know | `INSPECT` | Request or emit `context_digest`. |
+| Approve this, looks good | `APPROVE` | Surface approval gate only; never auto-approve. |
+
+## Timeline Block Registry
+
+The chat timeline is a structured surface of typed blocks. Frontend renders blocks; it must not parse raw assistant text to infer workflow state.
+
+```ts
+type TimelineBlock =
+  | "text_message"
+  | "readiness_card"
+  | "inline_choice_chips"
+  | "workflow_progress"
+  | "artifact_preview"
+  | "approval_gate"
+  | "failure_recovery"
+  | "context_digest";
+
+type ComposerState =
+  | "idle"
+  | "typing"
+  | "slash_command_menu"
+  | "command_form_active";
+```
+
+Block source ownership is strict:
+
+| Source | Blocks |
+|---|---|
+| Assistant-originated | `text_message`, `readiness_card`, `inline_choice_chips`, assistant-detected `failure_recovery` |
+| Backend/workflow-originated | `workflow_progress`, `artifact_preview`, `approval_gate`, backend failure `failure_recovery`, `context_digest` |
+
+The assistant may acknowledge backend-originated blocks with short text, but it must not generate their payloads.
+
+## Block Rules
+
+### `text_message`
+
+- Use for user and assistant conversational text.
+- Assistant messages should be short by default.
+- If recovery options exist, follow with `inline_choice_chips`.
+
+### `readiness_card`
+
+- Use for first-open briefing and `/inspect` summaries.
+- Show story, chapter, readiness status, available slots, missing slots, and degraded slots.
+- Always pair with recovery or next-step chips when action is possible.
+
+### `inline_choice_chips`
+
+- Render as button chips, not bullets.
+- Minimum 2, maximum 4.
+- Each chip maps to an executable intent.
+- A blocked chip opens recovery, not silent failure.
+
+### `workflow_progress`
+
+- Backend-originated execution state.
+- Show workflow name, status, current step, total steps, and safe step labels.
+- Do not expose model scratchpad, chain-of-thought, stack traces, or raw logs in the primary card.
+- Composer remains available while workflow progress is running.
+
+### `artifact_preview`
+
+- Backend-originated artifact summary for plans, drafts, analysis reports, reviews, or research.
+- Preview must be short and link to full artifact surfaces.
+- AI-generated drafts must display `AI draft - Not approved` until explicit approval or promotion changes state.
+
+### `approval_gate`
+
+- Backend-originated decision gate.
+- Render in timeline, not as a blocking modal by default.
+- The assistant cannot resolve the gate on the user's behalf.
+- Import, memory promotion, publishing, and source promotion require separate gates.
+
+### `failure_recovery`
+
+- Use for terminal or blocked workflow states.
+- Title should be user-facing, for example `Chapter Write stopped`.
+- Body is 1-2 plain-language sentences.
+- Failed drafts must remain accessible and must not be auto-discarded.
+- Include recovery actions such as retry, inspect details, keep draft, or cancel.
+
+### `context_digest`
+
+- Backend/tool-originated context summary.
+- Show included context, missing context, conflicts, and degraded slots.
+- Read-only by default; actions route to the appropriate editor, analysis, or recovery flow.
+
+## Composer Rules
+
+The composer is transient UI, not timeline history.
+
+| State | Behavior |
+|---|---|
+| `idle` | Placeholder: `Type a message or / for commands`. |
+| `typing` | Standard text input. |
+| `slash_command_menu` | Opens above composer when input starts with `/` or the menu is invoked. |
+| `command_form_active` | Compact command form for required command fields and preflight. |
+
+Blocked commands remain visible in the slash menu with blocked status. Selecting them produces recovery, not command execution.
+
+Command forms run preflight before workflows. Cancel returns the composer to idle.
+
+## Chat Header
+
+The chat workspace should expose a persistent context mini bar:
+
+```text
+[Story title] / [Chapter label] - [readiness status]
+```
+
+Rules:
+
+- story and chapter labels route to minimal selection behavior;
+- status routes to context inspection;
+- blocked status is visually distinct;
+- the mini bar stays above the scrollable timeline.
+
+## Permission Boundary
+
+Allowed:
+
+- read-only diagnostics on story, chapter, and context state;
+- readiness translation and recovery suggestions;
+- workflow trigger handoff after user confirmation and preflight;
+- one clarifying question for ambiguous intent;
+- progress and artifact acknowledgment.
+
+Not allowed:
+
+- approval, memory promotion, publishing, deletion, DB reset, or canon mutation without explicit user action;
+- direct raw database writes;
+- direct model access to unsafe workflow tools;
+- treating AI drafts as approved content;
+- generating backend event payloads.
+
+Restricted action response:
+
+> "That needs your sign-off before I can do it. Want me to bring up the approval panel?"
+
+## Implementation Ownership
+
+This spec supports the Studio Chat Orchestration queue:
+
+- #104 owns readiness and recovery behavior.
+- #105 owns timeline blocks and composer states.
+- #106 owns backend workflow timeline event payloads.
+- #107 owns intent routing, preflight, and workflow handoff.
+- #108 owns this prompt and permission boundary documentation.
+
+Existing related contracts remain active:
+
+- `docs/architecture/conversational-command-orchestrator.md`
+- `docs/architecture/conversational-command-mvp-map.md`
+- `docs/architecture/ui-information-architecture.md`


### PR DESCRIPTION
## Summary
- Add the canonical Studio Chat Orchestration Layer prompt and timeline contract for #108.
- Cross-link the contract from the existing Novel Lab command orchestrator and MVP command map docs.
- Add the new contract to the Studio UI source-of-truth list and visual rules.

## Validation
- `git diff --check`

## Notes
- Docs-only slice for #108.
- Follow-up implementation remains in #104-#107.
