### PR TITLE
fix: lock Write workspace viewport

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -51,6 +51,9 @@ Refactor direction for large modules:
 
 ### Write workspace chat block contracts
 
+- The Write workspace is viewport locked: the app shell reserves the fixed top bar, the Write grid fills the remaining visible height, and only internal panels scroll. The browser page itself must not become the scrolling surface for `/stories/[slug]/write`.
+- The center chat owns conversation history and the persistent bottom composer. User/assistant prose renders as compact chat bubbles with text-only copy actions; system state renders as compact timeline blocks.
+- The slash command menu is anchored above the composer with internal scrolling and must not shift the page layout.
 - Chat artifact summary cards use the `artifact_preview` timeline block contract. The chat timeline renders a compact card with title, status, short description, and actions; full artifact or document content stays in the artifact panel or document workspace.
 - Workflow progress uses `workflow_progress` blocks mapped from backend-shaped pipeline/job events. The chat timeline renders compact progress, while the right inspector renders detailed step state. Worker logs and diagnostics stay in Operations surfaces.
 - Right inspector modes reuse timeline block contracts where possible:

--- a/apps/studio/src/app/globals.css
+++ b/apps/studio/src/app/globals.css
@@ -19,6 +19,7 @@
   --radius-lg: 16px;
   --radius-xl: 20px;
   --radius-pill: 999px;
+  --topbar-height: 54px;
   --shadow-soft:
     0 1px 2px rgba(0, 0, 0, 0.04),
     0 12px 32px rgba(0, 0, 0, 0.05);
@@ -37,6 +38,7 @@
 }
 
 body {
+  min-height: 100dvh;
   background: #0b0f14;
   color: var(--foreground);
   font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -50,6 +52,12 @@ body {
 
 .app-shell {
   min-height: 100vh;
+}
+
+.app-shell--write {
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .app-header {
@@ -67,13 +75,19 @@ body {
   align-items: center;
   gap: 18px;
   width: 100%;
-  min-height: 54px;
+  min-height: var(--topbar-height);
   padding: 0 18px;
 }
 
 .app-body {
   width: 100%;
   padding: 0;
+}
+
+.app-shell--write .app-body {
+  height: calc(100dvh - var(--topbar-height));
+  min-height: 0;
+  overflow: hidden;
 }
 
 .app-context-bar {
@@ -296,7 +310,9 @@ body {
 .novel-lab-workspace {
   display: grid;
   grid-template-columns: 236px minmax(420px, 0.92fr) minmax(520px, 1.18fr);
-  min-height: calc(100svh - 55px);
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
   transition: grid-template-columns 0.45s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -306,6 +322,7 @@ body {
 
 .artifact-workspace {
   min-width: 0;
+  min-height: 0;
   background: var(--bg-sidebar);
   transition: opacity 0.3s ease, transform 0.4s ease;
 }
@@ -320,6 +337,9 @@ body {
   display: flex;
   flex-direction: column;
   gap: 18px;
+  min-height: 0;
+  height: 100%;
+  overflow-y: auto;
   padding: 16px;
   border-right: 1px solid var(--border-subtle);
 }
@@ -387,6 +407,8 @@ body {
   right: 18px;
   bottom: calc(100% + 10px);
   z-index: 5;
+  max-height: min(360px, calc(100dvh - var(--topbar-height) - 150px));
+  overflow-y: auto;
   padding: 10px;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
   animation: slashMenuAppear 0.2s cubic-bezier(0.4, 0, 0.2, 1);
@@ -434,18 +456,22 @@ body {
 
 .artifact-workspace {
   display: flex;
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 
 .artifact-main {
   display: flex;
   min-width: 0;
+  min-height: 0;
   flex: 1;
   flex-direction: column;
   background: #0d1219;
 }
 
 .artifact-header {
+  flex: 0 0 auto;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -475,6 +501,7 @@ body {
 }
 
 .artifact-tabs {
+  flex: 0 0 auto;
   border-bottom: 1px solid var(--border-subtle);
   padding: 10px 14px;
 }
@@ -561,23 +588,26 @@ body {
   flex: 1;
   width: 100%;
   height: 100%;
+  min-height: 0;
   border-left: 0;
   background: var(--bg-sidebar);
   padding: 12px;
-  overflow: auto;
+  overflow-y: auto;
 }
 
 .work-stream {
   position: relative;
   display: flex;
   flex-direction: column;
-  min-height: calc(100svh - 55px);
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
   border-right: 1px solid var(--border-subtle);
 }
 
 .chat-context-mini-bar {
-  position: sticky;
-  top: 0;
+  flex: 0 0 auto;
   z-index: 4;
   display: flex;
   align-items: center;
@@ -599,15 +629,31 @@ body {
 }
 
 .work-stream__scroll {
+  position: relative;
   min-height: 0;
   flex: 1;
-  overflow: auto;
-  padding: 28px 22px 120px;
+  overflow-y: auto;
+  padding: 18px 18px 24px;
+}
+
+.jump-to-bottom {
+  position: sticky;
+  bottom: 8px;
+  z-index: 3;
+  display: block;
+  margin: 10px auto 0;
+  border: 1px solid rgba(66, 199, 184, 0.28);
+  border-radius: var(--radius-pill);
+  background: rgba(17, 24, 39, 0.94);
+  color: var(--accent);
+  padding: 6px 10px;
+  font-size: 11px;
 }
 
 .timeline-stack {
   display: grid;
-  gap: 14px;
+  align-content: start;
+  gap: 12px;
 }
 
 .work-stream__intro {
@@ -721,28 +767,110 @@ body {
 .work-message,
 .timeline-card,
 .timeline-chip-row {
-  max-width: 620px;
-  width: 100%;
-  margin: 0 auto;
+  max-width: min(620px, 78%);
+  width: fit-content;
 }
 
 .work-message {
-  border-radius: var(--radius-md);
+  position: relative;
+  border-radius: 16px;
   background: rgba(255, 255, 255, 0.035);
-  padding: 14px 16px;
+  padding: 10px 13px;
+}
+
+.work-message--assistant,
+.timeline-card,
+.timeline-chip-row {
+  justify-self: start;
+}
+
+.work-message--user {
+  justify-self: end;
+  background: rgba(66, 199, 184, 0.14);
+  color: var(--text-primary);
 }
 
 .work-message__label {
-  margin-bottom: 6px;
+  margin-bottom: 4px;
   color: var(--text-muted);
   font-size: 11px;
+}
+
+.work-message__body {
+  white-space: pre-wrap;
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.work-message__actions {
+  position: absolute;
+  top: 50%;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition: opacity 120ms ease;
+}
+
+.work-message--assistant .work-message__actions {
+  right: -78px;
+}
+
+.work-message--user .work-message__actions {
+  left: -78px;
+}
+
+.work-message:hover .work-message__actions,
+.work-message:focus-within .work-message__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.work-message__actions button {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-pill);
+  background: rgba(17, 24, 39, 0.96);
+  color: var(--text-secondary);
+  padding: 4px 7px;
+  font-size: 10px;
+}
+
+.thinking-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 36px;
+  min-height: 18px;
+}
+
+.thinking-dots span {
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--text-secondary);
+  animation: thinkingPulse 1.1s infinite ease-in-out;
+}
+
+.thinking-dots span:nth-child(2) {
+  animation-delay: 0.14s;
+}
+
+.thinking-dots span:nth-child(3) {
+  animation-delay: 0.28s;
+}
+
+@keyframes thinkingPulse {
+  0%, 80%, 100% { opacity: 0.28; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-2px); }
 }
 
 .timeline-card {
   border: 1px solid rgba(255, 255, 255, 0.07);
   border-radius: var(--radius-md);
   background: rgba(17, 24, 39, 0.72);
-  padding: 16px;
+  padding: 12px;
 }
 
 .timeline-card--failure {
@@ -840,11 +968,12 @@ body {
 }
 
 .work-composer-wrap {
-  position: sticky;
+  position: relative;
+  flex: 0 0 auto;
   right: 0;
   bottom: 0;
   left: 0;
-  padding: 16px 18px 18px;
+  padding: 12px 18px 14px;
   background: linear-gradient(180deg, transparent, rgba(13, 18, 25, 0.92) 30%, rgba(13, 18, 25, 1));
 }
 
@@ -852,21 +981,26 @@ body {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 10px;
-  max-width: 680px;
+  max-width: 760px;
   margin: 0 auto;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-lg);
   background: #111827;
-  padding: 10px;
+  padding: 8px;
 }
 
-.work-composer input {
+.work-composer textarea {
   min-width: 0;
+  max-height: 140px;
+  resize: none;
   border: 0;
   background: transparent;
   color: var(--text-primary);
   font-size: 13px;
+  line-height: 1.45;
   outline: none;
+  overflow-y: auto;
+  padding: 7px 0;
 }
 
 .work-composer__menu {
@@ -1072,12 +1206,17 @@ body {
 
 @media (max-width: 1180px) {
   .novel-lab-workspace {
-    grid-template-columns: 220px minmax(0, 1fr);
+    grid-template-columns: 200px minmax(0, 1fr) 300px;
   }
 
   .artifact-workspace {
-    grid-column: 1 / -1;
-    min-height: 620px;
+    min-width: 0;
+  }
+
+  .work-message,
+  .timeline-card,
+  .timeline-chip-row {
+    max-width: min(680px, 84%);
   }
 }
 
@@ -1097,22 +1236,32 @@ body {
     grid-template-columns: 1fr;
   }
 
+  .novel-lab-nav,
   .artifact-workspace {
-    flex-direction: column;
-  }
-
-  .artifact-header {
-    flex-direction: column;
-  }
-
-  .artifact-inspector {
-    width: auto !important;
-    border-left: 0;
-    border-top: 1px solid var(--border-subtle);
-  }
-
-  .inspector-resize-handle {
     display: none;
+  }
+
+  .work-message,
+  .timeline-card,
+  .timeline-chip-row {
+    max-width: 92%;
+  }
+
+  .work-message__actions {
+    position: static;
+    margin-top: 6px;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+  }
+
+  .work-composer-wrap {
+    padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
+  }
+
+  .slash-menu {
+    left: 12px;
+    right: 12px;
   }
 }
 

--- a/apps/studio/src/components/AppShell.tsx
+++ b/apps/studio/src/components/AppShell.tsx
@@ -7,9 +7,11 @@ import { StoryProvider, useStory } from "@/features/story/StoryContext";
 import StorySelector from "@/features/story/StorySelector";
 
 export default function AppShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const isWriteRoute = pathname.includes("/write") || pathname === "/";
   return (
     <StoryProvider>
-      <div className="app-shell">
+      <div className={isWriteRoute ? "app-shell app-shell--write" : "app-shell"}>
         <header className="app-header">
           <div className="app-header__inner">
             <Link href="/" className="brand-mark text-sm" aria-label="Novel Lab home">
@@ -43,7 +45,7 @@ function routeLabel(pathname: string): string {
 
 function CompactContextBar() {
   const pathname = usePathname();
-  const { headerContext, isArtifactVisible } = useStory();
+  const { headerContext } = useStory();
   const areaLabel = routeLabel(pathname);
   const chapter = headerContext.chapterLabel ?? "No chapter";
 

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -180,6 +180,7 @@ function buildTimelineBlocks(args: {
   briefing: ReturnType<typeof buildAssistantReadiness>;
   composerValue: string;
   conversationBlocks: TimelineBlock[];
+  pendingAssistant: boolean;
   chapterId: string | null;
   hasDraft: boolean;
   showDraftPreview: boolean;
@@ -200,6 +201,18 @@ function buildTimelineBlocks(args: {
 
   if (args.composerValue.trim()) {
     blocks.push({ id: "composer-echo", type: "text_message", source: "user", label: "You", text: args.composerValue.trim() });
+  }
+
+  if (args.pendingAssistant) {
+    blocks.push({
+      id: "assistant-pending",
+      type: "text_message",
+      source: "assistant",
+      label: "Studio Writing Assistant",
+      text: "Thinking",
+      tone: "running",
+      pending: true,
+    });
   }
 
   const continuityEvent = continuityWorkflowProgressEvent({ chapterId: args.chapterId, queued: args.continuityQueued });
@@ -456,6 +469,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
   const router = useRouter();
   const [chatMode, setChatMode] = React.useState<"chat" | "brainstorm">("chat");
   const [conversationBlocks, setConversationBlocks] = React.useState<TimelineBlock[]>([]);
+  const [pendingAssistant, setPendingAssistant] = React.useState(false);
   const briefing = buildAssistantReadiness(props.assistantContext);
   const commands = buildCommands(props.assistantContext, props.chapterId);
   const { commandResult, intentBlock, runCommand, submitMessage } = useCommandRunner({
@@ -472,6 +486,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     briefing,
     composerValue: props.composerValue,
     conversationBlocks,
+    pendingAssistant,
     chapterId: props.chapterId,
     hasDraft: props.hasDraft,
     showDraftPreview: chatMode !== "brainstorm",
@@ -508,9 +523,13 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
             ...current,
             { id: `user-${Date.now()}`, type: "text_message", source: "user", label: "You", text: message },
           ]);
+          setPendingAssistant(true);
           props.onComposerValueChange("");
           props.onCommandMenuOpenChange(false);
-          submitMessage(message);
+          window.setTimeout(() => {
+            submitMessage(message);
+            setPendingAssistant(false);
+          }, 220);
         }}
       />
     </section>

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx
@@ -251,12 +251,28 @@ export default function ChatComposer({ value, menuOpen, commands, onValueChange,
               onMenuOpenChange(false);
               onValueChange("");
             }
+            if (event.key === "Enter" && !event.shiftKey && state === "slash_command_menu") {
+              event.preventDefault();
+              const selected = filteredCommands[activeIndex];
+              if (selected) selectCommand(selected);
+            }
           }}
         >
           <button type="button" className="work-composer__menu" aria-label="Open command menu" onClick={() => onMenuOpenChange(!menuOpen)}>
             /
           </button>
-          <input value={value} onChange={(event) => onValueChange(event.target.value)} placeholder="Type a message or / for commands" aria-label="Studio chat composer" />
+          <textarea
+            value={value}
+            onChange={(event) => onValueChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" || event.shiftKey || state === "slash_command_menu") return;
+              event.preventDefault();
+              event.currentTarget.form?.requestSubmit();
+            }}
+            rows={1}
+            placeholder="Message or / for commands"
+            aria-label="Studio chat composer"
+          />
           <button type="submit" className="primary-action px-3 py-2 text-xs" title={state === "slash_command_menu" ? "Run preflight" : "Send message"}>
             {state === "slash_command_menu" ? "Run" : "Send"}
           </button>

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatTimeline.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatTimeline.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import React from "react";
 import TimelineBlocks from "@/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks";
 import type { ChatContextMiniBarPayload, RecoveryChip, TimelineBlock } from "@/features/scenes/components/writeTab/types";
 
@@ -14,6 +17,22 @@ function statusClass(status: ChatContextMiniBarPayload["status"]): string {
 }
 
 export default function ChatTimeline({ context, blocks, onChip }: ChatTimelineProps) {
+  const scrollRef = React.useRef<HTMLDivElement | null>(null);
+  const [nearBottom, setNearBottom] = React.useState(true);
+
+  React.useEffect(() => {
+    if (!nearBottom) return;
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    scroll.scrollTo({ top: scroll.scrollHeight, behavior: "smooth" });
+  }, [blocks, nearBottom]);
+
+  const updateNearBottom = () => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    setNearBottom(scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight < 96);
+  };
+
   return (
     <>
       <div className="chat-context-mini-bar" aria-label="Current chat context">
@@ -22,10 +41,18 @@ export default function ChatTimeline({ context, blocks, onChip }: ChatTimelinePr
         <button type="button">{context.chapterLabel}</button>
         <span className={statusClass(context.status)}>{context.status.toUpperCase()}</span>
       </div>
-      <div className="work-stream__scroll">
+      <div ref={scrollRef} className="work-stream__scroll" onScroll={updateNearBottom}>
         <div className="timeline-stack">
           <TimelineBlocks blocks={blocks} onChip={onChip} />
         </div>
+        {!nearBottom ? (
+          <button type="button" className="jump-to-bottom" onClick={() => {
+            scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+            setNearBottom(true);
+          }}>
+            New messages
+          </button>
+        ) : null}
       </div>
     </>
   );

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import React from "react";
 import ReadinessBriefing from "@/features/scenes/components/writeTab/chatOrchestration/ReadinessBriefing";
 import type { RecoveryChip, TimelineBlock, WorkflowStepStatus } from "@/features/scenes/components/writeTab/types";
 
@@ -13,11 +16,37 @@ function workflowMarker(status: WorkflowStepStatus): string {
   return "○";
 }
 
+function copyMessageText(text: string, onCopied: () => void): void {
+  if (typeof navigator === "undefined" || !navigator.clipboard) return;
+  void navigator.clipboard.writeText(text).then(onCopied).catch(() => undefined);
+}
+
 function TextBlock({ block }: { block: Extract<TimelineBlock, { type: "text_message" }> }) {
+  const [copied, setCopied] = React.useState(false);
+  const copyText = () => copyMessageText(block.text, () => {
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1100);
+  });
   return (
     <div className={`work-message work-message--${block.source} work-message--${block.tone ?? "ready"}`}>
       <div className="work-message__label">{block.label}</div>
-      <div className={block.source === "user" ? "font-mono text-xs" : "text-sm"}>{block.text}</div>
+      <div className="work-message__body">
+        {block.pending ? (
+          <span className="thinking-dots" aria-label="Thinking">
+            <span />
+            <span />
+            <span />
+          </span>
+        ) : (
+          block.text
+        )}
+      </div>
+      {!block.pending ? (
+        <div className="work-message__actions" aria-label="Message actions">
+          <button type="button" onClick={copyText}>{copied ? "Copied" : "Copy"}</button>
+          <button type="button" title={block.source === "user" ? "Message options" : "Assistant options"}>...</button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -188,7 +188,7 @@ export type ContextDigestBlock = {
 };
 
 export type TimelineBlock =
-  | { type: "text_message"; id: string; source: "user" | "assistant"; label: string; text: string; tone?: "ready" | "blocked" | "running" }
+  | { type: "text_message"; id: string; source: "user" | "assistant"; label: string; text: string; tone?: "ready" | "blocked" | "running"; pending?: boolean }
   | { type: "readiness_card"; id: string; briefing: AssistantReadinessBriefing }
   | { type: "inline_choice_chips"; id: string; chips: InlineChoiceChip[] }
   | (WorkflowProgressBlock & { id: string })


### PR DESCRIPTION
## Summary
- closes #123
- lock the Write workspace under the app top bar with internal panel scroll boundaries
- keep the center composer visible and anchor slash commands above it without page layout shift
- render user/assistant prose as compact chat bubbles with copy and menu actions
- add pending assistant thinking bubble and near-bottom chat auto-scroll behavior
- keep artifact/progress/context detail separation from #119-#121 while polishing density

## Verification
- npm run typecheck
- npx eslint src/components/AppShell.tsx src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/chatOrchestration/ChatTimeline.tsx src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx src/features/scenes/components/writeTab/types.ts
- git diff --check
- npm run build
- curl -I --max-time 10 http://127.0.0.1:3000/stories/default/write

Note: targeted eslint still reports existing CommandWorkStream.tsx complexity/max-lines warnings; no errors. Browser screenshot automation was not available because Playwright/Chromium are not installed in this workspace.