### PR TITLE
fix: keep studio chat in conversation mode

### DIFF
--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -175,7 +175,7 @@ function resultBlock(result: CommandResult): TimelineBlock {
 function buildTimelineBlocks(args: {
   briefing: ReturnType<typeof buildAssistantReadiness>;
   composerValue: string;
-  submittedMessage: string | null;
+  conversationBlocks: TimelineBlock[];
   hasDraft: boolean;
   continuityQueued: boolean;
   commandResult: CommandResult | null;
@@ -190,9 +190,10 @@ function buildTimelineBlocks(args: {
     },
   ];
 
-  const userText = args.submittedMessage || args.composerValue.trim();
-  if (userText) {
-    blocks.push({ id: "composer-echo", type: "text_message", source: "user", label: "You", text: userText });
+  blocks.push(...args.conversationBlocks);
+
+  if (args.composerValue.trim()) {
+    blocks.push({ id: "composer-echo", type: "text_message", source: "user", label: "You", text: args.composerValue.trim() });
   }
 
   if (args.continuityQueued) {
@@ -290,6 +291,9 @@ function useCommandRunner(args: {
   onOpenAutoWrite: () => void;
   onQueueContinuity: () => void;
   readinessContext: AssistantReadinessContext;
+  mode: "chat" | "brainstorm";
+  onModeChange: (mode: "chat" | "brainstorm") => void;
+  onConversationBlock: (block: TimelineBlock) => void;
 }) {
   const router = useRouter();
   const [commandResult, setCommandResult] = React.useState<CommandResult | null>(null);
@@ -405,7 +409,7 @@ function useCommandRunner(args: {
   );
 
   const submitMessage = React.useCallback((message: string) => {
-    const route = routeStudioIntent({ message, readiness: args.readinessContext.readiness });
+    const route = routeStudioIntent({ message, readiness: args.readinessContext.readiness, mode: args.mode });
     setIntentBlock(null);
     if (route.intent === "SWITCH_STORY") {
       router.push("/shelf");
@@ -418,22 +422,49 @@ function useCommandRunner(args: {
       return;
     }
     if (route.intent === "BRAINSTORM") {
-      setCommandResult({ tone: "ready", title: "Brainstorm mode", detail: route.assistantText ?? "I can brainstorm here without starting a writing workflow." });
+      args.onModeChange("brainstorm");
+      args.onConversationBlock({
+        id: `assistant-${Date.now()}`,
+        type: "text_message",
+        source: "assistant",
+        label: "Studio Writing Assistant",
+        text: route.assistantText ?? "I can brainstorm here without starting a writing workflow.",
+        tone: "ready",
+      });
+      return;
+    }
+    if (route.intent === "CHAT") {
+      args.onConversationBlock({
+        id: `assistant-${Date.now()}`,
+        type: "text_message",
+        source: "assistant",
+        label: "Studio Writing Assistant",
+        text: route.assistantText ?? "Hi. I can chat freely or help with writing workflows when you ask.",
+        tone: "ready",
+      });
       return;
     }
     if (route.needsClarification) {
-      setCommandResult({ tone: "ready", title: "Clarify intent", detail: route.assistantText ?? "Which writing action should I help with?" });
+      args.onConversationBlock({
+        id: `assistant-${Date.now()}`,
+        type: "text_message",
+        source: "assistant",
+        label: "Studio Writing Assistant",
+        text: route.assistantText ?? "Which writing action should I help with?",
+        tone: "ready",
+      });
       return;
     }
     if (route.command) runCommand(route.command, route.goal);
-  }, [args.readinessContext.readiness, args.storySlug, router, runCommand]);
+  }, [args, router, runCommand]);
 
   return { commandResult, intentBlock, runCommand, submitMessage };
 }
 
 export default function CommandWorkStream(props: CommandWorkStreamProps) {
   const router = useRouter();
-  const [submittedMessage, setSubmittedMessage] = React.useState<string | null>(null);
+  const [chatMode, setChatMode] = React.useState<"chat" | "brainstorm">("chat");
+  const [conversationBlocks, setConversationBlocks] = React.useState<TimelineBlock[]>([]);
   const briefing = buildAssistantReadiness(props.assistantContext);
   const commands = buildCommands(props.assistantContext, props.chapterId);
   const { commandResult, intentBlock, runCommand, submitMessage } = useCommandRunner({
@@ -442,11 +473,14 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     onOpenAutoWrite: props.onOpenAutoWrite,
     onQueueContinuity: props.onQueueContinuity,
     readinessContext: props.assistantContext,
+    mode: chatMode,
+    onModeChange: setChatMode,
+    onConversationBlock: (block) => setConversationBlocks((current) => [...current, block]),
   });
   const blocks = buildTimelineBlocks({
     briefing,
     composerValue: props.composerValue,
-    submittedMessage,
+    conversationBlocks,
     hasDraft: props.hasDraft,
     continuityQueued: props.continuityQueued,
     commandResult,
@@ -473,16 +507,19 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
         onValueChange={props.onComposerValueChange}
         onMenuOpenChange={props.onCommandMenuOpenChange}
         onSubmitCommand={(command, goal) => {
-          setSubmittedMessage(null);
           props.onComposerValueChange(commandTail(command, goal));
           runCommand(command, goal);
         }}
         onSubmitMessage={(message) => {
-          setSubmittedMessage(message);
+          setConversationBlocks((current) => [
+            ...current,
+            { id: `user-${Date.now()}`, type: "text_message", source: "user", label: "You", text: message },
+          ]);
           props.onComposerValueChange("");
           props.onCommandMenuOpenChange(false);
           submitMessage(message);
         }}
+        mode={chatMode}
       />
     </section>
   );

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -234,7 +234,7 @@ function WorkspaceAutoWriteModal(
 export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
   const { isArtifactVisible } = useStory();
   const [continuityQueued, setContinuityQueued] = useState(false);
-  const [composerValue, setComposerValue] = useState(props.selectedChapterId ? `/write chapter ${props.selectedChapterId} ` : "");
+  const [composerValue, setComposerValue] = useState("");
   const [commandMenuOpen, setCommandMenuOpen] = useState(false);
   const draftSource = useMemo(() => buildDraftSource(props), [props]);
   const chapterTitle = selectedChapterTitle(props.selectedChapterId);

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx
@@ -25,6 +25,7 @@ type ChatComposerProps = {
   onMenuOpenChange: (value: boolean) => void;
   onSubmitCommand: (command: CommandId, goal: string) => void;
   onSubmitMessage: (message: string) => void;
+  mode: "chat" | "brainstorm";
 };
 
 const defaultDraft: CommandFormDraft = {
@@ -177,7 +178,7 @@ function CommandForm({
   );
 }
 
-export default function ChatComposer({ value, menuOpen, commands, onValueChange, onMenuOpenChange, onSubmitCommand, onSubmitMessage }: ChatComposerProps) {
+export default function ChatComposer({ value, menuOpen, commands, onValueChange, onMenuOpenChange, onSubmitCommand, onSubmitMessage, mode }: ChatComposerProps) {
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [activeCommand, setActiveCommand] = React.useState<CommandId | null>(null);
   const [draft, setDraft] = React.useState<CommandFormDraft>(defaultDraft);
@@ -257,8 +258,8 @@ export default function ChatComposer({ value, menuOpen, commands, onValueChange,
             /
           </button>
           <input value={value} onChange={(event) => onValueChange(event.target.value)} placeholder="Type a message or / for commands" aria-label="Studio chat composer" />
-          <button type="submit" className="primary-action px-3 py-2 text-xs" title="Run preflight">
-            Run
+          <button type="submit" className="primary-action px-3 py-2 text-xs" title={state === "slash_command_menu" ? "Run preflight" : "Send message"}>
+            {state === "slash_command_menu" ? "Run" : mode === "brainstorm" ? "Send" : "Send"}
           </button>
         </form>
       )}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts
@@ -5,6 +5,7 @@ function assert(condition: boolean, message: string): void {
 }
 
 export function runIntentRouterSelfTest(): void {
+  assert(detectStudioIntent("Hi") === "CHAT", "greeting maps to CHAT");
   assert(detectStudioIntent("continue") === "WRITE", "continue maps to WRITE");
   assert(detectStudioIntent("plan first") === "PLAN", "plan first maps to PLAN");
   assert(detectStudioIntent("analyze source") === "ANALYZE", "analyze source maps to ANALYZE");
@@ -19,6 +20,9 @@ export function runIntentRouterSelfTest(): void {
 
   const ambiguous = routeStudioIntent({ message: "maybe later", readiness: "degraded" });
   assert(ambiguous.needsClarification && ambiguous.assistantText !== null, "ambiguous input asks one clarifying question");
+
+  const brainstormFollowup = routeStudioIntent({ message: "maybe a betrayal scene", readiness: "degraded", mode: "brainstorm" });
+  assert(brainstormFollowup.intent === "BRAINSTORM" && !brainstormFollowup.needsClarification, "brainstorm mode keeps free chat active");
 
   const blockedWrite = routeStudioIntent({ message: "continue", readiness: "blocked" });
   assert(blockedWrite.command === "/write chapter", "blocked write still routes through preflight");

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
@@ -11,6 +11,7 @@ export type IntentRoute = {
 type RouteIntentArgs = {
   message: string;
   readiness: ContextReadiness;
+  mode?: "chat" | "brainstorm";
 };
 
 const commandByIntent: Partial<Record<StudioChatIntent, CommandId>> = {
@@ -35,6 +36,7 @@ function includesAny(message: string, patterns: RegExp[]): boolean {
 export function detectStudioIntent(message: string): StudioChatIntent {
   const text = normalizedMessage(message);
   if (!text) return "AMBIGUOUS";
+  if (includesAny(text, [/^(hi|hello|hey|yo|chao|xin chao|chào)$/i, /\bhow are you\b/])) return "CHAT";
   if (includesAny(text, [/\bbrainstorm\b/, /\bno writing\b/, /\bno draft\b/, /\bjust chat\b/, /\btalk freely\b/])) return "BRAINSTORM";
   if (includesAny(text, [/\bswitch story\b/, /\bbrowse stories\b/, /\buse .* story\b/])) return "SWITCH_STORY";
   if (includesAny(text, [/\badd context\b/, /\badd characters?\b/, /\bmissing context\b/, /\bcharacter data\b/])) return "ADD_CONTEXT";
@@ -59,6 +61,24 @@ function goalFromMessage(message: string, intent: StudioChatIntent): string {
 export function routeStudioIntent(args: RouteIntentArgs): IntentRoute {
   const intent = detectStudioIntent(args.message);
   const goal = goalFromMessage(args.message, intent);
+  if (args.mode === "brainstorm" && intent === "AMBIGUOUS") {
+    return {
+      intent: "BRAINSTORM",
+      command: null,
+      goal: args.message.trim(),
+      needsClarification: false,
+      assistantText: "I can keep brainstorming here without starting a workflow. Tell me the direction, conflict, character, or scene problem you want to explore.",
+    };
+  }
+  if (intent === "CHAT") {
+    return {
+      intent,
+      command: null,
+      goal,
+      needsClarification: false,
+      assistantText: "Hi. I can chat freely, brainstorm, inspect context, analyze source, or help write when you're ready.",
+    };
+  }
   if (intent === "AMBIGUOUS") {
     return {
       intent,

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -84,6 +84,7 @@ export type AssistantReadinessBriefing = {
 export type ComposerState = "idle" | "typing" | "slash_command_menu" | "command_form_active";
 
 export type StudioChatIntent =
+  | "CHAT"
   | "WRITE"
   | "PLAN"
   | "ANALYZE"


### PR DESCRIPTION
## Summary
- Treats greetings like "hi" as normal chat instead of ambiguous workflow intent.
- Persists free-chat/brainstorm messages in the timeline so brainstorm mode does not snap back to the previous clarification state.
- Starts the composer empty and changes the main free-text submit button to "Send"; slash command mode still uses Run/preflight behavior.

## Verification
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts src/features/scenes/components/writeTab/types.ts src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
  - exits 0; existing orchestration complexity warnings remain
- git diff --check
- npm run build
