### PR TITLE
feat: wire chat intents to workflow preflight

### DIFF
--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useRouter } from "next/navigation";
 import ChatComposer, { type ChatCommandOption } from "@/features/scenes/components/writeTab/chatOrchestration/ChatComposer";
 import ChatTimeline from "@/features/scenes/components/writeTab/chatOrchestration/ChatTimeline";
+import { routeStudioIntent } from "@/features/scenes/components/writeTab/chatOrchestration/intentRouter";
 import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
 import type {
   AssistantReadinessContext,
@@ -42,10 +43,14 @@ type CommandDefinition = {
 
 const commandDefinitions: CommandDefinition[] = [
   { id: "/write chapter", description: "Generate chapter draft", group: "primary", visible: true },
+  { id: "/plan", description: "Create chapter outline", group: "primary", visible: true },
   { id: "/analyze chapter", description: "Analyze source or context", group: "primary", visible: true },
+  { id: "/research", description: "Research story or worldbuilding context", group: "primary", visible: true },
+  { id: "/inspect", description: "Show full context digest", group: "primary", visible: true },
   { id: "/check continuity", description: "Review canon and timeline handoff", group: "primary", visible: true },
   { id: "/extract memory", description: "Open story memory extraction", group: "more", visible: true },
   { id: "/review chapter", description: "Open review panel", group: "more", visible: true },
+  { id: "/split", description: "Prepare chapter split request", group: "more", visible: true },
   {
     id: "/rewrite selection",
     description: "Rewrite selected prose",
@@ -89,7 +94,7 @@ function commandTail(command: CommandId, goal: string): string {
 }
 
 function contextWithCommandIntent(context: AssistantReadinessContext, command: CommandId, goal: string): AssistantReadinessContext {
-  if (command !== "/write chapter" && command !== "/analyze chapter") return context;
+  if (command !== "/write chapter" && command !== "/plan" && command !== "/analyze chapter" && command !== "/research") return context;
   return {
     ...context,
     availability: {
@@ -120,6 +125,9 @@ function buildCommands(context: AssistantReadinessContext, chapterId: string): C
       }
       if (command.id === "/check continuity" && !chapterId) {
         blockedReason = "Choose or create a chapter before checking continuity.";
+      }
+      if ((command.id === "/plan" || command.id === "/split") && !chapterId) {
+        blockedReason = "Choose or create a chapter before running this command.";
       }
 
       return {
@@ -167,9 +175,11 @@ function resultBlock(result: CommandResult): TimelineBlock {
 function buildTimelineBlocks(args: {
   briefing: ReturnType<typeof buildAssistantReadiness>;
   composerValue: string;
+  submittedMessage: string | null;
   hasDraft: boolean;
   continuityQueued: boolean;
   commandResult: CommandResult | null;
+  intentBlock: TimelineBlock | null;
 }): TimelineBlock[] {
   const blocks: TimelineBlock[] = [
     { id: "readiness", type: "readiness_card", briefing: args.briefing },
@@ -180,8 +190,9 @@ function buildTimelineBlocks(args: {
     },
   ];
 
-  if (args.composerValue.trim()) {
-    blocks.push({ id: "composer-echo", type: "text_message", source: "user", label: "You", text: args.composerValue.trim() });
+  const userText = args.submittedMessage || args.composerValue.trim();
+  if (userText) {
+    blocks.push({ id: "composer-echo", type: "text_message", source: "user", label: "You", text: userText });
   }
 
   if (args.continuityQueued) {
@@ -220,7 +231,57 @@ function buildTimelineBlocks(args: {
   }
 
   if (args.commandResult) blocks.push(resultBlock(args.commandResult));
+  if (args.intentBlock) blocks.push(args.intentBlock);
   return blocks;
+}
+
+function buildContextDigestBlock(context: AssistantReadinessContext): TimelineBlock {
+  const included = [
+    context.storySelected ? "Story selected" : "",
+    context.chapterId ? "Chapter selected" : "",
+    context.availability.has_source_chapters ? "Source material" : "",
+    context.availability.has_active_characters ? "Active characters" : "",
+    context.availability.has_memory_snapshot ? "Memory snapshot" : "",
+    context.availability.has_style_profile ? "Style profile" : "",
+    context.availability.has_immediate_continuity ? "Immediate continuity" : "",
+    context.availability.has_chapter_intent ? "Chapter intent" : "",
+  ].filter(Boolean);
+  const missing = [
+    context.storySelected ? "" : "Story selected",
+    context.chapterId ? "" : "Chapter selected",
+    context.availability.has_source_chapters ? "" : "Source material",
+    context.availability.has_active_characters ? "" : "Active characters",
+    context.availability.has_chapter_intent ? "" : "Chapter intent",
+  ].filter(Boolean);
+  const degraded = [
+    context.availability.has_memory_snapshot ? "" : "Memory snapshot",
+    context.availability.has_style_profile ? "" : "Style profile",
+    context.availability.has_immediate_continuity ? "" : "Immediate continuity",
+  ].filter(Boolean);
+
+  return {
+    id: "intent-context-digest",
+    type: "context_digest",
+    source: "assistant",
+    title: context.chapterId ? `Chapter ${context.chapterId} context` : "Current story context",
+    included,
+    missing,
+    degraded,
+    conflicts: context.readiness === "blocked" ? ["Current context is blocked for writing."] : [],
+  };
+}
+
+function approvalGateBlock(chapterId: string): TimelineBlock {
+  return {
+    id: "intent-approval-gate",
+    type: "approval_gate",
+    source: "assistant",
+    gate_type: "import_to_editor",
+    description: chapterId
+      ? "This needs your sign-off before I can continue. Importing to the editor does not approve story memory or publish the chapter."
+      : "Choose a chapter before approving or importing draft content.",
+    actions: ["import_to_editor", "keep_as_draft", "run_continuity_check"],
+  };
 }
 
 function useCommandRunner(args: {
@@ -232,9 +293,11 @@ function useCommandRunner(args: {
 }) {
   const router = useRouter();
   const [commandResult, setCommandResult] = React.useState<CommandResult | null>(null);
+  const [intentBlock, setIntentBlock] = React.useState<TimelineBlock | null>(null);
 
   const runCommand = React.useCallback(
     (command: CommandId, goal: string) => {
+      setIntentBlock(null);
       const definition = commandDefinition(command);
       if (definition?.visible === false) {
         setCommandResult({
@@ -247,6 +310,52 @@ function useCommandRunner(args: {
 
       const storyBase = `/stories/${encodeURIComponent(args.storySlug)}`;
       const commandContext = contextWithCommandIntent(args.readinessContext, command, goal);
+      if (command === "/inspect" || command === "/status") {
+        setIntentBlock(buildContextDigestBlock(commandContext));
+        setCommandResult({ tone: "ready", title: "Context digest ready", detail: "I found the current story and chapter context state." });
+        return;
+      }
+
+      if (command === "/approve draft") {
+        setIntentBlock(approvalGateBlock(args.chapterId));
+        setCommandResult({ tone: "blocked", title: "Approval required", detail: "I surfaced the approval gate, but I cannot approve or promote the draft for you." });
+        return;
+      }
+
+      if (command === "/plan") {
+        if (!args.chapterId) {
+          setCommandResult({ tone: "blocked", title: "Chapter Planning", detail: "Choose or create a chapter before planning." });
+          return;
+        }
+        if (!goal.trim()) {
+          setCommandResult({ tone: "blocked", title: "Chapter Planning", detail: "I need to know what this chapter should accomplish before planning." });
+          return;
+        }
+        const readiness = buildAssistantReadiness(commandContext);
+        if (readiness.status === "blocked") {
+          setCommandResult({ tone: "blocked", title: "Chapter Planning", detail: readiness.blockedWriteReason ?? "The chapter context is blocked. Add missing context before planning." });
+          return;
+        }
+        args.onOpenAutoWrite();
+        setCommandResult({ tone: "running", title: "Planning preflight passed", detail: "The AutoWrite planner is ready to continue with your chapter goal." });
+        return;
+      }
+
+      if (command === "/research") {
+        router.push(`${storyBase}/analysis`);
+        setCommandResult({ tone: "ready", title: "Opening research context", detail: "Research and source analysis continue in the analysis workspace." });
+        return;
+      }
+
+      if (command === "/split") {
+        if (!args.chapterId) {
+          setCommandResult({ tone: "blocked", title: "Chapter Split", detail: "Choose or create a chapter before splitting." });
+          return;
+        }
+        setCommandResult({ tone: "ready", title: "Split request captured", detail: "Chapter splitting remains gated by the artifact workflow; review the current draft before running the split pipeline." });
+        return;
+      }
+
       if (command === "/write chapter") {
         const readiness = buildAssistantReadiness(commandContext);
         if (!readiness.canWrite) {
@@ -295,14 +404,39 @@ function useCommandRunner(args: {
     [args, router]
   );
 
-  return { commandResult, runCommand };
+  const submitMessage = React.useCallback((message: string) => {
+    const route = routeStudioIntent({ message, readiness: args.readinessContext.readiness });
+    setIntentBlock(null);
+    if (route.intent === "SWITCH_STORY") {
+      router.push("/shelf");
+      setCommandResult({ tone: "ready", title: "Opening story selector", detail: "Choose the story you want to work on next." });
+      return;
+    }
+    if (route.intent === "ADD_CONTEXT") {
+      router.push(`/stories/${encodeURIComponent(args.storySlug)}/analysis`);
+      setCommandResult({ tone: "ready", title: "Opening context tools", detail: "Add or analyze story context before writing." });
+      return;
+    }
+    if (route.intent === "BRAINSTORM") {
+      setCommandResult({ tone: "ready", title: "Brainstorm mode", detail: route.assistantText ?? "I can brainstorm here without starting a writing workflow." });
+      return;
+    }
+    if (route.needsClarification) {
+      setCommandResult({ tone: "ready", title: "Clarify intent", detail: route.assistantText ?? "Which writing action should I help with?" });
+      return;
+    }
+    if (route.command) runCommand(route.command, route.goal);
+  }, [args.readinessContext.readiness, args.storySlug, router, runCommand]);
+
+  return { commandResult, intentBlock, runCommand, submitMessage };
 }
 
 export default function CommandWorkStream(props: CommandWorkStreamProps) {
   const router = useRouter();
+  const [submittedMessage, setSubmittedMessage] = React.useState<string | null>(null);
   const briefing = buildAssistantReadiness(props.assistantContext);
   const commands = buildCommands(props.assistantContext, props.chapterId);
-  const { commandResult, runCommand } = useCommandRunner({
+  const { commandResult, intentBlock, runCommand, submitMessage } = useCommandRunner({
     storySlug: props.storySlug,
     chapterId: props.chapterId,
     onOpenAutoWrite: props.onOpenAutoWrite,
@@ -312,9 +446,11 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
   const blocks = buildTimelineBlocks({
     briefing,
     composerValue: props.composerValue,
+    submittedMessage,
     hasDraft: props.hasDraft,
     continuityQueued: props.continuityQueued,
     commandResult,
+    intentBlock,
   });
 
   const handleChip = (chip: RecoveryChip) => {
@@ -337,8 +473,15 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
         onValueChange={props.onComposerValueChange}
         onMenuOpenChange={props.onCommandMenuOpenChange}
         onSubmitCommand={(command, goal) => {
+          setSubmittedMessage(null);
           props.onComposerValueChange(commandTail(command, goal));
           runCommand(command, goal);
+        }}
+        onSubmitMessage={(message) => {
+          setSubmittedMessage(message);
+          props.onComposerValueChange("");
+          props.onCommandMenuOpenChange(false);
+          submitMessage(message);
         }}
       />
     </section>

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx
@@ -24,6 +24,7 @@ type ChatComposerProps = {
   onValueChange: (value: string) => void;
   onMenuOpenChange: (value: boolean) => void;
   onSubmitCommand: (command: CommandId, goal: string) => void;
+  onSubmitMessage: (message: string) => void;
 };
 
 const defaultDraft: CommandFormDraft = {
@@ -101,7 +102,7 @@ function CommandForm({
   onCancel: () => void;
   onSubmit: () => void;
 }) {
-  const isWrite = command === "/write chapter";
+  const isGoalCommand = command === "/write chapter" || command === "/plan" || command === "/research";
   const isAnalyze = command === "/analyze chapter" || command === "/extract memory";
 
   return (
@@ -119,26 +120,28 @@ function CommandForm({
         </button>
       </div>
 
-      {isWrite ? (
+      {isGoalCommand ? (
         <>
           <label>
             <span>Goal</span>
             <input value={draft.goal} onChange={(event) => onDraftChange({ ...draft, goal: event.target.value })} placeholder="What should this chapter accomplish?" />
           </label>
-          <div className="command-form__grid">
-            <label>
-              <span>Mode</span>
-              <select value={draft.mode} onChange={(event) => onDraftChange({ ...draft, mode: event.target.value as CommandFormDraft["mode"] })}>
-                <option value="plan_first">Plan first</option>
-                <option value="direct">Direct</option>
-                <option value="research_first">Research first</option>
-              </select>
-            </label>
-            <label>
-              <span>Word target</span>
-              <input type="number" min={300} max={10000} step={100} value={draft.wordTarget} onChange={(event) => onDraftChange({ ...draft, wordTarget: Number(event.target.value) })} />
-            </label>
-          </div>
+          {command === "/write chapter" ? (
+            <div className="command-form__grid">
+              <label>
+                <span>Mode</span>
+                <select value={draft.mode} onChange={(event) => onDraftChange({ ...draft, mode: event.target.value as CommandFormDraft["mode"] })}>
+                  <option value="plan_first">Plan first</option>
+                  <option value="direct">Direct</option>
+                  <option value="research_first">Research first</option>
+                </select>
+              </label>
+              <label>
+                <span>Word target</span>
+                <input type="number" min={300} max={10000} step={100} value={draft.wordTarget} onChange={(event) => onDraftChange({ ...draft, wordTarget: Number(event.target.value) })} />
+              </label>
+            </div>
+          ) : null}
         </>
       ) : null}
 
@@ -163,7 +166,7 @@ function CommandForm({
         </div>
       ) : null}
 
-      {!isWrite && !isAnalyze ? <p>Run preflight for {commandLabel(command)} using the current story and chapter context.</p> : null}
+      {!isGoalCommand && !isAnalyze ? <p>Run preflight for {commandLabel(command)} using the current story and chapter context.</p> : null}
 
       <div className="command-form__actions">
         <button type="submit" className="primary-action px-3 py-2 text-xs">
@@ -174,7 +177,7 @@ function CommandForm({
   );
 }
 
-export default function ChatComposer({ value, menuOpen, commands, onValueChange, onMenuOpenChange, onSubmitCommand }: ChatComposerProps) {
+export default function ChatComposer({ value, menuOpen, commands, onValueChange, onMenuOpenChange, onSubmitCommand, onSubmitMessage }: ChatComposerProps) {
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [activeCommand, setActiveCommand] = React.useState<CommandId | null>(null);
   const [draft, setDraft] = React.useState<CommandFormDraft>(defaultDraft);
@@ -225,8 +228,14 @@ export default function ChatComposer({ value, menuOpen, commands, onValueChange,
           className="work-composer"
           onSubmit={(event) => {
             event.preventDefault();
-            const selected = filteredCommands[activeIndex] ?? commands.find((command) => value.trimStart().startsWith(command.id));
-            if (selected) selectCommand(selected);
+            const text = value.trim();
+            if (!text) return;
+            if (state === "slash_command_menu" || text.startsWith("/")) {
+              const selected = filteredCommands[activeIndex] ?? commands.find((command) => text.startsWith(command.id));
+              if (selected) selectCommand(selected);
+              return;
+            }
+            onSubmitMessage(text);
           }}
           onKeyDown={(event) => {
             if (state !== "slash_command_menu") return;

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts
@@ -1,0 +1,27 @@
+import { detectStudioIntent, routeStudioIntent } from "@/features/scenes/components/writeTab/chatOrchestration/intentRouter";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+export function runIntentRouterSelfTest(): void {
+  assert(detectStudioIntent("continue") === "WRITE", "continue maps to WRITE");
+  assert(detectStudioIntent("plan first") === "PLAN", "plan first maps to PLAN");
+  assert(detectStudioIntent("analyze source") === "ANALYZE", "analyze source maps to ANALYZE");
+  assert(detectStudioIntent("research worldbuilding") === "RESEARCH", "research maps to RESEARCH");
+  assert(detectStudioIntent("switch story") === "SWITCH_STORY", "switch story maps to SWITCH_STORY");
+  assert(detectStudioIntent("add characters") === "ADD_CONTEXT", "add characters maps to ADD_CONTEXT");
+  assert(detectStudioIntent("brainstorm with me, no writing yet") === "BRAINSTORM", "brainstorm maps to BRAINSTORM");
+  assert(detectStudioIntent("review what was written") === "REVIEW", "review maps to REVIEW");
+  assert(detectStudioIntent("split this chapter") === "SPLIT", "split maps to SPLIT");
+  assert(detectStudioIntent("inspect context") === "INSPECT", "inspect maps to INSPECT");
+  assert(detectStudioIntent("approve this") === "APPROVE", "approve maps to APPROVE");
+
+  const ambiguous = routeStudioIntent({ message: "maybe later", readiness: "degraded" });
+  assert(ambiguous.needsClarification && ambiguous.assistantText !== null, "ambiguous input asks one clarifying question");
+
+  const blockedWrite = routeStudioIntent({ message: "continue", readiness: "blocked" });
+  assert(blockedWrite.command === "/write chapter", "blocked write still routes through preflight");
+}
+
+runIntentRouterSelfTest();

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
@@ -1,0 +1,99 @@
+import type { CommandId, ContextReadiness, StudioChatIntent } from "@/features/scenes/components/writeTab/types";
+
+export type IntentRoute = {
+  intent: StudioChatIntent;
+  command: CommandId | null;
+  goal: string;
+  needsClarification: boolean;
+  assistantText: string | null;
+};
+
+type RouteIntentArgs = {
+  message: string;
+  readiness: ContextReadiness;
+};
+
+const commandByIntent: Partial<Record<StudioChatIntent, CommandId>> = {
+  WRITE: "/write chapter",
+  PLAN: "/plan",
+  ANALYZE: "/analyze chapter",
+  RESEARCH: "/research",
+  REVIEW: "/review chapter",
+  SPLIT: "/split",
+  INSPECT: "/inspect",
+  APPROVE: "/approve draft",
+};
+
+function normalizedMessage(message: string): string {
+  return message.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function includesAny(message: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(message));
+}
+
+export function detectStudioIntent(message: string): StudioChatIntent {
+  const text = normalizedMessage(message);
+  if (!text) return "AMBIGUOUS";
+  if (includesAny(text, [/\bbrainstorm\b/, /\bno writing\b/, /\bno draft\b/, /\bjust chat\b/, /\btalk freely\b/])) return "BRAINSTORM";
+  if (includesAny(text, [/\bswitch story\b/, /\bbrowse stories\b/, /\buse .* story\b/])) return "SWITCH_STORY";
+  if (includesAny(text, [/\badd context\b/, /\badd characters?\b/, /\bmissing context\b/, /\bcharacter data\b/])) return "ADD_CONTEXT";
+  if (includesAny(text, [/\binspect context\b/, /\bwhat do you know\b/, /\bshow context\b/, /^\/?status\b/])) return "INSPECT";
+  if (includesAny(text, [/\bapprove\b/, /\blooks good\b/, /\bsign off\b/])) return "APPROVE";
+  if (includesAny(text, [/\banaly[sz]e\b/, /\bsource\b/, /\bdiagnos(e|tic)\b/])) return "ANALYZE";
+  if (includesAny(text, [/\bresearch\b/, /\blore\b/, /\bworldbuilding\b/])) return "RESEARCH";
+  if (includesAny(text, [/\bplan first\b/, /\boutline\b/, /\bchapter plan\b/, /\bplan\b/])) return "PLAN";
+  if (includesAny(text, [/\breview\b/, /\bshow draft\b/, /\bopen draft\b/])) return "REVIEW";
+  if (includesAny(text, [/\bsplit\b/, /\btoo long\b/, /\bbreak.*chapter\b/])) return "SPLIT";
+  if (includesAny(text, [/\bcontinue\b/, /\bkeep writing\b/, /\blet'?s go\b/, /\bwrite\b/, /\bdraft\b/])) return "WRITE";
+  return "AMBIGUOUS";
+}
+
+function goalFromMessage(message: string, intent: StudioChatIntent): string {
+  const text = message.trim();
+  if (intent === "WRITE") return text.replace(/^(continue|keep writing|let'?s go|write|draft)\b[:,\s-]*/i, "").trim();
+  if (intent === "PLAN") return text.replace(/^(plan first|outline|chapter plan|plan)\b[:,\s-]*/i, "").trim();
+  return text;
+}
+
+export function routeStudioIntent(args: RouteIntentArgs): IntentRoute {
+  const intent = detectStudioIntent(args.message);
+  const goal = goalFromMessage(args.message, intent);
+  if (intent === "AMBIGUOUS") {
+    return {
+      intent,
+      command: null,
+      goal: "",
+      needsClarification: true,
+      assistantText: "Do you want to brainstorm, inspect context, analyze source, or write the chapter?",
+    };
+  }
+  if (intent === "BRAINSTORM") {
+    return {
+      intent,
+      command: null,
+      goal,
+      needsClarification: false,
+      assistantText: "I can brainstorm here without starting a writing workflow.",
+    };
+  }
+  if (intent === "SWITCH_STORY" || intent === "ADD_CONTEXT") {
+    return { intent, command: null, goal, needsClarification: false, assistantText: null };
+  }
+  if (intent === "WRITE" && args.readiness === "blocked" && !goal) {
+    return {
+      intent,
+      command: "/write chapter",
+      goal,
+      needsClarification: false,
+      assistantText: null,
+    };
+  }
+  return {
+    intent,
+    command: commandByIntent[intent] ?? null,
+    goal,
+    needsClarification: false,
+    assistantText: null,
+  };
+}

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -83,6 +83,20 @@ export type AssistantReadinessBriefing = {
 
 export type ComposerState = "idle" | "typing" | "slash_command_menu" | "command_form_active";
 
+export type StudioChatIntent =
+  | "WRITE"
+  | "PLAN"
+  | "ANALYZE"
+  | "RESEARCH"
+  | "SWITCH_STORY"
+  | "ADD_CONTEXT"
+  | "BRAINSTORM"
+  | "REVIEW"
+  | "SPLIT"
+  | "INSPECT"
+  | "APPROVE"
+  | "AMBIGUOUS";
+
 export type ChatContextMiniBarPayload = {
   storyTitle: string;
   chapterLabel: string;
@@ -185,7 +199,9 @@ export type ArtifactKind = "document" | "analysis" | "review" | "memory" | "publ
 
 export type CommandId =
   | "/write chapter"
+  | "/plan"
   | "/analyze chapter"
+  | "/research"
   | "/rewrite selection"
   | "/continue from cursor"
   | "/check continuity"
@@ -194,6 +210,7 @@ export type CommandId =
   | "/approve draft"
   | "/publish preview"
   | "/status"
+  | "/inspect"
   | "/split";
 
 export type HeaderContextPayload = {


### PR DESCRIPTION
## Summary
- Adds deterministic intent routing for write, plan, analyze, research, switch story, add context, brainstorm, review, split, inspect, and approve.
- Allows the Studio composer to submit free-text messages as chat intents, while slash commands still use compact command forms.
- Routes blocked workflow actions to recovery/context/approval timeline blocks instead of silent failure or direct mutation.

## Verification
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts src/features/scenes/components/writeTab/types.ts
  - exits 0; complexity warnings remain in the orchestration UI file
- git diff --check
- npm run build

Closes #107
