### PR TITLE
feat: emit workflow timeline events

### DIFF
--- a/apps/studio/src/features/chat-orchestration/server/timelineEvents.test.ts
+++ b/apps/studio/src/features/chat-orchestration/server/timelineEvents.test.ts
@@ -1,0 +1,88 @@
+import {
+  buildApprovalGateEvent,
+  buildArtifactPreviewEvent,
+  buildChapterWritingTimelineEvents,
+  buildFailureRecoveryEvent,
+  buildWorkflowProgressEvent,
+  plainTimelineReason,
+  type TimelineEvent,
+} from "@/features/chat-orchestration/server/timelineEvents";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+export function runTimelineEventDtoSelfTest(): TimelineEvent[] {
+  const running = buildWorkflowProgressEvent({
+    storyId: 1,
+    chapterId: "ch01",
+    jobId: 10,
+    workflowName: "Chapter Write",
+    jobStatus: "RUNNING",
+    currentStepLabel: "Write chapter draft",
+    steps: [{ label: "Write chapter draft", status: "active" }],
+  });
+  assert(running.type === "workflow_progress" && running.source === "backend", "workflow progress must be backend sourced");
+
+  const artifact = buildArtifactPreviewEvent({
+    storyId: 1,
+    chapterId: "ch01",
+    jobId: 10,
+    artifactId: "draft:ch01",
+    artifactType: "draft",
+    title: "Chapter ch01 Draft",
+    status: "draft",
+    wordCount: 1200,
+    previewLines: ["Draft created"],
+    actions: ["open_draft"],
+  });
+  assert(artifact.type === "artifact_preview" && artifact.word_count === 1200, "artifact preview must carry draft metadata");
+
+  const approval = buildApprovalGateEvent({
+    storyId: 1,
+    chapterId: "ch01",
+    jobId: 10,
+    gateType: "import_to_editor",
+    description: "Needs explicit user action.",
+    actions: ["import_to_editor", "keep_as_draft"],
+  });
+  assert(approval.type === "approval_gate" && approval.actions.length === 2, "approval gate must expose user actions");
+
+  const failure = buildFailureRecoveryEvent({
+    storyId: 1,
+    chapterId: "ch01",
+    jobId: 10,
+    workflowName: "Chapter Write",
+    stoppedAtStep: "Planning",
+    reason: "PLAN_INVALID_NO_ALLOWED_CHARACTERS",
+    fallbackReason: "The writing run stopped.",
+    draftPreserved: false,
+  });
+  assert(failure.plain_reason.includes("character data"), "failure recovery must translate raw reason codes");
+
+  const chapterEvents = buildChapterWritingTimelineEvents({
+    storyId: 1,
+    chapterId: "ch01",
+    jobId: 10,
+    jobStatus: "DONE",
+    doneTasks: 3,
+    totalTasks: 3,
+    latestTaskType: "CHAPTER_WRITE_V3",
+    latestTaskStatus: "DONE",
+    latestTaskError: null,
+    narrativeTasks: [{ task_type: "CHAPTER_WRITE_V3", status: "DONE" }],
+    proseReady: true,
+    wordCount: 1400,
+    planJson: { beats: [{ title: "Opening" }] },
+    memoryRuntimeV5: { evidence_refs: { canon: ["c1"] } },
+    finalReviewReady: true,
+    blockedByConflictReview: false,
+    blockedByCanonConflict: false,
+    blockingReason: null,
+  });
+  assert(chapterEvents.some((event) => event.type === "context_digest"), "chapter events must include context digest");
+  assert(plainTimelineReason("SOURCE_CHAPTER_MISSING", "fallback").includes("source material"), "known reason codes must map to plain language");
+  return [running, artifact, approval, failure, ...chapterEvents];
+}
+
+runTimelineEventDtoSelfTest();

--- a/apps/studio/src/features/chat-orchestration/server/timelineEvents.ts
+++ b/apps/studio/src/features/chat-orchestration/server/timelineEvents.ts
@@ -1,0 +1,422 @@
+export type TimelineEventSource = "backend";
+
+export type TimelineEventBase = {
+  event_id: string;
+  source: TimelineEventSource;
+  story_id: number | null;
+  chapter_id: string | null;
+  job_id?: number | null;
+};
+
+export type TimelineWorkflowStepStatus = "complete" | "active" | "pending" | "failed";
+
+export type WorkflowProgressTimelineEvent = TimelineEventBase & {
+  type: "workflow_progress";
+  workflow_name: string;
+  status: "running" | "complete" | "failed" | "cancelled";
+  current_step: number;
+  total_steps: number;
+  current_step_label: string;
+  steps: Array<{ label: string; status: TimelineWorkflowStepStatus }>;
+};
+
+export type ArtifactPreviewTimelineEvent = TimelineEventBase & {
+  type: "artifact_preview";
+  artifact_id: string;
+  artifact_type: "plan" | "draft" | "analysis" | "review" | "research";
+  title: string;
+  status: "draft" | "needs_approval" | "approved" | "failed" | "superseded";
+  word_count: number | null;
+  beat_count: number | null;
+  preview_lines: string[];
+  actions: string[];
+};
+
+export type ApprovalGateTimelineEvent = TimelineEventBase & {
+  type: "approval_gate";
+  gate_type: "import_to_editor" | "promote_to_memory" | "publish_chapter" | "approve_plan";
+  description: string;
+  actions: string[];
+};
+
+export type FailureRecoveryTimelineEvent = TimelineEventBase & {
+  type: "failure_recovery";
+  workflow_name: string;
+  stopped_at_step: string;
+  plain_reason: string;
+  draft_preserved: boolean;
+  actions: string[];
+  detail_log: string[];
+  details: { reason_codes: string[] };
+};
+
+export type ContextDigestTimelineEvent = TimelineEventBase & {
+  type: "context_digest";
+  title: string;
+  included: string[];
+  missing: string[];
+  degraded: string[];
+  conflicts: string[];
+};
+
+export type TimelineEvent =
+  | WorkflowProgressTimelineEvent
+  | ArtifactPreviewTimelineEvent
+  | ApprovalGateTimelineEvent
+  | FailureRecoveryTimelineEvent
+  | ContextDigestTimelineEvent;
+
+type ChapterWritingTask = {
+  task_type: string;
+  status: string;
+  error?: string | null;
+};
+
+type ChapterWritingTimelineArgs = {
+  storyId: number | null;
+  chapterId: string;
+  jobId: number | null;
+  jobStatus: string;
+  doneTasks: number;
+  totalTasks: number;
+  latestTaskType: string | null;
+  latestTaskStatus: string | null;
+  latestTaskError: string | null;
+  narrativeTasks: ChapterWritingTask[];
+  proseReady: boolean;
+  wordCount: number;
+  planJson: Record<string, unknown> | null;
+  memoryRuntimeV5: Record<string, unknown>;
+  finalReviewReady: boolean;
+  blockedByConflictReview: boolean;
+  blockedByCanonConflict: boolean;
+  blockingReason: string | null;
+};
+
+const reasonMessages: Record<string, string> = {
+  INTENT_MISSING: "I don't know what this chapter needs to accomplish yet.",
+  MISSING_CHAPTER_INTENT: "I don't know what this chapter needs to accomplish yet.",
+  CONTINUITY_REQUIRED_BUT_MISSING: "I don't have a safe handoff from the previous chapter.",
+  CURRENT_STATE_HARD_CONFLICT: "There's a conflict in the current character or event state that needs review.",
+  STYLE_ANCHOR_MISSING: "I can continue, but I don't have a clear voice anchor for this story yet.",
+  CHARACTER_COUNT_LOW: "This chapter has very few active characters, which may limit the scene.",
+  NO_STORY_SELECTED: "No story is selected. I need to know which story we're working on.",
+  NO_CHAPTER_SELECTED: "No chapter is selected. Which chapter are we working on?",
+  PLAN_INVALID_NO_ALLOWED_CHARACTERS: "I don't have enough character data for this chapter's plan.",
+  MEMORY_SNAPSHOT_STALE: "The memory snapshot is out of date. I may miss recent story developments.",
+  SOURCE_CHAPTER_MISSING: "There's no source material to ground this chapter in.",
+  BLOCKED_BY_CONFLICT_REVIEW: "This needs conflict review before writing can continue.",
+  BLOCKED_BY_CANON_CONFLICT: "This plan conflicts with existing canon and needs review before writing can continue.",
+  JOB_NOT_FOUND: "I couldn't find the writing run for this chapter.",
+  WRITING_STATUS_FAILED: "I couldn't read the writing run status.",
+};
+
+function eventId(parts: Array<string | number | null | undefined>): string {
+  return parts.filter((part) => part !== null && part !== undefined && String(part).length > 0).join(":");
+}
+
+function cleanReasonCode(raw: string | null | undefined): string | null {
+  const value = String(raw || "").trim();
+  if (!value) return null;
+  const direct = value.toUpperCase();
+  if (/^[A-Z0-9_]+$/.test(direct)) return direct;
+  const match = direct.match(/[A-Z0-9]+(?:_[A-Z0-9]+)+/);
+  return match ? match[0] : null;
+}
+
+export function plainTimelineReason(raw: string | null | undefined, fallback: string): string {
+  const code = cleanReasonCode(raw);
+  if (code && reasonMessages[code]) return reasonMessages[code];
+  const text = String(raw || "").trim();
+  if (!text || /^[A-Z0-9_]+$/.test(text)) return fallback;
+  return text.length > 180 ? `${text.slice(0, 177)}...` : text;
+}
+
+function normalizeJobStatus(status: string): WorkflowProgressTimelineEvent["status"] {
+  const normalized = String(status || "").toUpperCase();
+  if (normalized === "DONE" || normalized === "COMPLETE" || normalized === "COMPLETED") return "complete";
+  if (normalized === "FAILED" || normalized === "ERROR") return "failed";
+  if (normalized === "CANCELLED" || normalized === "CANCELED") return "cancelled";
+  return "running";
+}
+
+function taskLabel(taskType: string | null): string {
+  const type = String(taskType || "").toUpperCase();
+  if (type === "CHAPTER_WRITE_V3") return "Write chapter draft";
+  if (type === "CHAPTER_LEDGER_EXTRACT") return "Extract chapter ledger";
+  if (type === "MEMORY_ROLLUP_V3") return "Update memory rollup";
+  if (type === "NARRATIVE_START") return "Start narrative run";
+  if (type === "NARRATIVE_STYLIST") return "Apply story voice";
+  if (type === "NARRATIVE_CRITIC") return "Review draft quality";
+  if (type === "NARRATIVE_REFINE") return "Refine draft";
+  if (type === "NARRATIVE_FINALIZE") return "Finalize draft artifact";
+  return type ? type.toLowerCase().replaceAll("_", " ") : "Read workflow state";
+}
+
+function taskStatus(status: string): TimelineWorkflowStepStatus {
+  const normalized = String(status || "").toUpperCase();
+  if (normalized === "DONE" || normalized === "COMPLETE" || normalized === "COMPLETED") return "complete";
+  if (normalized === "FAILED" || normalized === "ERROR") return "failed";
+  if (normalized === "RUNNING" || normalized === "READY") return "active";
+  return "pending";
+}
+
+export function buildWorkflowProgressEvent(args: {
+  storyId: number | null;
+  chapterId: string | null;
+  jobId?: number | null;
+  workflowName: string;
+  jobStatus: string;
+  currentStepLabel: string;
+  steps: Array<{ label: string; status: TimelineWorkflowStepStatus }>;
+}): WorkflowProgressTimelineEvent {
+  const totalSteps = Math.max(args.steps.length, 1);
+  const activeIndex = args.steps.findIndex((step) => step.status === "active" || step.status === "failed");
+  const currentStep = activeIndex >= 0 ? activeIndex + 1 : totalSteps;
+  return {
+    event_id: eventId(["workflow", args.jobId, args.chapterId, args.workflowName]),
+    source: "backend",
+    story_id: args.storyId,
+    chapter_id: args.chapterId,
+    job_id: args.jobId ?? null,
+    type: "workflow_progress",
+    workflow_name: args.workflowName,
+    status: normalizeJobStatus(args.jobStatus),
+    current_step: currentStep,
+    total_steps: totalSteps,
+    current_step_label: args.currentStepLabel,
+    steps: args.steps.length > 0 ? args.steps : [{ label: args.currentStepLabel, status: "active" }],
+  };
+}
+
+export function buildFailureRecoveryEvent(args: {
+  storyId: number | null;
+  chapterId: string | null;
+  jobId?: number | null;
+  workflowName: string;
+  stoppedAtStep: string;
+  reason: string | null;
+  fallbackReason: string;
+  draftPreserved: boolean;
+  detailLog?: string[];
+}): FailureRecoveryTimelineEvent {
+  const code = cleanReasonCode(args.reason);
+  return {
+    event_id: eventId(["failure", args.jobId, args.chapterId, args.stoppedAtStep]),
+    source: "backend",
+    story_id: args.storyId,
+    chapter_id: args.chapterId,
+    job_id: args.jobId ?? null,
+    type: "failure_recovery",
+    workflow_name: args.workflowName,
+    stopped_at_step: args.stoppedAtStep,
+    plain_reason: plainTimelineReason(args.reason, args.fallbackReason),
+    draft_preserved: args.draftPreserved,
+    actions: ["retry", "open_details", args.draftPreserved ? "keep_draft" : "cancel_run"],
+    detail_log: args.detailLog ?? [],
+    details: { reason_codes: code ? [code] : [] },
+  };
+}
+
+export function buildArtifactPreviewEvent(args: {
+  storyId: number | null;
+  chapterId: string | null;
+  jobId?: number | null;
+  artifactId: string;
+  artifactType: ArtifactPreviewTimelineEvent["artifact_type"];
+  title: string;
+  status: ArtifactPreviewTimelineEvent["status"];
+  wordCount?: number | null;
+  beatCount?: number | null;
+  previewLines: string[];
+  actions: string[];
+}): ArtifactPreviewTimelineEvent {
+  return {
+    event_id: eventId(["artifact", args.artifactType, args.artifactId]),
+    source: "backend",
+    story_id: args.storyId,
+    chapter_id: args.chapterId,
+    job_id: args.jobId ?? null,
+    type: "artifact_preview",
+    artifact_id: args.artifactId,
+    artifact_type: args.artifactType,
+    title: args.title,
+    status: args.status,
+    word_count: args.wordCount ?? null,
+    beat_count: args.beatCount ?? null,
+    preview_lines: args.previewLines.slice(0, 3),
+    actions: args.actions,
+  };
+}
+
+export function buildApprovalGateEvent(args: {
+  storyId: number | null;
+  chapterId: string | null;
+  jobId?: number | null;
+  gateType: ApprovalGateTimelineEvent["gate_type"];
+  description: string;
+  actions: string[];
+}): ApprovalGateTimelineEvent {
+  return {
+    event_id: eventId(["approval", args.gateType, args.jobId, args.chapterId]),
+    source: "backend",
+    story_id: args.storyId,
+    chapter_id: args.chapterId,
+    job_id: args.jobId ?? null,
+    type: "approval_gate",
+    gate_type: args.gateType,
+    description: args.description,
+    actions: args.actions,
+  };
+}
+
+export function buildContextDigestEvent(args: {
+  storyId: number | null;
+  chapterId: string | null;
+  title: string;
+  included: string[];
+  missing: string[];
+  degraded: string[];
+  conflicts: string[];
+}): ContextDigestTimelineEvent {
+  return {
+    event_id: eventId(["context", args.storyId, args.chapterId]),
+    source: "backend",
+    story_id: args.storyId,
+    chapter_id: args.chapterId,
+    type: "context_digest",
+    title: args.title,
+    included: args.included,
+    missing: args.missing,
+    degraded: args.degraded,
+    conflicts: args.conflicts,
+  };
+}
+
+function beatCount(planJson: Record<string, unknown> | null): number | null {
+  const beats = planJson?.beats;
+  return Array.isArray(beats) ? beats.length : null;
+}
+
+function contextDigestFromMemory(args: ChapterWritingTimelineArgs): ContextDigestTimelineEvent {
+  const degradedReasons = Array.isArray(args.memoryRuntimeV5.degraded_reasons)
+    ? args.memoryRuntimeV5.degraded_reasons.map((reason) => plainTimelineReason(String(reason), "Context is degraded."))
+    : [];
+  const hasEvidenceRefs = Boolean(args.memoryRuntimeV5.evidence_refs && typeof args.memoryRuntimeV5.evidence_refs === "object");
+  return buildContextDigestEvent({
+    storyId: args.storyId,
+    chapterId: args.chapterId,
+    title: `Chapter ${args.chapterId} context`,
+    included: [
+      args.planJson ? "Chapter plan" : "",
+      hasEvidenceRefs ? "Evidence references" : "",
+      args.proseReady ? "Draft prose" : "",
+    ].filter(Boolean),
+    missing: [
+      args.planJson ? "" : "Chapter plan",
+      hasEvidenceRefs ? "" : "Evidence references",
+      args.proseReady ? "" : "Draft prose",
+    ].filter(Boolean),
+    degraded: degradedReasons,
+    conflicts: [
+      args.blockedByCanonConflict ? "Canon conflict requires review." : "",
+      args.blockedByConflictReview ? "Conflict review is required." : "",
+    ].filter(Boolean),
+  });
+}
+
+function planPreviewFromArgs(args: ChapterWritingTimelineArgs): ArtifactPreviewTimelineEvent | null {
+  if (!args.planJson) return null;
+  return buildArtifactPreviewEvent({
+    storyId: args.storyId,
+    chapterId: args.chapterId,
+    jobId: args.jobId,
+    artifactId: `plan:${args.chapterId}`,
+    artifactType: "plan",
+    title: `Chapter ${args.chapterId} Plan`,
+    status: args.blockedByCanonConflict || args.blockedByConflictReview ? "needs_approval" : "draft",
+    beatCount: beatCount(args.planJson),
+    previewLines: ["Plan artifact is available for review."],
+    actions: ["open_full", "edit", "regenerate"],
+  });
+}
+
+function draftPreviewFromArgs(args: ChapterWritingTimelineArgs): ArtifactPreviewTimelineEvent | null {
+  if (!args.proseReady) return null;
+  return buildArtifactPreviewEvent({
+    storyId: args.storyId,
+    chapterId: args.chapterId,
+    jobId: args.jobId,
+    artifactId: `draft:${args.chapterId}`,
+    artifactType: "draft",
+    title: `Chapter ${args.chapterId} Draft`,
+    status: "draft",
+    wordCount: args.wordCount,
+    previewLines: ["Draft created. Open the document editor to review the prose."],
+    actions: ["open_draft", "review_continuity", "edit_in_document"],
+  });
+}
+
+function importGateFromArgs(args: ChapterWritingTimelineArgs): ApprovalGateTimelineEvent | null {
+  if (!args.proseReady) return null;
+  return buildApprovalGateEvent({
+    storyId: args.storyId,
+    chapterId: args.chapterId,
+    jobId: args.jobId,
+    gateType: "import_to_editor",
+    description: "This draft can be moved into the editor, but it is not approved story content yet.",
+    actions: args.finalReviewReady ? ["import_to_editor", "keep_as_draft", "run_continuity_check"] : ["run_continuity_check", "keep_as_draft"],
+  });
+}
+
+function blockedFailureFromArgs(args: ChapterWritingTimelineArgs): FailureRecoveryTimelineEvent | null {
+  if (!args.blockedByCanonConflict && !args.blockedByConflictReview) return null;
+  return buildFailureRecoveryEvent({
+    storyId: args.storyId,
+    chapterId: args.chapterId,
+    jobId: args.jobId,
+    workflowName: "Chapter Write",
+    stoppedAtStep: "Planning",
+    reason: args.blockingReason || (args.blockedByCanonConflict ? "BLOCKED_BY_CANON_CONFLICT" : "BLOCKED_BY_CONFLICT_REVIEW"),
+    fallbackReason: "The chapter plan needs review before writing can continue.",
+    draftPreserved: args.proseReady,
+    detailLog: args.blockingReason ? [args.blockingReason] : [],
+  });
+}
+
+function taskFailureFromArgs(args: ChapterWritingTimelineArgs): FailureRecoveryTimelineEvent | null {
+  if (normalizeJobStatus(args.jobStatus) !== "failed" && args.latestTaskStatus?.toUpperCase() !== "FAILED") return null;
+  return buildFailureRecoveryEvent({
+    storyId: args.storyId,
+    chapterId: args.chapterId,
+    jobId: args.jobId,
+    workflowName: "Chapter Write",
+    stoppedAtStep: taskLabel(args.latestTaskType),
+    reason: args.latestTaskError,
+    fallbackReason: "The writing run stopped before completion.",
+    draftPreserved: args.proseReady,
+    detailLog: args.latestTaskError ? [args.latestTaskError] : [],
+  });
+}
+
+export function buildChapterWritingTimelineEvents(args: ChapterWritingTimelineArgs): TimelineEvent[] {
+  const taskSteps = args.narrativeTasks.map((task) => ({
+    label: taskLabel(task.task_type),
+    status: taskStatus(task.status),
+  }));
+  const currentStepLabel = taskLabel(args.latestTaskType) || "Read workflow state";
+  const events: TimelineEvent[] = [
+    buildWorkflowProgressEvent({
+      storyId: args.storyId,
+      chapterId: args.chapterId,
+      jobId: args.jobId,
+      workflowName: "Chapter Write",
+      jobStatus: args.jobStatus,
+      currentStepLabel,
+      steps: taskSteps.length > 0 ? taskSteps : [{ label: currentStepLabel, status: normalizeJobStatus(args.jobStatus) === "complete" ? "complete" : "active" }],
+    }),
+  ];
+  const optionalEvents: Array<TimelineEvent | null> = [planPreviewFromArgs(args), draftPreviewFromArgs(args), importGateFromArgs(args), blockedFailureFromArgs(args), taskFailureFromArgs(args)];
+  events.push(...optionalEvents.filter((event): event is TimelineEvent => Boolean(event)), contextDigestFromMemory(args));
+  return events;
+}

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -145,6 +145,7 @@ function resultBlock(result: CommandResult): TimelineBlock {
     return {
       id: "command-recovery",
       type: "failure_recovery",
+      source: "assistant",
       workflow_name: result.title,
       stopped_at_step: "Preflight",
       plain_reason: result.detail,
@@ -187,6 +188,7 @@ function buildTimelineBlocks(args: {
     blocks.push({
       id: "continuity-progress",
       type: "workflow_progress",
+      source: "backend",
       workflow_name: "Continuity Check",
       status: "running",
       current_step: 2,
@@ -205,6 +207,7 @@ function buildTimelineBlocks(args: {
     blocks.push({
       id: "draft-preview",
       type: "artifact_preview",
+      source: "backend",
       artifact_id: "current-draft",
       artifact_type: "draft",
       title: "Current chapter draft",

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -97,6 +97,11 @@ export type WorkflowStepStatus = "complete" | "active" | "pending" | "failed";
 
 export type WorkflowProgressBlock = {
   type: "workflow_progress";
+  source: "backend" | "assistant";
+  event_id?: string;
+  story_id?: number | null;
+  chapter_id?: string | null;
+  job_id?: number | null;
   workflow_name: string;
   status: "running" | "complete" | "failed" | "cancelled";
   current_step: number;
@@ -110,6 +115,11 @@ export type WorkflowProgressBlock = {
 
 export type ArtifactPreviewBlock = {
   type: "artifact_preview";
+  source: "backend" | "assistant";
+  event_id?: string;
+  story_id?: number | null;
+  chapter_id?: string | null;
+  job_id?: number | null;
   artifact_id: string;
   artifact_type: "plan" | "draft" | "analysis" | "review" | "research";
   title: string;
@@ -122,6 +132,11 @@ export type ArtifactPreviewBlock = {
 
 export type ApprovalGateBlock = {
   type: "approval_gate";
+  source: "backend" | "assistant";
+  event_id?: string;
+  story_id?: number | null;
+  chapter_id?: string | null;
+  job_id?: number | null;
   gate_type: "import_to_editor" | "promote_to_memory" | "publish_chapter" | "approve_plan";
   description: string;
   actions: string[];
@@ -129,15 +144,26 @@ export type ApprovalGateBlock = {
 
 export type FailureRecoveryBlock = {
   type: "failure_recovery";
+  source: "backend" | "assistant";
+  event_id?: string;
+  story_id?: number | null;
+  chapter_id?: string | null;
+  job_id?: number | null;
   workflow_name: string;
   stopped_at_step: string;
   plain_reason: string;
   draft_preserved: boolean;
   actions: string[];
+  detail_log?: string[];
+  details?: { reason_codes: string[] };
 };
 
 export type ContextDigestBlock = {
   type: "context_digest";
+  source: "backend" | "assistant";
+  event_id?: string;
+  story_id?: number | null;
+  chapter_id?: string | null;
   title: string;
   included: string[];
   missing: string[];

--- a/apps/studio/src/features/scenes/server/scenesApiService.ts
+++ b/apps/studio/src/features/scenes/server/scenesApiService.ts
@@ -22,6 +22,13 @@ import {
 } from "@/features/scenes/server/scenesApi/payloadBuilders";
 import { parseVirtualScenesFromText, VirtualScene } from "@/features/autowrite/server/virtualSceneProvider";
 import { enqueueChapterWriteV3, invalidateDownstream } from "@/features/autowrite/server/writingPipelineService";
+import {
+  buildApprovalGateEvent,
+  buildArtifactPreviewEvent,
+  buildChapterWritingTimelineEvents,
+  buildFailureRecoveryEvent,
+  buildWorkflowProgressEvent,
+} from "@/features/chat-orchestration/server/timelineEvents";
 
 function isWritingV2ProductionEnabled(): boolean {
   const raw = (process.env.WRITING_V2_PRODUCTION ?? "1").trim().toLowerCase();
@@ -634,11 +641,12 @@ export async function postChapterAutoWriteResponse(req: NextRequest, storySlug: 
     const blockedByConflictReview = Boolean(planObj?.blocked_by_conflict_review);
     const blockedByCanonConflict = Boolean(planObj?.blocked_by_canon_conflict);
     if (blockedByConflictReview || blockedByCanonConflict) {
+      const blockingReason = String(planObj?.blocked_reason || (blockedByConflictReview ? "BLOCKED_BY_CONFLICT_REVIEW" : "BLOCKED_BY_CANON_CONFLICT"));
       return NextResponse.json({
         ok: true,
         chapter_id: chapterId,
         status: blockedByConflictReview ? "BLOCKED_BY_CONFLICT_REVIEW" : "BLOCKED_BY_CANON_CONFLICT",
-        blocking_reason: String(planObj?.blocked_reason || (blockedByConflictReview ? "BLOCKED_BY_CONFLICT_REVIEW" : "BLOCKED_BY_CANON_CONFLICT")),
+        blocking_reason: blockingReason,
         plan: planResult.plan,
         writing_intent_mode: writingIntentMode,
         retcon_accepted: Boolean(planObj?.retcon_accepted),
@@ -655,6 +663,36 @@ export async function postChapterAutoWriteResponse(req: NextRequest, storySlug: 
         entity_merge_challenge_v1: Array.isArray(planObj?.entity_merge_challenge_v1) ? planObj.entity_merge_challenge_v1 : [],
         entity_resolution_cache_v1: planObj?.entity_resolution_cache_v1 ?? null,
         final_review_ready: false,
+        timeline_events: [
+          buildArtifactPreviewEvent({
+            storyId,
+            chapterId,
+            artifactId: `plan:${chapterId}`,
+            artifactType: "plan",
+            title: `Chapter ${chapterId} Plan`,
+            status: "needs_approval",
+            beatCount: Array.isArray(planObj?.beats) ? planObj.beats.length : null,
+            previewLines: ["Plan created, but it needs review before writing can continue."],
+            actions: ["open_full", "edit", "regenerate"],
+          }),
+          buildFailureRecoveryEvent({
+            storyId,
+            chapterId,
+            workflowName: "Chapter Write",
+            stoppedAtStep: "Planning",
+            reason: blockingReason,
+            fallbackReason: "The chapter plan needs review before writing can continue.",
+            draftPreserved: false,
+            detailLog: [blockingReason],
+          }),
+          buildApprovalGateEvent({
+            storyId,
+            chapterId,
+            gateType: "approve_plan",
+            description: "This plan needs your review before I can continue writing.",
+            actions: ["open_full", "edit", "regenerate"],
+          }),
+        ],
       });
     }
     const writingResult = await enqueueCanonicalChapterWriteV3({
@@ -696,11 +734,54 @@ export async function postChapterAutoWriteResponse(req: NextRequest, storySlug: 
       pre_chapter_profile_v1: planObj?.pre_chapter_profile_v1 ?? null,
       analysis_delta_report_v1: planObj?.analysis_delta_report_v1 ?? null,
       entity_merge_challenge_v1: Array.isArray(planObj?.entity_merge_challenge_v1) ? planObj.entity_merge_challenge_v1 : [],
+      timeline_events: [
+        buildWorkflowProgressEvent({
+          storyId,
+          chapterId,
+          jobId: writingResult.job_id ?? null,
+          workflowName: "Chapter Write",
+          jobStatus: writingResult.status,
+          currentStepLabel: "Write chapter draft",
+          steps: [
+            { label: "Create chapter plan", status: "complete" },
+            { label: "Write chapter draft", status: "active" },
+            { label: "Extract chapter ledger", status: "pending" },
+            { label: "Update memory rollup", status: "pending" },
+          ],
+        }),
+        buildArtifactPreviewEvent({
+          storyId,
+          chapterId,
+          jobId: writingResult.job_id ?? null,
+          artifactId: `plan:${chapterId}`,
+          artifactType: "plan",
+          title: `Chapter ${chapterId} Plan`,
+          status: "draft",
+          beatCount: Array.isArray(planObj?.beats) ? planObj.beats.length : null,
+          previewLines: ["Plan created and writing has started."],
+          actions: ["open_full", "edit", "regenerate"],
+        }),
+      ],
     });
   } catch (error: unknown) {
     const msg = getScenesApiErrorMessage(error, "AUTO_WRITE_FAILED");
     const status = msg.includes("BLOCKED_BY_CANON_CONFLICT") || msg.includes("BLOCKED_BY_CONFLICT_REVIEW") ? 409 : 500;
-    return NextResponse.json({ ok: false, error: msg }, { status });
+    return NextResponse.json({
+      ok: false,
+      error: msg,
+      timeline_events: [
+        buildFailureRecoveryEvent({
+          storyId: null,
+          chapterId,
+          workflowName: "Chapter Write",
+          stoppedAtStep: "Preflight",
+          reason: msg,
+          fallbackReason: "The writing run stopped before it could start.",
+          draftPreserved: false,
+          detailLog: [msg],
+        }),
+      ],
+    }, { status });
   }
 }
 
@@ -785,7 +866,22 @@ export async function postChapterExecuteControlResponse(req: NextRequest, storyS
       [jobId, storyId, chapterId]
     );
     if ((jobRes.rowCount ?? 0) === 0) {
-      return NextResponse.json({ ok: false, error: "JOB_NOT_FOUND" }, { status: 404 });
+      return NextResponse.json({
+        ok: false,
+        error: "JOB_NOT_FOUND",
+        timeline_events: [
+          buildFailureRecoveryEvent({
+            storyId,
+            chapterId,
+            workflowName: "Chapter Write",
+            stoppedAtStep: "Status lookup",
+            reason: "JOB_NOT_FOUND",
+            fallbackReason: "I couldn't find the writing run for this chapter.",
+            draftPreserved: false,
+            detailLog: ["JOB_NOT_FOUND"],
+          }),
+        ],
+      }, { status: 404 });
     }
     const currentStatus = String(jobRes.rows[0].status || "").toUpperCase();
     if (["DONE", "FAILED", "CANCELLED"].includes(currentStatus)) {
@@ -1142,7 +1238,6 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         : null;
     const resolutionStatus = typeof planJson?.resolution_status === "string" ? String(planJson.resolution_status) : null;
     const entityAssignments = Array.isArray(planJson?.entity_assignments) ? planJson?.entity_assignments : [];
-
     const planningInputPackJson = {
       source: "PERSISTED_PLAN_AND_JOB_CONFIG",
       job_id: job.id,
@@ -1185,6 +1280,26 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         error: row.error,
         updated_at: row.updated_at,
       };
+    });
+    const timelineEvents = buildChapterWritingTimelineEvents({
+      storyId,
+      chapterId,
+      jobId: job.id,
+      jobStatus,
+      doneTasks,
+      totalTasks,
+      latestTaskType: progress.latest_task_type,
+      latestTaskStatus: progress.latest_task_status,
+      latestTaskError: progress.latest_task_error,
+      narrativeTasks,
+      proseReady,
+      wordCount,
+      planJson,
+      memoryRuntimeV5,
+      finalReviewReady,
+      blockedByConflictReview,
+      blockedByCanonConflict,
+      blockingReason,
     });
     const proseTaskTypes = new Set(["CHAPTER_WRITE_V3", "NARRATIVE_STYLIST", "NARRATIVE_CRITIC", "NARRATIVE_REFINE", "NARRATIVE_FINALIZE"]);
     const reversedNarrativeTasks = [...narrativeTasks].reverse();
@@ -1333,10 +1448,26 @@ export async function getChapterWritingStatusResponse(req: NextRequest, storySlu
         cutoverRow?.parity_window_stats && typeof cutoverRow.parity_window_stats === "object" && !Array.isArray(cutoverRow.parity_window_stats)
           ? (cutoverRow.parity_window_stats as Record<string, unknown>)
           : {},
+      timeline_events: timelineEvents,
     });
   } catch (error: unknown) {
     const msg = getScenesApiErrorMessage(error, "WRITING_STATUS_FAILED");
-    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+    return NextResponse.json({
+      ok: false,
+      error: msg,
+      timeline_events: [
+        buildFailureRecoveryEvent({
+          storyId: null,
+          chapterId,
+          workflowName: "Chapter Write",
+          stoppedAtStep: "Status lookup",
+          reason: msg,
+          fallbackReason: "I couldn't read the writing run status.",
+          draftPreserved: false,
+          detailLog: [msg],
+        }),
+      ],
+    }, { status: 500 });
   }
 }
 

--- a/docs/operations/specs/studio-chat-orchestration-layer.md
+++ b/docs/operations/specs/studio-chat-orchestration-layer.md
@@ -213,6 +213,8 @@ The assistant may acknowledge backend-originated blocks with short text, but it 
 - Show workflow name, status, current step, total steps, and safe step labels.
 - Do not expose model scratchpad, chain-of-thought, stack traces, or raw logs in the primary card.
 - Composer remains available while workflow progress is running.
+- Polling transports may attach backend blocks as `timeline_events` on existing workflow status responses before durable event streaming exists.
+- Every backend event must include `source: "backend"`, story/chapter scope, and a workflow or artifact identifier when one exists.
 
 ### `artifact_preview`
 
@@ -234,6 +236,7 @@ The assistant may acknowledge backend-originated blocks with short text, but it 
 - Body is 1-2 plain-language sentences.
 - Failed drafts must remain accessible and must not be auto-discarded.
 - Include recovery actions such as retry, inspect details, keep draft, or cancel.
+- Raw reason codes and stack traces stay in collapsed details or Operations views. The primary reason must be plain language.
 
 ### `context_digest`
 


### PR DESCRIPTION
## Summary
- Adds backend timeline event DTO builders for workflow progress, artifacts, approval gates, failures, and context digests.
- Adds polling-compatible `timeline_events` payloads to chapter AutoWrite start/status/failure responses.
- Aligns frontend block types with backend event source metadata and documents the additive transport contract.

## Verification
- npm run typecheck
- npx eslint src/features/chat-orchestration/server/timelineEvents.ts src/features/chat-orchestration/server/timelineEvents.test.ts src/features/scenes/server/scenesApiService.ts src/features/scenes/components/writeTab/types.ts src/features/scenes/components/writeTab/CommandWorkStream.tsx
  - exits 0; existing scenesApiService warnings remain
- git diff --check
- npm run build

Closes #106
