### PR TITLE
fix: stabilize Write viewport scroll

### DIFF
--- a/apps/studio/src/app/globals.css
+++ b/apps/studio/src/app/globals.css
@@ -46,6 +46,13 @@ body {
   font-size: 13px;
 }
 
+html.write-route-lock,
+body.write-route-lock {
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+}
+
 ::selection {
   background: rgba(66, 199, 184, 0.24);
 }
@@ -336,27 +343,42 @@ body {
 .novel-lab-nav {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 10px;
   min-height: 0;
   height: 100%;
-  overflow-y: auto;
-  padding: 16px;
+  overflow: hidden;
+  padding: 12px;
   border-right: 1px solid var(--border-subtle);
+}
+
+.novel-lab-nav__fixed {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 10px;
+}
+
+.novel-lab-nav__scroll {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 2px;
 }
 
 .novel-lab-story-card {
   display: grid;
-  grid-template-columns: 48px minmax(0, 1fr);
-  gap: 12px;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: 10px;
   align-items: center;
   border-radius: var(--radius-sm);
-  padding: 10px;
+  padding: 8px;
   background: rgba(255, 255, 255, 0.025);
 }
 
 .novel-lab-cover {
-  width: 48px;
-  height: 64px;
+  width: 40px;
+  height: 54px;
   border-radius: 6px;
   border: 1px solid rgba(66, 199, 184, 0.22);
   background:
@@ -372,7 +394,7 @@ body {
   justify-content: space-between;
   gap: 8px;
   border-radius: var(--radius-sm);
-  padding: 8px;
+  padding: 7px 8px;
   color: var(--text-secondary);
 }
 
@@ -634,6 +656,24 @@ body {
   flex: 1;
   overflow-y: auto;
   padding: 18px 18px 24px;
+}
+
+.novel-lab-nav__scroll,
+.work-stream__scroll,
+.artifact-inspector,
+.document-artifact,
+.slash-menu {
+  scrollbar-width: none;
+}
+
+.novel-lab-nav__scroll::-webkit-scrollbar,
+.work-stream__scroll::-webkit-scrollbar,
+.artifact-inspector::-webkit-scrollbar,
+.document-artifact::-webkit-scrollbar,
+.slash-menu::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
 }
 
 .jump-to-bottom {
@@ -989,6 +1029,11 @@ body {
   padding: 8px;
 }
 
+.work-composer:focus-within {
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+}
+
 .work-composer textarea {
   min-width: 0;
   max-height: 140px;
@@ -999,8 +1044,16 @@ body {
   font-size: 13px;
   line-height: 1.45;
   outline: none;
+  box-shadow: none;
+  appearance: none;
   overflow-y: auto;
   padding: 7px 0;
+}
+
+.work-composer textarea:focus,
+.work-composer textarea:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .work-composer__menu {

--- a/apps/studio/src/components/AppShell.tsx
+++ b/apps/studio/src/components/AppShell.tsx
@@ -2,13 +2,22 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { StoryProvider, useStory } from "@/features/story/StoryContext";
 import StorySelector from "@/features/story/StorySelector";
 
 export default function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const isWriteRoute = pathname.includes("/write") || pathname === "/";
+  useEffect(() => {
+    document.documentElement.classList.toggle("write-route-lock", isWriteRoute);
+    document.body.classList.toggle("write-route-lock", isWriteRoute);
+    return () => {
+      document.documentElement.classList.remove("write-route-lock");
+      document.body.classList.remove("write-route-lock");
+    };
+  }, [isWriteRoute]);
+
   return (
     <StoryProvider>
       <div className={isWriteRoute ? "app-shell app-shell--write" : "app-shell"}>

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -108,82 +108,86 @@ function NavigationPanel(
 
   return (
     <aside className="novel-lab-nav" aria-label="Story navigation">
-      <div className="novel-lab-story-card">
-        <div className="novel-lab-cover" aria-hidden />
-        <div>
-          <div className="text-sm font-semibold">{storyLabel}</div>
-          <div className="muted text-xs">{props.chapterIds.length ? `${props.chapterIds.length} chapters` : "No chapters loaded"}</div>
-          <div className="mt-2 text-xs text-[var(--accent)]">{props.selectedChapterId || "No chapter"}</div>
+      <div className="novel-lab-nav__fixed">
+        <div className="novel-lab-story-card">
+          <div className="novel-lab-cover" aria-hidden />
+          <div>
+            <div className="text-sm font-semibold">{storyLabel}</div>
+            <div className="muted text-xs">{props.chapterIds.length ? `${props.chapterIds.length} chapters` : "No chapters loaded"}</div>
+            <div className="mt-2 text-xs text-[var(--accent)]">{props.selectedChapterId || "No chapter"}</div>
+          </div>
         </div>
+
+        <NextActionRail
+          storySlug={props.storySlug}
+          hasChapter={Boolean(props.selectedChapterId || props.chapterIds.length)}
+          hasDraft={props.hasDraft}
+          continuityQueued={props.continuityQueued}
+          readiness={props.readiness}
+          loading={props.loadingWorkspace}
+        />
       </div>
 
-      <NextActionRail
-        storySlug={props.storySlug}
-        hasChapter={Boolean(props.selectedChapterId || props.chapterIds.length)}
-        hasDraft={props.hasDraft}
-        continuityQueued={props.continuityQueued}
-        readiness={props.readiness}
-        loading={props.loadingWorkspace}
-      />
-
-      <nav className="space-y-1 text-sm" aria-label="Workspace views">
-        {workspaceLinks.map((item) => (
-          <Link
-            key={item.label}
-            href={item.href}
-            className={`novel-lab-nav-row no-underline hover:bg-white/[0.04] ${item.active ? "novel-lab-nav-row--active" : ""}`}
-          >
-            <span aria-hidden>{item.label.slice(0, 1)}</span>
-            <span>{item.label}</span>
-          </Link>
-        ))}
-        <button
-          type="button"
-          className={`novel-lab-nav-row border-0 bg-transparent text-left hover:bg-white/[0.04] ${
-            isArtifactVisible ? "novel-lab-nav-row--active" : ""
-          }`}
-          aria-pressed={isArtifactVisible}
-          onClick={() => setIsArtifactVisible(!isArtifactVisible)}
-        >
-          <span aria-hidden>A</span>
-          <span>Artifacts</span>
-        </button>
-      </nav>
-
-      <div className="space-y-2">
-        <div className="muted text-xs uppercase tracking-wide">Chapters</div>
-        {props.loadingScenes ? <div className="muted text-xs">Loading chapters...</div> : null}
-        {visibleChapters.length ? (
-          visibleChapters.map((chapterId) => (
-            <button
-              key={chapterId}
-              type="button"
-              className={`novel-lab-chapter-row ${chapterId === props.selectedChapterId ? "novel-lab-chapter-row--selected" : ""}`}
-              onClick={() => props.onChapterIdChange(chapterId)}
+      <div className="novel-lab-nav__scroll">
+        <nav className="space-y-1 text-sm" aria-label="Workspace views">
+          {workspaceLinks.map((item) => (
+            <Link
+              key={item.label}
+              href={item.href}
+              className={`novel-lab-nav-row no-underline hover:bg-white/[0.04] ${item.active ? "novel-lab-nav-row--active" : ""}`}
             >
-              <span>{getChapterTitle(chapterId)}</span>
-              <span>{chapterId === props.selectedChapterId ? "Drafting" : "Not started"}</span>
-            </button>
-          ))
-        ) : (
-          <div className="quiet-empty-state p-3 text-xs">No chapters yet.</div>
-        )}
-        <button type="button" className="shell-link w-full px-3 py-2 text-xs" onClick={() => void props.onCreateNewChapter()}>
-          New chapter
-        </button>
-      </div>
-
-      <details className="novel-lab-operations">
-        <summary>Operations</summary>
-        <div className="mt-2 space-y-1">
-          {operationLinks.map((item) => (
-            <Link key={item.label} href={item.href} className="novel-lab-nav-row novel-lab-nav-row--secondary no-underline hover:bg-white/[0.04]">
               <span aria-hidden>{item.label.slice(0, 1)}</span>
               <span>{item.label}</span>
             </Link>
           ))}
+          <button
+            type="button"
+            className={`novel-lab-nav-row border-0 bg-transparent text-left hover:bg-white/[0.04] ${
+              isArtifactVisible ? "novel-lab-nav-row--active" : ""
+            }`}
+            aria-pressed={isArtifactVisible}
+            onClick={() => setIsArtifactVisible(!isArtifactVisible)}
+          >
+            <span aria-hidden>A</span>
+            <span>Artifacts</span>
+          </button>
+        </nav>
+
+        <div className="space-y-2">
+          <div className="muted text-xs uppercase tracking-wide">Chapters</div>
+          {props.loadingScenes ? <div className="muted text-xs">Loading chapters...</div> : null}
+          {visibleChapters.length ? (
+            visibleChapters.map((chapterId) => (
+              <button
+                key={chapterId}
+                type="button"
+                className={`novel-lab-chapter-row ${chapterId === props.selectedChapterId ? "novel-lab-chapter-row--selected" : ""}`}
+                onClick={() => props.onChapterIdChange(chapterId)}
+              >
+                <span>{getChapterTitle(chapterId)}</span>
+                <span>{chapterId === props.selectedChapterId ? "Drafting" : "Not started"}</span>
+              </button>
+            ))
+          ) : (
+            <div className="quiet-empty-state p-3 text-xs">No chapters yet.</div>
+          )}
+          <button type="button" className="shell-link w-full px-3 py-2 text-xs" onClick={() => void props.onCreateNewChapter()}>
+            New chapter
+          </button>
         </div>
-      </details>
+
+        <details className="novel-lab-operations">
+          <summary>Operations</summary>
+          <div className="mt-2 space-y-1">
+            {operationLinks.map((item) => (
+              <Link key={item.label} href={item.href} className="novel-lab-nav-row novel-lab-nav-row--secondary no-underline hover:bg-white/[0.04]">
+                <span aria-hidden>{item.label.slice(0, 1)}</span>
+                <span>{item.label}</span>
+              </Link>
+            ))}
+          </div>
+        </details>
+      </div>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- lock html/body during Write routes so the browser page cannot become the scroll surface
- split the left navigation into fixed and internal-scroll regions so sidebar content does not exceed the viewport
- hide internal panel scrollbars while preserving internal scroll behavior
- remove composer focus border/ring noise for a stable chat input surface

## Verification
- npm run typecheck
- npx eslint src/components/AppShell.tsx src/features/scenes/components/writeTab/NovelLabWorkspace.tsx src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/chatOrchestration/ChatTimeline.tsx src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx src/features/scenes/components/writeTab/chatOrchestration/ChatComposer.tsx src/features/scenes/components/writeTab/types.ts
- git diff --check
- npm run build
- curl -I --max-time 10 http://127.0.0.1:3000/stories/default/write

Note: targeted eslint still reports existing CommandWorkStream.tsx complexity/max-lines warnings; no errors.