### PR TITLE
fix: align chat timeline block contracts

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -48,6 +48,16 @@ Refactor direction for large modules:
   - `src/features/scenes/components/writeTab/NovelLabWorkspace.tsx` (Novel Lab command/artifact Write slice)
   - `src/features/scenes/components/writeTab/ArtifactSurface.tsx` owns state-backed Read/Edit/Analyze/Review/Approve artifact tabs, local approval gate display, and reader/publish handoff.
   - `src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx` renders artifact diagnostics from current workflow state, not static preview content.
+
+### Write workspace chat block contracts
+
+- Chat artifact summary cards use the `artifact_preview` timeline block contract. The chat timeline renders a compact card with title, status, short description, and actions; full artifact or document content stays in the artifact panel or document workspace.
+- Workflow progress uses `workflow_progress` blocks mapped from backend-shaped pipeline/job events. The chat timeline renders compact progress, while the right inspector renders detailed step state. Worker logs and diagnostics stay in Operations surfaces.
+- Right inspector modes reuse timeline block contracts where possible:
+  - Context uses `context_digest` shaped data.
+  - Progress uses `workflow_progress`.
+  - Artifacts use `artifact_preview`.
+  - Memory/continuity remains a read-only snapshot view unless a dedicated block contract is added.
 - Dictionary & Shelf:
   - `src/features/dictionary/components/DictionaryManager.tsx`
   - `src/app/shelf/page.tsx`

--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
@@ -1,7 +1,16 @@
 import { useState, type MouseEvent as ReactMouseEvent } from "react";
-import type { ContextReadiness, ContextReadinessLabel } from "@/features/scenes/components/writeTab/types";
+import {
+  ArtifactPreviewBlockView,
+  ContextDigestBlockView,
+  WorkflowProgressBlockView,
+} from "@/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks";
+import {
+  continuityWorkflowProgressEvent,
+  workflowProgressBlockFromEvent,
+} from "@/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents";
+import type { ContextReadiness, ContextReadinessLabel, TimelineBlock } from "@/features/scenes/components/writeTab/types";
 
-type InspectorTab = "Progress" | "Context" | "Issues" | "Memory" | "Versions";
+type InspectorTab = "Progress" | "Context" | "Artifacts" | "Memory";
 
 type ArtifactInspectorRailProps = {
   readiness: ContextReadiness;
@@ -36,12 +45,8 @@ function readinessClass(readiness: ContextReadiness): string {
 }
 
 function progressPercent(diagnostics: ArtifactInspectorDiagnostics, continuityQueued: boolean) {
-  const completed =
-    Number(diagnostics.hasChapter) +
-    Number(diagnostics.hasDraft) +
-    Number(continuityQueued || diagnostics.canApprove) +
-    Number(diagnostics.canApprove);
-  return Math.max(8, Math.round((completed / 4) * 100));
+  const workflowBlock = buildWorkflowBlock(diagnostics, continuityQueued);
+  return Math.max(8, Math.round((workflowBlock.current_step / workflowBlock.total_steps) * 100));
 }
 
 function warningCount(readiness: ContextReadiness, diagnostics: ArtifactInspectorDiagnostics, continuityQueued: boolean) {
@@ -54,100 +59,89 @@ function warningCount(readiness: ContextReadiness, diagnostics: ArtifactInspecto
   ].filter(Boolean).length;
 }
 
-function workflowSteps(diagnostics: ArtifactInspectorDiagnostics, continuityQueued: boolean) {
-  return [
-    {
-      label: "Chapter",
-      status: diagnostics.hasChapter ? "Done" : "Locked",
-      note: diagnostics.hasChapter ? diagnostics.chapterId : "Select or create a chapter",
-    },
-    {
-      label: "Draft",
-      status: diagnostics.hasDraft ? "Done" : "Waiting",
-      note: diagnostics.hasDraft ? `${diagnostics.draftWordCount} words available` : "Create or paste prose",
-    },
-    {
-      label: "Continuity",
-      status: continuityQueued ? "Running" : diagnostics.canApprove ? "Done" : "Waiting",
-      note: continuityQueued ? "Validation running" : "Run after edit",
-    },
-    {
-      label: "Approval",
-      status: diagnostics.canApprove ? "Ready" : "Locked",
-      note: diagnostics.gateLabel,
-    },
-    {
-      label: "Memory",
-      status: diagnostics.canApprove ? "Waiting" : "Locked",
-      note: diagnostics.canApprove ? "Ready after reviewer approval" : "Approved revision only",
-    },
-  ];
+function present(condition: boolean, label: string): string | null {
+  return condition ? label : null;
 }
 
-function stepClass(status: string, continuityQueued: boolean) {
-  if (status === "Done" || status === "Ready") return "done";
-  if (status === "Locked") return "locked";
-  if (status === "Running" || continuityQueued) return "active";
-  return "pending";
-}
-
-function ProgressSummary({ diagnostics, continuityQueued }: { diagnostics: ArtifactInspectorDiagnostics; continuityQueued: boolean }) {
-  return (
-    <div className="inspector-summary-list">
-      {workflowSteps(diagnostics, continuityQueued).map((step) => (
-        <div key={step.label} className="inspector-summary-row">
-          <span className={`workflow-dot workflow-dot--${stepClass(step.status, continuityQueued)}`} />
-          <div>
-            <strong>{step.label}</strong>
-            <p>{step.status} · {step.note}</p>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function ContextPreview({ readiness, diagnostics }: { readiness: ContextReadiness; diagnostics: ArtifactInspectorDiagnostics }) {
-  const contextItems = [
-    `Chapter: ${diagnostics.hasChapter ? diagnostics.chapterTitle : "Missing"}`,
+function buildContextDigestBlock(readiness: ContextReadiness, diagnostics: ArtifactInspectorDiagnostics, continuityQueued: boolean): Extract<TimelineBlock, { type: "context_digest" }> {
+  const included = [
+    present(diagnostics.hasChapter, `Chapter: ${diagnostics.chapterTitle}`),
+    present(diagnostics.hasDraft, `Draft: ${diagnostics.draftWordCount} words`),
     `Artifact mode: ${diagnostics.activeMode}`,
-    `Readiness: ${readinessLabels[readiness]}`,
-    `Draft words: ${diagnostics.draftWordCount}`,
     `Approval: ${diagnostics.gateLabel}`,
-  ];
-  return (
-    <div className="inspector-card-grid">
-      {contextItems.map((item) => (
-        <div key={item} className="inspector-mini-card">{item}</div>
-      ))}
-    </div>
-  );
+  ].filter((item): item is string => Boolean(item));
+  const missing = [
+    present(!diagnostics.hasChapter, "Chapter selected"),
+    present(!diagnostics.hasDraft, "Draft artifact"),
+  ].filter((item): item is string => Boolean(item));
+  const degraded = [
+    present(readiness !== "proceed", `Readiness: ${readinessLabels[readiness]}`),
+    present(continuityQueued, "Continuity validation running"),
+  ].filter((item): item is string => Boolean(item));
+  const conflicts = [
+    present(!diagnostics.hasChapter, "No chapter selected"),
+    present(!diagnostics.hasDraft, "No draft artifact available"),
+    present(readiness === "blocked", "Context readiness is blocked"),
+    present(readiness === "degraded", "Context readiness is partial"),
+    present(continuityQueued, "Continuity validation is running"),
+    present(!diagnostics.canApprove, diagnostics.gateDetail),
+  ].filter((item): item is string => Boolean(item));
+  return {
+    id: "inspector-context-digest",
+    type: "context_digest",
+    source: "assistant",
+    title: diagnostics.hasChapter ? `${diagnostics.chapterTitle} context` : "Context readiness",
+    included,
+    missing,
+    degraded,
+    conflicts,
+  };
 }
 
-function IssuesPreview({
-  readiness,
-  diagnostics,
-  continuityQueued,
-}: {
-  readiness: ContextReadiness;
-  diagnostics: ArtifactInspectorDiagnostics;
-  continuityQueued: boolean;
-}) {
-  const issues = [
-    !diagnostics.hasChapter ? "No chapter selected" : null,
-    !diagnostics.hasDraft ? "No draft artifact available" : null,
-    readiness === "blocked" ? "Context readiness is blocked" : null,
-    readiness === "degraded" ? "Context readiness is partial" : null,
-    continuityQueued ? "Continuity validation is running" : null,
-    !diagnostics.canApprove ? diagnostics.gateDetail : null,
-  ].filter((item): item is string => Boolean(item));
-  return (
-    <div className="inspector-stack">
-      {(issues.length ? issues : ["No blocking artifact issues."]).map((item) => (
-        <div key={item} className="inspector-note">{item}</div>
-      ))}
-    </div>
-  );
+function buildWorkflowBlock(diagnostics: ArtifactInspectorDiagnostics, continuityQueued: boolean): Extract<TimelineBlock, { type: "workflow_progress" }> {
+  const event = continuityWorkflowProgressEvent({ chapterId: diagnostics.chapterId, queued: continuityQueued });
+  if (event) return workflowProgressBlockFromEvent(event);
+  const currentStep = diagnostics.canApprove ? 4 : diagnostics.hasDraft ? 2 : 1;
+  return {
+    id: "inspector-artifact-progress",
+    type: "workflow_progress",
+    source: "backend",
+    event_id: "artifact-progress-snapshot",
+    chapter_id: diagnostics.chapterId,
+    job_id: null,
+    workflow_name: "Artifact Readiness",
+    status: diagnostics.canApprove ? "complete" : "running",
+    current_step: currentStep,
+    total_steps: 4,
+    current_step_label: diagnostics.canApprove ? "Ready for review" : diagnostics.gateLabel,
+    steps: [
+      { label: "Chapter selected", status: diagnostics.hasChapter ? "complete" : "pending" },
+      { label: "Draft artifact", status: diagnostics.hasDraft ? "complete" : "pending" },
+      { label: "Continuity validation", status: diagnostics.canApprove ? "complete" : "pending" },
+      { label: "Reviewer approval", status: diagnostics.canApprove ? "active" : "pending" },
+    ],
+  };
+}
+
+function buildArtifactPreviewBlock(diagnostics: ArtifactInspectorDiagnostics): Extract<TimelineBlock, { type: "artifact_preview" }> {
+  return {
+    id: "inspector-artifact-preview",
+    type: "artifact_preview",
+    source: "backend",
+    artifact_id: "current-draft",
+    artifact_type: "draft",
+    title: diagnostics.hasChapter ? diagnostics.chapterTitle : "No chapter selected",
+    status: diagnostics.hasDraft ? "draft" : "failed",
+    description: diagnostics.hasDraft ? "Draft content opens in the artifact/document workspace." : "Create or select a draft before artifact actions are available.",
+    word_count: diagnostics.hasDraft ? diagnostics.draftWordCount : null,
+    beat_count: null,
+    preview_lines: [
+      diagnostics.hasDraft ? `${diagnostics.draftWordCount} words available` : "No draft artifact available",
+      diagnostics.gateDetail,
+      diagnostics.currentVersionNo !== null ? `Current version v${diagnostics.currentVersionNo} · ${diagnostics.currentVersionKind ?? "unknown"}` : "No current scene version",
+    ],
+    actions: diagnostics.hasDraft ? ["open_draft", "review_continuity", "edit_in_document"] : ["create_draft"],
+  };
 }
 
 function MemoryPreview({ diagnostics }: { diagnostics: ArtifactInspectorDiagnostics }) {
@@ -165,22 +159,6 @@ function MemoryPreview({ diagnostics }: { diagnostics: ArtifactInspectorDiagnost
   );
 }
 
-function VersionsPreview({ diagnostics, continuityQueued }: { diagnostics: ArtifactInspectorDiagnostics; continuityQueued: boolean }) {
-  const versionItems = [
-    diagnostics.currentVersionNo !== null ? `Current version v${diagnostics.currentVersionNo} · ${diagnostics.currentVersionKind ?? "unknown"}` : "No current scene version",
-    diagnostics.hasDraft ? `Current draft · ${diagnostics.draftWordCount} words` : "No draft version",
-    continuityQueued ? "Continuity check queued" : "Continuity check not running",
-    diagnostics.canApprove ? "Approval candidate ready" : `Approval locked · ${diagnostics.gateLabel}`,
-  ];
-  return (
-    <div className="inspector-stack">
-      {versionItems.map((item) => (
-        <div key={item} className="inspector-note">{item}</div>
-      ))}
-    </div>
-  );
-}
-
 function TabPreview({
   tab,
   readiness,
@@ -192,11 +170,11 @@ function TabPreview({
   diagnostics: ArtifactInspectorDiagnostics;
   continuityQueued: boolean;
 }) {
-  if (tab === "Progress") return <ProgressSummary diagnostics={diagnostics} continuityQueued={continuityQueued} />;
-  if (tab === "Context") return <ContextPreview readiness={readiness} diagnostics={diagnostics} />;
-  if (tab === "Issues") return <IssuesPreview readiness={readiness} diagnostics={diagnostics} continuityQueued={continuityQueued} />;
+  if (tab === "Progress") return <WorkflowProgressBlockView block={buildWorkflowBlock(diagnostics, continuityQueued)} density="detail" />;
+  if (tab === "Context") return <ContextDigestBlockView block={buildContextDigestBlock(readiness, diagnostics, continuityQueued)} />;
+  if (tab === "Artifacts") return <ArtifactPreviewBlockView block={buildArtifactPreviewBlock(diagnostics)} density="detail" />;
   if (tab === "Memory") return <MemoryPreview diagnostics={diagnostics} />;
-  return <VersionsPreview diagnostics={diagnostics} continuityQueued={continuityQueued} />;
+  return null;
 }
 
 export default function ArtifactInspectorRail({ readiness, continuityQueued, diagnostics }: ArtifactInspectorRailProps) {
@@ -229,7 +207,7 @@ export default function ArtifactInspectorRail({ readiness, continuityQueued, dia
         <span className="muted text-[10px]">{warnings} warnings</span>
       </div>
       <div className="inspector-tabs" role="tablist">
-        {(["Progress", "Context", "Issues", "Memory", "Versions"] as InspectorTab[]).map((tab) => (
+        {(["Progress", "Context", "Artifacts", "Memory"] as InspectorTab[]).map((tab) => (
           <button key={tab} type="button" className={tab === activeTab ? "shell-link shell-link--active px-2 py-1 text-xs" : "shell-link px-2 py-1 text-xs"} onClick={() => setActiveTab(tab)}>
             {tab}
           </button>

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -4,6 +4,10 @@ import ChatComposer, { type ChatCommandOption } from "@/features/scenes/componen
 import ChatTimeline from "@/features/scenes/components/writeTab/chatOrchestration/ChatTimeline";
 import { routeStudioIntent } from "@/features/scenes/components/writeTab/chatOrchestration/intentRouter";
 import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
+import {
+  continuityWorkflowProgressEvent,
+  workflowProgressBlockFromEvent,
+} from "@/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents";
 import type {
   AssistantReadinessContext,
   ChatContextMiniBarPayload,
@@ -176,6 +180,7 @@ function buildTimelineBlocks(args: {
   briefing: ReturnType<typeof buildAssistantReadiness>;
   composerValue: string;
   conversationBlocks: TimelineBlock[];
+  chapterId: string | null;
   hasDraft: boolean;
   showDraftPreview: boolean;
   continuityQueued: boolean;
@@ -197,24 +202,8 @@ function buildTimelineBlocks(args: {
     blocks.push({ id: "composer-echo", type: "text_message", source: "user", label: "You", text: args.composerValue.trim() });
   }
 
-  if (args.continuityQueued) {
-    blocks.push({
-      id: "continuity-progress",
-      type: "workflow_progress",
-      source: "backend",
-      workflow_name: "Continuity Check",
-      status: "running",
-      current_step: 2,
-      total_steps: 4,
-      current_step_label: "Checking timeline handoff",
-      steps: [
-        { label: "Read current artifact", status: "complete" },
-        { label: "Check timeline handoff", status: "active" },
-        { label: "Validate reveal constraints", status: "pending" },
-        { label: "Save review result", status: "pending" },
-      ],
-    });
-  }
+  const continuityEvent = continuityWorkflowProgressEvent({ chapterId: args.chapterId, queued: args.continuityQueued });
+  if (continuityEvent) blocks.push(workflowProgressBlockFromEvent(continuityEvent));
 
   if (args.hasDraft && args.showDraftPreview) {
     blocks.push({
@@ -225,6 +214,7 @@ function buildTimelineBlocks(args: {
       artifact_type: "draft",
       title: "Current chapter draft",
       status: "draft",
+      description: "Draft content is open in the artifact workspace.",
       word_count: null,
       beat_count: null,
       preview_lines: ["Draft content is open in the artifact workspace.", "Use the editor surface for prose edits and approval gates."],
@@ -482,6 +472,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     briefing,
     composerValue: props.composerValue,
     conversationBlocks,
+    chapterId: props.chapterId,
     hasDraft: props.hasDraft,
     showDraftPreview: chatMode !== "brainstorm",
     continuityQueued: props.continuityQueued,

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
@@ -34,7 +34,14 @@ function ChoiceChipsBlock({ block, onChip }: { block: Extract<TimelineBlock, { t
   );
 }
 
-function WorkflowProgress({ block }: { block: Extract<TimelineBlock, { type: "workflow_progress" }> }) {
+export function WorkflowProgressBlockView({
+  block,
+  density = "compact",
+}: {
+  block: Extract<TimelineBlock, { type: "workflow_progress" }>;
+  density?: "compact" | "detail";
+}) {
+  const progress = Math.max(8, Math.round((block.current_step / Math.max(block.total_steps, 1)) * 100));
   return (
     <article className={`timeline-card timeline-card--workflow timeline-card--${block.status}`}>
       <div className="timeline-card__header">
@@ -46,40 +53,57 @@ function WorkflowProgress({ block }: { block: Extract<TimelineBlock, { type: "wo
         </div>
         <span className="status-pill status-pill--partial">{block.status.toUpperCase()}</span>
       </div>
-      <div className="timeline-step-list">
-        {block.steps.map((step) => (
-          <div key={step.label} className={`timeline-step timeline-step--${step.status}`}>
-            <span aria-hidden>{workflowMarker(step.status)}</span>
-            <span>{step.label}</span>
-          </div>
-        ))}
+      <div className="context-progress-container !m-0 !max-w-none">
+        <div className="context-progress-fill" style={{ width: `${progress}%` }} />
       </div>
-      <div className="timeline-card__actions">
-        <button type="button">Show details</button>
-        <button type="button">Cancel</button>
-      </div>
+      {density === "detail" ? (
+        <div className="timeline-step-list">
+          {block.steps.map((step) => (
+            <div key={step.label} className={`timeline-step timeline-step--${step.status}`}>
+              <span aria-hidden>{workflowMarker(step.status)}</span>
+              <span>{step.label}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {density === "detail" ? (
+        <div className="timeline-card__actions">
+          <button type="button">Open operations</button>
+          <button type="button">Cancel</button>
+        </div>
+      ) : null}
     </article>
   );
 }
 
-function ArtifactPreview({ block }: { block: Extract<TimelineBlock, { type: "artifact_preview" }> }) {
+export function ArtifactPreviewBlockView({
+  block,
+  density = "compact",
+}: {
+  block: Extract<TimelineBlock, { type: "artifact_preview" }>;
+  density?: "compact" | "detail";
+}) {
   const meta =
     block.artifact_type === "draft"
       ? `AI draft · Not approved${block.word_count ? ` · ${block.word_count.toLocaleString()} words` : ""}`
       : block.beat_count
         ? `${block.beat_count} beats · ${block.status.replace("_", " ")}`
         : block.status.replace("_", " ");
+  const description = block.description ?? block.preview_lines[0] ?? "Open the artifact surface for full content.";
 
   return (
     <article className="timeline-card timeline-card--artifact">
       <div className="timeline-card__kicker">{block.artifact_type.toUpperCase()}</div>
       <h2>{block.title}</h2>
       <div className="timeline-card__meta">{meta}</div>
-      <div className="timeline-preview-lines">
-        {block.preview_lines.slice(0, 3).map((line) => (
-          <p key={line}>{line}</p>
-        ))}
-      </div>
+      <p className="timeline-card__description">{description}</p>
+      {density === "detail" ? (
+        <div className="timeline-preview-lines">
+          {block.preview_lines.slice(0, 3).map((line) => (
+            <p key={line}>{line}</p>
+          ))}
+        </div>
+      ) : null}
       <div className="timeline-card__actions">
         {block.actions.map((action) => (
           <button key={action} type="button">
@@ -126,7 +150,7 @@ function FailureRecovery({ block }: { block: Extract<TimelineBlock, { type: "fai
   );
 }
 
-function ContextDigest({ block }: { block: Extract<TimelineBlock, { type: "context_digest" }> }) {
+export function ContextDigestBlockView({ block }: { block: Extract<TimelineBlock, { type: "context_digest" }> }) {
   return (
     <article className="timeline-card timeline-card--digest">
       <div className="timeline-card__kicker">Context digest</div>
@@ -157,11 +181,11 @@ export default function TimelineBlocks({ blocks, onChip }: TimelineBlocksProps) 
         if (block.type === "text_message") return <TextBlock key={block.id} block={block} />;
         if (block.type === "readiness_card") return <ReadinessBriefing key={block.id} briefing={block.briefing} onChip={onChip} />;
         if (block.type === "inline_choice_chips") return <ChoiceChipsBlock key={block.id} block={block} onChip={onChip} />;
-        if (block.type === "workflow_progress") return <WorkflowProgress key={block.id} block={block} />;
-        if (block.type === "artifact_preview") return <ArtifactPreview key={block.id} block={block} />;
+        if (block.type === "workflow_progress") return <WorkflowProgressBlockView key={block.id} block={block} />;
+        if (block.type === "artifact_preview") return <ArtifactPreviewBlockView key={block.id} block={block} />;
         if (block.type === "approval_gate") return <ApprovalGate key={block.id} block={block} />;
         if (block.type === "failure_recovery") return <FailureRecovery key={block.id} block={block} />;
-        return <ContextDigest key={block.id} block={block} />;
+        return <ContextDigestBlockView key={block.id} block={block} />;
       })}
     </>
   );

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents.test.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents.test.ts
@@ -1,0 +1,28 @@
+import {
+  continuityWorkflowProgressEvent,
+  upsertWorkflowProgressBlock,
+  workflowProgressBlockFromEvent,
+} from "@/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+export function runWorkflowProgressEventsSelfTest(): void {
+  const event = continuityWorkflowProgressEvent({ chapterId: "ch01", queued: true });
+  assert(event !== null, "queued continuity creates a backend-shaped event");
+  if (!event) throw new Error("continuity event missing");
+  const block = workflowProgressBlockFromEvent(event);
+  assert(block.type === "workflow_progress", "event maps to workflow_progress block");
+  assert(block.source === "backend", "workflow progress block is backend-originated");
+
+  const updated = upsertWorkflowProgressBlock([], event);
+  assert(updated.length === 1, "upsert appends first workflow block");
+
+  const completeEvent = { ...event, status: "complete" as const, current_step: 4, current_step_label: "Review saved" };
+  const merged = upsertWorkflowProgressBlock(updated, completeEvent);
+  assert(merged.length === 1, "upsert updates existing workflow block");
+  assert(merged[0]?.type === "workflow_progress" && merged[0].status === "complete", "upsert preserves latest workflow status");
+}
+
+runWorkflowProgressEventsSelfTest();

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents.ts
@@ -1,0 +1,48 @@
+import type { TimelineBlock, WorkflowProgressBlock } from "@/features/scenes/components/writeTab/types";
+
+export type BackendWorkflowProgressEvent = Omit<WorkflowProgressBlock, "type" | "source"> & {
+  event_id: string;
+};
+
+export function workflowProgressBlockId(event: BackendWorkflowProgressEvent): string {
+  return event.job_id ? `workflow-progress-${event.job_id}` : `workflow-progress-${event.event_id}`;
+}
+
+export function workflowProgressBlockFromEvent(event: BackendWorkflowProgressEvent): Extract<TimelineBlock, { type: "workflow_progress" }> {
+  return {
+    ...event,
+    id: workflowProgressBlockId(event),
+    type: "workflow_progress",
+    source: "backend",
+  };
+}
+
+export function upsertWorkflowProgressBlock(
+  blocks: TimelineBlock[],
+  event: BackendWorkflowProgressEvent
+): TimelineBlock[] {
+  const nextBlock = workflowProgressBlockFromEvent(event);
+  const existingIndex = blocks.findIndex((block) => block.type === "workflow_progress" && block.id === nextBlock.id);
+  if (existingIndex === -1) return [...blocks, nextBlock];
+  return blocks.map((block, index) => (index === existingIndex ? nextBlock : block));
+}
+
+export function continuityWorkflowProgressEvent(args: { chapterId: string | null; queued: boolean }): BackendWorkflowProgressEvent | null {
+  if (!args.queued) return null;
+  return {
+    event_id: "continuity-check-active",
+    chapter_id: args.chapterId,
+    job_id: null,
+    workflow_name: "Continuity Check",
+    status: "running",
+    current_step: 2,
+    total_steps: 4,
+    current_step_label: "Checking timeline handoff",
+    steps: [
+      { label: "Read current artifact", status: "complete" },
+      { label: "Check timeline handoff", status: "active" },
+      { label: "Validate reveal constraints", status: "pending" },
+      { label: "Save review result", status: "pending" },
+    ],
+  };
+}

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -139,6 +139,7 @@ export type ArtifactPreviewBlock = {
   artifact_type: "plan" | "draft" | "analysis" | "review" | "research";
   title: string;
   status: "draft" | "needs_approval" | "approved" | "failed" | "superseded";
+  description?: string;
   word_count: number | null;
   beat_count: number | null;
   preview_lines: string[];


### PR DESCRIPTION
## Summary
- closes #119 by rendering chat artifact cards through the existing artifact_preview contract with compact timeline density
- closes #120 by adding backend-shaped workflow progress event mapping and routing continuity progress through workflow_progress blocks
- closes #121 by reusing context_digest, workflow_progress, and artifact_preview block contracts inside the right inspector modes
- documents the write workspace block-contract alignment in apps/studio/README.md

## Verification
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx src/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents.ts src/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents.test.ts src/features/scenes/components/writeTab/types.ts
- git diff --check
- npm run build

Note: targeted eslint still reports existing CommandWorkStream.tsx complexity/max-lines warnings; no errors.