### PR TITLE
feat: add chat readiness recovery

### DIFF
--- a/apps/studio/src/app/globals.css
+++ b/apps/studio/src/app/globals.css
@@ -607,6 +607,88 @@ body {
   text-transform: uppercase;
 }
 
+.readiness-card {
+  max-width: 620px;
+  margin: 0 auto 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(17, 24, 39, 0.72);
+  padding: 16px;
+}
+
+.readiness-card--blocked {
+  border-color: rgba(239, 68, 68, 0.24);
+}
+
+.readiness-card--degraded {
+  border-color: rgba(242, 179, 95, 0.24);
+}
+
+.readiness-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.readiness-card__header h1 {
+  margin-top: 6px;
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.readiness-card__items {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.readiness-card__item {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.readiness-card__item--ok {
+  color: #86efac;
+}
+
+.readiness-card__item--missing {
+  color: #fca5a5;
+}
+
+.readiness-card__item--partial {
+  color: var(--accent-2);
+}
+
+.readiness-card p {
+  margin-top: 14px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.readiness-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.readiness-card__chips button {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--text-primary);
+  padding: 7px 10px;
+  font-size: 12px;
+}
+
 .work-message,
 .work-task-list {
   max-width: 620px;

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { useRouter } from "next/navigation";
-import type { CommandId, CommandTaskCard } from "@/features/scenes/components/writeTab/types";
+import ReadinessBriefing from "@/features/scenes/components/writeTab/chatOrchestration/ReadinessBriefing";
+import TaskCard from "@/features/scenes/components/writeTab/chatOrchestration/TaskCard";
+import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
+import type { AssistantReadinessContext, CommandId, CommandTaskCard, RecoveryChip } from "@/features/scenes/components/writeTab/types";
 
 type CommandWorkStreamProps = {
   storySlug: string;
@@ -13,6 +16,7 @@ type CommandWorkStreamProps = {
   onCommandMenuOpenChange: (value: boolean) => void;
   onOpenAutoWrite: () => void;
   onQueueContinuity: () => void;
+  assistantContext: AssistantReadinessContext;
 };
 
 type CommandOption = {
@@ -34,6 +38,7 @@ type CommandRunnerArgs = {
   chapterId: string;
   onOpenAutoWrite: () => void;
   onQueueContinuity: () => void;
+  readinessContext: AssistantReadinessContext;
 };
 
 type CommandGroup = "primary" | "more" | "hidden";
@@ -84,13 +89,6 @@ const moreCommands = commandDefinitions.filter((command) => command.visible && c
 
 const moreMenuItem: CommandMenuItem = { id: "More", description: "" };
 const allAvailableCommands: CommandMenuItem[] = [...primaryCommands, moreMenuItem, ...moreCommands];
-
-function statusLabel(status: CommandTaskCard["status"]): string {
-  if (status === "running") return "Running";
-  if (status === "completed") return "Completed";
-  if (status === "blocked") return "Blocked";
-  return "Ready";
-}
 
 function SlashCommandMenu({ 
   onSelect, 
@@ -211,6 +209,23 @@ function commandUnavailable(command: CommandId, detail: string): CommandResult {
   };
 }
 
+function commandTail(value: string, command: CommandId): string {
+  const normalized = value.trimStart();
+  if (!normalized.startsWith(command)) return "";
+  return normalized.slice(command.length).trim();
+}
+
+function contextWithComposerIntent(context: AssistantReadinessContext, composerValue: string, command: CommandId | null): AssistantReadinessContext {
+  if (command !== "/write chapter" && command !== "/analyze chapter") return context;
+  return {
+    ...context,
+    availability: {
+      ...context.availability,
+      has_chapter_intent: context.availability.has_chapter_intent || commandTail(composerValue, command).length > 0,
+    },
+  };
+}
+
 function useCommandRunner(args: CommandRunnerArgs) {
   const router = useRouter();
   const [commandResult, setCommandResult] = React.useState<CommandResult | null>(null);
@@ -225,8 +240,9 @@ function useCommandRunner(args: CommandRunnerArgs) {
 
       const storyBase = `/stories/${encodeURIComponent(args.storySlug)}`;
       if (command === "/write chapter") {
-        if (!args.chapterId) {
-          setCommandResult(commandUnavailable(command, "Choose or create a chapter before opening AutoWrite."));
+        const readiness = buildAssistantReadiness(args.readinessContext);
+        if (!readiness.canWrite) {
+          setCommandResult(commandUnavailable(command, readiness.blockedWriteReason ?? "The chapter context is blocked. Add missing context before opening AutoWrite."));
           return;
         }
         args.onOpenAutoWrite();
@@ -330,37 +346,55 @@ function handleSlashMenuKeyDown({
   if (event.key === "Escape") onClose();
 }
 
-function TaskCard({ task, onRunCommand }: { task: CommandTaskCard; onRunCommand: (command: CommandId) => void }) {
+function chipTarget(storySlug: string, chip: RecoveryChip): string | null {
+  const storyBase = `/stories/${encodeURIComponent(storySlug)}`;
+  if (chip.intent === "browse_stories" || chip.intent === "switch_story") return "/shelf";
+  if (chip.intent === "start_story") return "/";
+  if (chip.intent === "add_context" || chip.intent === "analyze_source") return `${storyBase}/analysis`;
+  if (chip.intent === "inspect_context") return `${storyBase}/memory`;
+  return null;
+}
+
+function CommandResultMessage({ result }: { result: CommandResult }) {
   return (
-    <article className={`work-task-card work-task-card--${task.status}`}>
-      <div className="work-task-card__meta">
-        <span className="font-mono text-xs">{task.command}</span>
-        <span>{statusLabel(task.status)}</span>
-      </div>
-      <div className="work-task-card__title">{task.title}</div>
-      <p>{task.detail}</p>
-      {task.cta && task.ctaCommand ? (
-        <button type="button" onClick={() => task.ctaCommand && onRunCommand(task.ctaCommand)}>
-          {task.cta}
-        </button>
-      ) : null}
-    </article>
+    <div className={`work-message mt-4 work-message--${result.tone === "blocked" ? "user" : "assistant"}`}>
+      <div className="work-message__label">{result.tone === "blocked" ? "Blocked" : "Novel Lab"}</div>
+      <div className="text-sm font-semibold">{result.title}</div>
+      <div className="muted mt-1 text-xs">{result.detail}</div>
+    </div>
   );
 }
 
 export default function CommandWorkStream(props: CommandWorkStreamProps) {
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [isMoreOpen, setIsMoreOpen] = React.useState(false);
+  const router = useRouter();
+  const currentCommand = commandFromValue(props.composerValue);
+  const readinessContext = contextWithComposerIntent(props.assistantContext, props.composerValue, currentCommand);
+  const briefing = buildAssistantReadiness(readinessContext);
   const { commandResult, runCommand, setCommandResult } = useCommandRunner({
     storySlug: props.storySlug,
     chapterId: props.chapterId,
     onOpenAutoWrite: props.onOpenAutoWrite,
     onQueueContinuity: props.onQueueContinuity,
+    readinessContext,
   });
   
   const showSlashMenu = props.commandMenuOpen || props.composerValue.trimStart().startsWith("/");
   const maxIndex = getMaxCommandIndex(isMoreOpen);
   const tasks = buildTasks(props);
+  const handleChip = (chip: RecoveryChip) => {
+    const target = chipTarget(props.storySlug, chip);
+    if (chip.intent === "describe_goal") {
+      props.onComposerValueChange(props.chapterId ? `/write chapter ${props.chapterId} ` : "");
+      return;
+    }
+    if (chip.intent === "continue_degraded") {
+      props.onComposerValueChange(props.chapterId ? `/write chapter ${props.chapterId} ` : "/write chapter ");
+      return;
+    }
+    if (target) router.push(target);
+  };
 
   const handleSelect = (command: string) => {
     if (command === "More") {
@@ -388,11 +422,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
   return (
     <section className="work-stream" aria-label="Command work stream">
       <div className="work-stream__scroll">
-        <div className="work-stream__intro">
-          <div className="work-stream__eyebrow">Current work</div>
-          <h1 className="text-xl font-bold">Write and validate</h1>
-          <p className="text-xs muted">Give Novel Lab a command, then review the resulting artifact on the right.</p>
-        </div>
+        <ReadinessBriefing briefing={briefing} onChip={handleChip} />
 
         {props.composerValue && (
           <div className="work-message work-message--user mb-4">
@@ -407,13 +437,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
           ))}
         </div>
 
-        {commandResult ? (
-          <div className={`work-message mt-4 work-message--${commandResult.tone === "blocked" ? "user" : "assistant"}`}>
-            <div className="work-message__label">{commandResult.tone === "blocked" ? "Blocked" : "Novel Lab"}</div>
-            <div className="text-sm font-semibold">{commandResult.title}</div>
-            <div className="muted mt-1 text-xs">{commandResult.detail}</div>
-          </div>
-        ) : null}
+        {commandResult ? <CommandResultMessage result={commandResult} /> : null}
       </div>
 
       <div className="work-composer-wrap">

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -6,6 +6,7 @@ import AutoWriteWizard from "@/features/scenes/components/writeTab/AutoWriteWiza
 import ArtifactSurface from "@/features/scenes/components/writeTab/ArtifactSurface";
 import CommandWorkStream from "@/features/scenes/components/writeTab/CommandWorkStream";
 import type {
+  AssistantAvailability,
   ChapterSceneItem,
   ContextReadiness,
   CurrentVersion,
@@ -195,6 +196,18 @@ function selectedChapterTitle(selectedChapterId: string): string {
   return selectedChapterId ? `${getChapterTitle(selectedChapterId)} Draft` : "No chapter selected";
 }
 
+function assistantAvailability(props: NovelLabWorkspaceProps, hasDraft: boolean): AssistantAvailability {
+  const hasSourceChapters = props.chapterScenes.length > 0 || Boolean(props.current?.text_content || props.stagingData?.llm_prose || props.v3Draft?.full_text);
+  return {
+    has_source_chapters: hasSourceChapters,
+    has_active_characters: false,
+    has_memory_snapshot: Boolean(props.v3Draft?.virtual_scenes?.length || props.stagingData),
+    has_style_profile: false,
+    has_chapter_intent: false,
+    has_immediate_continuity: hasDraft,
+  };
+}
+
 function WorkspaceStatusMessages({ error, loadingDetail, loadingChapter }: Pick<NovelLabWorkspaceProps, "error" | "loadingDetail" | "loadingChapter">) {
   return (
     <>
@@ -228,6 +241,7 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
   const hasDraft = draftSource.text.trim().length > 0;
   const loadingWorkspace = props.loadingScenes || props.loadingDetail || props.loadingChapter;
   const readiness: ContextReadiness = "degraded";
+  const availability = assistantAvailability(props, hasDraft);
 
   return (
     <>
@@ -260,6 +274,14 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
           onCommandMenuOpenChange={setCommandMenuOpen}
           onOpenAutoWrite={() => props.setShowAutoWrite(true)}
           onQueueContinuity={() => setContinuityQueued(true)}
+          assistantContext={{
+            storyTitle: storyLabelFromSlug(props.storySlug),
+            storySelected: Boolean(props.storySlug),
+            chapterId: props.selectedChapterId || null,
+            chapterTitle,
+            readiness,
+            availability,
+          }}
         />
         <ArtifactSurface
           storySlug={props.storySlug}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ReadinessBriefing.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ReadinessBriefing.tsx
@@ -1,0 +1,45 @@
+import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
+import type { RecoveryChip } from "@/features/scenes/components/writeTab/types";
+
+type ReadinessBriefingProps = {
+  briefing: ReturnType<typeof buildAssistantReadiness>;
+  onChip: (chip: RecoveryChip) => void;
+};
+
+function readinessMarker(state: "ok" | "missing" | "partial"): string {
+  if (state === "ok") return "✓";
+  if (state === "partial") return "~";
+  return "✗";
+}
+
+export default function ReadinessBriefing({ briefing, onChip }: ReadinessBriefingProps) {
+  return (
+    <section className={`readiness-card readiness-card--${briefing.status}`} aria-label="Studio readiness briefing">
+      <div className="readiness-card__header">
+        <div>
+          <div className="work-stream__eyebrow">Studio Writing Assistant</div>
+          <h1>{briefing.title}</h1>
+        </div>
+        <span className={`status-pill status-pill--${briefing.status === "ready" ? "clean" : briefing.status === "degraded" ? "partial" : "blocked"}`}>
+          {briefing.status.toUpperCase()}
+        </span>
+      </div>
+      <div className="readiness-card__items">
+        {briefing.items.map((item) => (
+          <div key={item.label} className={`readiness-card__item readiness-card__item--${item.state}`}>
+            <span aria-hidden>{readinessMarker(item.state)}</span>
+            <span>{item.label}</span>
+          </div>
+        ))}
+      </div>
+      <p>{briefing.summary}</p>
+      <div className="readiness-card__chips" aria-label="Recovery options">
+        {briefing.chips.map((chip) => (
+          <button key={`${chip.intent}-${chip.label}`} type="button" onClick={() => onChip(chip)}>
+            {chip.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TaskCard.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TaskCard.tsx
@@ -1,0 +1,31 @@
+import type { CommandId, CommandTaskCard } from "@/features/scenes/components/writeTab/types";
+
+type TaskCardProps = {
+  task: CommandTaskCard;
+  onRunCommand: (command: CommandId) => void;
+};
+
+function statusLabel(status: CommandTaskCard["status"]): string {
+  if (status === "running") return "Running";
+  if (status === "completed") return "Completed";
+  if (status === "blocked") return "Blocked";
+  return "Ready";
+}
+
+export default function TaskCard({ task, onRunCommand }: TaskCardProps) {
+  return (
+    <article className={`work-task-card work-task-card--${task.status}`}>
+      <div className="work-task-card__meta">
+        <span className="font-mono text-xs">{task.command}</span>
+        <span>{statusLabel(task.status)}</span>
+      </div>
+      <div className="work-task-card__title">{task.title}</div>
+      <p>{task.detail}</p>
+      {task.cta && task.ctaCommand ? (
+        <button type="button" onClick={() => task.ctaCommand && onRunCommand(task.ctaCommand)}>
+          {task.cta}
+        </button>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/readiness.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/readiness.ts
@@ -1,0 +1,108 @@
+import type {
+  AssistantReadinessBriefing,
+  AssistantReadinessContext,
+  AssistantReadinessItem,
+  AssistantReadinessStatus,
+  RecoveryChip,
+} from "@/features/scenes/components/writeTab/types";
+
+function item(label: string, state: AssistantReadinessItem["state"]): AssistantReadinessItem {
+  return { label, state };
+}
+
+function storyTitle(context: AssistantReadinessContext): string {
+  return context.storyTitle?.trim() || "Current story";
+}
+
+function chapterLabel(context: AssistantReadinessContext): string {
+  if (!context.chapterId) return "No chapter selected";
+  if (context.chapterTitle?.trim()) return `${context.chapterId} - ${context.chapterTitle.trim()}`;
+  return context.chapterId;
+}
+
+function statusFromContext(context: AssistantReadinessContext): AssistantReadinessStatus {
+  if (!context.storySelected || !context.chapterId) return "blocked";
+  if (!context.availability.has_chapter_intent || !context.availability.has_active_characters) return "blocked";
+  if (context.readiness === "blocked") return "blocked";
+  if (context.readiness === "degraded") return "degraded";
+  if (!context.availability.has_source_chapters || !context.availability.has_immediate_continuity || !context.availability.has_style_profile) {
+    return "degraded";
+  }
+  return "ready";
+}
+
+function blockedWriteReason(context: AssistantReadinessContext): string | null {
+  if (!context.storySelected) return "No story is selected. I need to know which story we're working on.";
+  if (!context.chapterId) return "No chapter is selected. Which chapter are we working on?";
+  if (!context.availability.has_chapter_intent) return "I don't know what this chapter needs to accomplish yet.";
+  if (!context.availability.has_active_characters) return "I don't have enough character data for this chapter's plan.";
+  if (context.readiness === "blocked") return "The chapter context is blocked. Inspect the context or add missing material before writing.";
+  return null;
+}
+
+function recoveryChips(context: AssistantReadinessContext, status: AssistantReadinessStatus): RecoveryChip[] {
+  if (!context.storySelected) {
+    return [
+      { label: "Browse existing stories", intent: "browse_stories" },
+      { label: "Start a new story", intent: "start_story" },
+      { label: "Tell me what you want to work on", intent: "describe_goal" },
+    ];
+  }
+  if (!context.chapterId) {
+    return [
+      { label: "Choose chapter", intent: "switch_story" },
+      { label: "Add missing context", intent: "add_context" },
+      { label: "Inspect context", intent: "inspect_context" },
+    ];
+  }
+  if (status === "blocked") {
+    return [
+      { label: "Add missing context", intent: "add_context" },
+      { label: "Analyze source first", intent: "analyze_source" },
+      { label: "Inspect context", intent: "inspect_context" },
+      { label: "Switch story", intent: "switch_story" },
+    ];
+  }
+  if (status === "degraded") {
+    return [
+      { label: "Continue with caveat", intent: "continue_degraded" },
+      { label: "Analyze source first", intent: "analyze_source" },
+      { label: "Inspect context", intent: "inspect_context" },
+    ];
+  }
+  return [
+    { label: "Write chapter", intent: "continue_degraded" },
+    { label: "Inspect context", intent: "inspect_context" },
+  ];
+}
+
+function summary(context: AssistantReadinessContext, status: AssistantReadinessStatus, writeBlocker: string | null): string {
+  if (writeBlocker) return writeBlocker;
+  if (status === "degraded") return "I can help, but output quality may be reduced until the missing context is refreshed.";
+  return "The chapter has enough context for the next writing action.";
+}
+
+export function buildAssistantReadiness(context: AssistantReadinessContext): AssistantReadinessBriefing {
+  const status = statusFromContext(context);
+  const writeBlocker = blockedWriteReason(context);
+  const items: AssistantReadinessItem[] = [
+    item("Story selected", context.storySelected ? "ok" : "missing"),
+    item("Chapter selected", context.chapterId ? "ok" : "missing"),
+    item("Chapter intent", context.availability.has_chapter_intent ? "ok" : "missing"),
+    item("Active characters", context.availability.has_active_characters ? "ok" : "missing"),
+    item("Source material", context.availability.has_source_chapters ? "ok" : "missing"),
+    item("Memory snapshot", context.availability.has_memory_snapshot ? "ok" : "partial"),
+    item("Style profile", context.availability.has_style_profile ? "ok" : "partial"),
+    item("Immediate continuity", context.availability.has_immediate_continuity ? "ok" : "partial"),
+  ];
+
+  return {
+    status,
+    title: context.storySelected ? `${storyTitle(context)} / ${chapterLabel(context)}` : "No story selected",
+    summary: summary(context, status, writeBlocker),
+    items,
+    chips: recoveryChips(context, status),
+    canWrite: !writeBlocker,
+    blockedWriteReason: writeBlocker,
+  };
+}

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -29,6 +29,58 @@ export type ContextReadiness = "proceed" | "degraded" | "blocked";
 
 export type ContextReadinessLabel = "Context Clean" | "Context Partial" | "Context Blocked";
 
+export type AssistantReadinessStatus = "ready" | "degraded" | "blocked";
+
+export type AssistantReadinessItemState = "ok" | "missing" | "partial";
+
+export type AssistantReadinessItem = {
+  label: string;
+  state: AssistantReadinessItemState;
+};
+
+export type AssistantAvailability = {
+  has_source_chapters: boolean;
+  has_active_characters: boolean;
+  has_memory_snapshot: boolean;
+  has_style_profile: boolean;
+  has_chapter_intent: boolean;
+  has_immediate_continuity: boolean;
+};
+
+export type RecoveryIntent =
+  | "browse_stories"
+  | "start_story"
+  | "describe_goal"
+  | "add_context"
+  | "analyze_source"
+  | "inspect_context"
+  | "switch_story"
+  | "continue_degraded";
+
+export type RecoveryChip = {
+  label: string;
+  intent: RecoveryIntent;
+};
+
+export type AssistantReadinessContext = {
+  storyTitle: string | null;
+  storySelected: boolean;
+  chapterId: string | null;
+  chapterTitle: string | null;
+  readiness: ContextReadiness;
+  availability: AssistantAvailability;
+};
+
+export type AssistantReadinessBriefing = {
+  status: AssistantReadinessStatus;
+  title: string;
+  summary: string;
+  items: AssistantReadinessItem[];
+  chips: RecoveryChip[];
+  canWrite: boolean;
+  blockedWriteReason: string | null;
+};
+
 export type ArtifactKind = "document" | "analysis" | "review" | "memory" | "publish_preview" | "operations";
 
 export type CommandTaskStatus = "idle" | "running" | "completed" | "blocked";


### PR DESCRIPTION
## Summary
- Add a Studio Writing Assistant readiness briefing to the Novel Lab command stream.
- Add readiness/recovery helper types and chips for missing story/chapter/intent/characters/source states.
- Gate `/write chapter` so blocked context opens recovery instead of AutoWrite.

## Validation
- `npm run typecheck`
- `npx eslint src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/NovelLabWorkspace.tsx src/features/scenes/components/writeTab/types.ts src/features/scenes/components/writeTab/chatOrchestration/readiness.ts src/features/scenes/components/writeTab/chatOrchestration/ReadinessBriefing.tsx src/features/scenes/components/writeTab/chatOrchestration/TaskCard.tsx`
- `git diff --check`
- `npm run build`

## Notes
- Implements the first readiness/recovery slice for #104.
- Deeper timeline block registry remains #105; backend workflow events remain #106; full intent orchestration remains #107.
