### PR TITLE
Route Write commands into workspace surfaces

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -54,6 +54,8 @@ Refactor direction for large modules:
 - The Write workspace is viewport locked: the app shell reserves the fixed top bar, the Write grid fills the remaining visible height, and only internal panels scroll. The browser page itself must not become the scrolling surface for `/stories/[slug]/write`.
 - The center chat owns conversation history and the persistent bottom composer. User/assistant prose renders as compact chat bubbles with text-only copy actions; system state renders as compact timeline blocks.
 - The slash command menu is anchored above the composer with internal scrolling and must not shift the page layout.
+- Write workspace commands stay inside Write by default. Command handlers append the relevant timeline block and switch the shared right-inspector mode; they must not use route navigation for `/analyze`, `/research`, `/review`, `/memory`, `/pipeline`, `/context`, `/inspect`, or `/status`.
+- Inspector mode is workspace UI state, not route state. Deep Analysis, Reviews, Memory, and Pipelines pages remain available only through explicit secondary links such as "Open full analysis workspace".
 - Chat artifact summary cards use the `artifact_preview` timeline block contract. The chat timeline renders a compact card with title, status, short description, and actions; full artifact or document content stays in the artifact panel or document workspace.
 - Workflow progress uses `workflow_progress` blocks mapped from backend-shaped pipeline/job events. The chat timeline renders compact progress, while the right inspector renders detailed step state. Worker logs and diagnostics stay in Operations surfaces.
 - Right inspector modes reuse timeline block contracts where possible:

--- a/apps/studio/src/app/globals.css
+++ b/apps/studio/src/app/globals.css
@@ -959,6 +959,7 @@ body.write-route-lock {
 }
 
 .timeline-card__actions button,
+.timeline-card__actions a,
 .timeline-chip-row button {
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-pill);
@@ -966,6 +967,7 @@ body.write-route-lock {
   color: var(--accent);
   padding: 6px 9px;
   font-size: 11px;
+  text-decoration: none;
 }
 
 .timeline-step-list,

--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx
@@ -8,14 +8,21 @@ import {
   continuityWorkflowProgressEvent,
   workflowProgressBlockFromEvent,
 } from "@/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents";
-import type { ContextReadiness, ContextReadinessLabel, TimelineBlock } from "@/features/scenes/components/writeTab/types";
+import type { ContextReadiness, ContextReadinessLabel, TimelineBlock, WriteInspectorMode } from "@/features/scenes/components/writeTab/types";
 
-type InspectorTab = "Progress" | "Context" | "Artifacts" | "Memory";
+const inspectorTabs: Array<{ mode: WriteInspectorMode; label: string }> = [
+  { mode: "progress", label: "Progress" },
+  { mode: "context", label: "Context" },
+  { mode: "artifacts", label: "Artifacts" },
+  { mode: "memory", label: "Memory" },
+];
 
 type ArtifactInspectorRailProps = {
   readiness: ContextReadiness;
   continuityQueued: boolean;
   diagnostics: ArtifactInspectorDiagnostics;
+  mode: WriteInspectorMode;
+  onModeChange: (mode: WriteInspectorMode) => void;
 };
 
 export type ArtifactInspectorDiagnostics = {
@@ -165,21 +172,20 @@ function TabPreview({
   diagnostics,
   continuityQueued,
 }: {
-  tab: InspectorTab;
+  tab: WriteInspectorMode;
   readiness: ContextReadiness;
   diagnostics: ArtifactInspectorDiagnostics;
   continuityQueued: boolean;
 }) {
-  if (tab === "Progress") return <WorkflowProgressBlockView block={buildWorkflowBlock(diagnostics, continuityQueued)} density="detail" />;
-  if (tab === "Context") return <ContextDigestBlockView block={buildContextDigestBlock(readiness, diagnostics, continuityQueued)} />;
-  if (tab === "Artifacts") return <ArtifactPreviewBlockView block={buildArtifactPreviewBlock(diagnostics)} density="detail" />;
-  if (tab === "Memory") return <MemoryPreview diagnostics={diagnostics} />;
+  if (tab === "progress") return <WorkflowProgressBlockView block={buildWorkflowBlock(diagnostics, continuityQueued)} density="detail" />;
+  if (tab === "context") return <ContextDigestBlockView block={buildContextDigestBlock(readiness, diagnostics, continuityQueued)} />;
+  if (tab === "artifacts") return <ArtifactPreviewBlockView block={buildArtifactPreviewBlock(diagnostics)} density="detail" />;
+  if (tab === "memory") return <MemoryPreview diagnostics={diagnostics} />;
   return null;
 }
 
-export default function ArtifactInspectorRail({ readiness, continuityQueued, diagnostics }: ArtifactInspectorRailProps) {
+export default function ArtifactInspectorRail({ readiness, continuityQueued, diagnostics, mode, onModeChange }: ArtifactInspectorRailProps) {
   const [inspectorWidth, setInspectorWidth] = useState(308);
-  const [activeTab, setActiveTab] = useState<InspectorTab>("Progress");
   const progress = progressPercent(diagnostics, continuityQueued);
   const warnings = warningCount(readiness, diagnostics, continuityQueued);
 
@@ -207,13 +213,13 @@ export default function ArtifactInspectorRail({ readiness, continuityQueued, dia
         <span className="muted text-[10px]">{warnings} warnings</span>
       </div>
       <div className="inspector-tabs" role="tablist">
-        {(["Progress", "Context", "Artifacts", "Memory"] as InspectorTab[]).map((tab) => (
-          <button key={tab} type="button" className={tab === activeTab ? "shell-link shell-link--active px-2 py-1 text-xs" : "shell-link px-2 py-1 text-xs"} onClick={() => setActiveTab(tab)}>
-            {tab}
+        {inspectorTabs.map((tab) => (
+          <button key={tab.mode} type="button" className={tab.mode === mode ? "shell-link shell-link--active px-2 py-1 text-xs" : "shell-link px-2 py-1 text-xs"} onClick={() => onModeChange(tab.mode)}>
+            {tab.label}
           </button>
         ))}
       </div>
-      <TabPreview tab={activeTab} readiness={readiness} diagnostics={diagnostics} continuityQueued={continuityQueued} />
+      <TabPreview tab={mode} readiness={readiness} diagnostics={diagnostics} continuityQueued={continuityQueued} />
     </aside>
   );
 }

--- a/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/ArtifactSurface.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import ArtifactInspectorRail, { type ArtifactInspectorDiagnostics } from "@/features/scenes/components/writeTab/ArtifactInspectorRail";
-import type { ContextReadiness } from "@/features/scenes/components/writeTab/types";
+import type { ContextReadiness, WriteInspectorMode } from "@/features/scenes/components/writeTab/types";
 
 type ArtifactMode = "read" | "edit" | "analysis" | "review" | "approve";
 
@@ -20,6 +20,8 @@ type ArtifactSurfaceProps = {
   onQueueContinuity: () => void;
   onSaveDraft: (text: string) => Promise<void>;
   isVisible: boolean;
+  inspectorMode: WriteInspectorMode;
+  onInspectorModeChange: (mode: WriteInspectorMode) => void;
 };
 
 type ApprovalGate = {
@@ -241,7 +243,7 @@ function ReviewArtifact({ storySlug, chapterId }: { storySlug: string; chapterId
         <div className="font-semibold">Review handoff</div>
         <p className="muted text-xs">Chapter review requests and reviewer scoring live in the story review workspace.</p>
         <Link href={`/stories/${encodeURIComponent(storySlug)}/reviews`} className="shell-link w-fit px-3 py-2 text-xs">
-          Open reviews
+          Open full reviews workspace
         </Link>
         {chapterId ? <span className="muted text-xs">Active chapter: {chapterId}</span> : null}
       </div>
@@ -271,7 +273,7 @@ function ApproveArtifact({
           {gate.canApprove ? "Ready for review" : "Approval locked"}
         </button>
         <Link href={`/stories/${encodeURIComponent(storySlug)}/reviews`} className="shell-link w-fit px-3 py-2 text-xs">
-          Open reviews
+          Open full reviews workspace
         </Link>
         {readerHref ? (
           <Link href={readerHref} className="shell-link w-fit px-3 py-2 text-xs">
@@ -382,7 +384,13 @@ export default function ArtifactSurface(props: ArtifactSurfaceProps) {
           )}
         </div>
       ) : (
-        <ArtifactInspectorRail readiness={props.readiness} continuityQueued={props.continuityQueued} diagnostics={inspectorDiagnostics} />
+        <ArtifactInspectorRail
+          readiness={props.readiness}
+          continuityQueued={props.continuityQueued}
+          diagnostics={inspectorDiagnostics}
+          mode={props.inspectorMode}
+          onModeChange={props.onInspectorModeChange}
+        />
       )}
     </section>
   );

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -1,7 +1,22 @@
 import React from "react";
 import { useRouter } from "next/navigation";
-import ChatComposer, { type ChatCommandOption } from "@/features/scenes/components/writeTab/chatOrchestration/ChatComposer";
+import ChatComposer from "@/features/scenes/components/writeTab/chatOrchestration/ChatComposer";
 import ChatTimeline from "@/features/scenes/components/writeTab/chatOrchestration/ChatTimeline";
+import {
+  approvalGateBlock,
+  buildCommands,
+  buildContextDigestBlock,
+  buildContextMiniBar,
+  buildWorkspaceArtifactBlock,
+  buildWorkspaceWorkflowBlock,
+  chipTarget,
+  commandDefinition,
+  commandLabel,
+  commandTail,
+  contextWithCommandIntent,
+  type CommandResult,
+  workspaceHref,
+} from "@/features/scenes/components/writeTab/chatOrchestration/commandSurfaceContracts";
 import { routeStudioIntent } from "@/features/scenes/components/writeTab/chatOrchestration/intentRouter";
 import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
 import {
@@ -10,11 +25,11 @@ import {
 } from "@/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents";
 import type {
   AssistantReadinessContext,
-  ChatContextMiniBarPayload,
   CommandId,
   FailureRecoveryBlock,
   RecoveryChip,
   TimelineBlock,
+  WriteInspectorMode,
 } from "@/features/scenes/components/writeTab/types";
 
 type CommandWorkStreamProps = {
@@ -28,129 +43,9 @@ type CommandWorkStreamProps = {
   onCommandMenuOpenChange: (value: boolean) => void;
   onOpenAutoWrite: () => void;
   onQueueContinuity: () => void;
+  onInspectorModeChange: (mode: WriteInspectorMode) => void;
   assistantContext: AssistantReadinessContext;
 };
-
-type CommandResult = {
-  tone: "ready" | "blocked" | "running";
-  title: string;
-  detail: string;
-};
-
-type CommandDefinition = {
-  id: CommandId;
-  description: string;
-  group: "primary" | "more" | "hidden";
-  visible: boolean;
-  unavailableDetail?: string;
-};
-
-const commandDefinitions: CommandDefinition[] = [
-  { id: "/write chapter", description: "Generate chapter draft", group: "primary", visible: true },
-  { id: "/plan", description: "Create chapter outline", group: "primary", visible: true },
-  { id: "/analyze chapter", description: "Analyze source or context", group: "primary", visible: true },
-  { id: "/research", description: "Research story or worldbuilding context", group: "primary", visible: true },
-  { id: "/inspect", description: "Show full context digest", group: "primary", visible: true },
-  { id: "/check continuity", description: "Review canon and timeline handoff", group: "primary", visible: true },
-  { id: "/extract memory", description: "Open story memory extraction", group: "more", visible: true },
-  { id: "/review chapter", description: "Open review panel", group: "more", visible: true },
-  { id: "/split", description: "Prepare chapter split request", group: "more", visible: true },
-  {
-    id: "/rewrite selection",
-    description: "Rewrite selected prose",
-    group: "hidden",
-    visible: false,
-    unavailableDetail: "Selection-backed rewriting is not wired in the Novel Lab artifact surface yet.",
-  },
-  {
-    id: "/continue from cursor",
-    description: "Continue from cursor",
-    group: "hidden",
-    visible: false,
-    unavailableDetail: "Cursor-backed continuation is not wired in the Novel Lab artifact surface yet.",
-  },
-  {
-    id: "/approve draft",
-    description: "Approve active draft",
-    group: "hidden",
-    visible: false,
-    unavailableDetail: "Approval gates are not connected to durable review state from the command surface yet.",
-  },
-  {
-    id: "/publish preview",
-    description: "Preview approved output",
-    group: "hidden",
-    visible: false,
-    unavailableDetail: "Publish preview remains owned by the artifact approval surface until publish workflow state is durable.",
-  },
-];
-
-function commandDefinition(command: CommandId): CommandDefinition | null {
-  return commandDefinitions.find((item) => item.id === command) ?? null;
-}
-
-function commandLabel(command: CommandId): string {
-  return command.replace("/", "").replaceAll("_", " ");
-}
-
-function commandTail(command: CommandId, goal: string): string {
-  return goal.trim() ? `${command} ${goal.trim()}` : `${command} `;
-}
-
-function contextWithCommandIntent(context: AssistantReadinessContext, command: CommandId, goal: string): AssistantReadinessContext {
-  if (command !== "/write chapter" && command !== "/plan" && command !== "/analyze chapter" && command !== "/research") return context;
-  return {
-    ...context,
-    availability: {
-      ...context.availability,
-      has_chapter_intent: context.availability.has_chapter_intent || goal.trim().length > 0,
-    },
-  };
-}
-
-function chipTarget(storySlug: string, chip: RecoveryChip): string | null {
-  const storyBase = `/stories/${encodeURIComponent(storySlug)}`;
-  if (chip.intent === "browse_stories" || chip.intent === "switch_story") return "/shelf";
-  if (chip.intent === "start_story") return "/";
-  if (chip.intent === "add_context" || chip.intent === "analyze_source") return `${storyBase}/analysis`;
-  if (chip.intent === "inspect_context") return `${storyBase}/memory`;
-  return null;
-}
-
-function buildCommands(context: AssistantReadinessContext, chapterId: string): ChatCommandOption[] {
-  const readiness = buildAssistantReadiness(context);
-
-  return commandDefinitions
-    .filter((command) => command.visible)
-    .map((command) => {
-      let blockedReason: string | undefined;
-      if (command.id === "/write chapter" && !readiness.canWrite) {
-        blockedReason = readiness.blockedWriteReason ?? "The chapter context is blocked.";
-      }
-      if (command.id === "/check continuity" && !chapterId) {
-        blockedReason = "Choose or create a chapter before checking continuity.";
-      }
-      if ((command.id === "/plan" || command.id === "/split") && !chapterId) {
-        blockedReason = "Choose or create a chapter before running this command.";
-      }
-
-      return {
-        id: command.id,
-        description: blockedReason ?? command.description,
-        group: command.group === "more" ? "more" : "primary",
-        status: blockedReason ? "blocked" : "ready",
-        blockedReason,
-      };
-    });
-}
-
-function buildContextMiniBar(context: AssistantReadinessContext, status: ChatContextMiniBarPayload["status"]): ChatContextMiniBarPayload {
-  return {
-    storyTitle: context.storyTitle?.trim() || "No story selected",
-    chapterLabel: context.chapterTitle?.trim() || context.chapterId || "No chapter selected",
-    status,
-  };
-}
 
 function resultBlock(result: CommandResult): TimelineBlock {
   if (result.tone === "blocked") {
@@ -240,55 +135,8 @@ function buildTimelineBlocks(args: {
   return blocks;
 }
 
-function buildContextDigestBlock(context: AssistantReadinessContext): TimelineBlock {
-  const included = [
-    context.storySelected ? "Story selected" : "",
-    context.chapterId ? "Chapter selected" : "",
-    context.availability.has_source_chapters ? "Source material" : "",
-    context.availability.has_active_characters ? "Active characters" : "",
-    context.availability.has_memory_snapshot ? "Memory snapshot" : "",
-    context.availability.has_style_profile ? "Style profile" : "",
-    context.availability.has_immediate_continuity ? "Immediate continuity" : "",
-    context.availability.has_chapter_intent ? "Chapter intent" : "",
-  ].filter(Boolean);
-  const missing = [
-    context.storySelected ? "" : "Story selected",
-    context.chapterId ? "" : "Chapter selected",
-    context.availability.has_source_chapters ? "" : "Source material",
-    context.availability.has_active_characters ? "" : "Active characters",
-    context.availability.has_chapter_intent ? "" : "Chapter intent",
-  ].filter(Boolean);
-  const degraded = [
-    context.availability.has_memory_snapshot ? "" : "Memory snapshot",
-    context.availability.has_style_profile ? "" : "Style profile",
-    context.availability.has_immediate_continuity ? "" : "Immediate continuity",
-  ].filter(Boolean);
-
-  return {
-    id: "intent-context-digest",
-    type: "context_digest",
-    source: "assistant",
-    title: context.chapterId ? `Chapter ${context.chapterId} context` : "Current story context",
-    included,
-    missing,
-    degraded,
-    conflicts: context.readiness === "blocked" ? ["Current context is blocked for writing."] : [],
-  };
-}
-
-function approvalGateBlock(chapterId: string): TimelineBlock {
-  return {
-    id: "intent-approval-gate",
-    type: "approval_gate",
-    source: "assistant",
-    gate_type: "import_to_editor",
-    description: chapterId
-      ? "This needs your sign-off before I can continue. Importing to the editor does not approve story memory or publish the chapter."
-      : "Choose a chapter before approving or importing draft content.",
-    actions: ["import_to_editor", "keep_as_draft", "run_continuity_check"],
-  };
-}
-
+// Command dispatch mirrors the slash-command contract table; keep branches explicit so blocked/degraded routing stays readable.
+// eslint-disable-next-line max-lines-per-function
 function useCommandRunner(args: {
   storySlug: string;
   chapterId: string;
@@ -298,14 +146,17 @@ function useCommandRunner(args: {
   mode: "chat" | "brainstorm";
   onModeChange: (mode: "chat" | "brainstorm") => void;
   onConversationBlock: (block: TimelineBlock) => void;
+  onInspectorModeChange: (mode: WriteInspectorMode) => void;
 }) {
   const router = useRouter();
   const [commandResult, setCommandResult] = React.useState<CommandResult | null>(null);
   const [intentBlock, setIntentBlock] = React.useState<TimelineBlock | null>(null);
 
   const runCommand = React.useCallback(
+    // eslint-disable-next-line complexity, max-lines-per-function
     (command: CommandId, goal: string) => {
       setIntentBlock(null);
+      setCommandResult(null);
       const definition = commandDefinition(command);
       if (definition?.visible === false) {
         setCommandResult({
@@ -316,11 +167,25 @@ function useCommandRunner(args: {
         return;
       }
 
-      const storyBase = `/stories/${encodeURIComponent(args.storySlug)}`;
       const commandContext = contextWithCommandIntent(args.readinessContext, command, goal);
-      if (command === "/inspect" || command === "/status") {
-        setIntentBlock(buildContextDigestBlock(commandContext));
+      if (command === "/inspect" || command === "/status" || command === "/context") {
+        args.onInspectorModeChange("context");
+        setIntentBlock(buildContextDigestBlock(commandContext, [{ label: "Open full memory workspace", href: workspaceHref(args.storySlug, "memory") }]));
         setCommandResult({ tone: "ready", title: "Context digest ready", detail: "I found the current story and chapter context state." });
+        return;
+      }
+
+      if (command === "/pipeline") {
+        args.onInspectorModeChange("progress");
+        args.onConversationBlock(buildWorkspaceWorkflowBlock({
+          id: `pipeline-${Date.now()}`,
+          workflowName: "Pipeline Progress",
+          stepLabel: "Inspecting active workflow state",
+          chapterId: args.chapterId,
+          actionLabel: "Open full pipelines workspace",
+          actionHref: workspaceHref(args.storySlug, "pipelines"),
+        }));
+        setCommandResult({ tone: "ready", title: "Pipeline progress opened", detail: "I kept the workflow state in the Write workspace inspector." });
         return;
       }
 
@@ -350,8 +215,25 @@ function useCommandRunner(args: {
       }
 
       if (command === "/research") {
-        router.push(`${storyBase}/analysis`);
-        setCommandResult({ tone: "ready", title: "Opening research context", detail: "Research and source analysis continue in the analysis workspace." });
+        args.onInspectorModeChange("context");
+        const stamp = Date.now();
+        args.onConversationBlock(buildWorkspaceWorkflowBlock({
+          id: `research-progress-${stamp}`,
+          workflowName: "Research Context",
+          stepLabel: "Preparing research context",
+          chapterId: args.chapterId,
+          actionLabel: "Open full analysis workspace",
+          actionHref: workspaceHref(args.storySlug, "analysis"),
+        }));
+        args.onConversationBlock(buildWorkspaceArtifactBlock({
+          id: `research-artifact-${stamp}`,
+          artifactType: "research",
+          title: "Research context",
+          description: "Research stays in this Write workspace; open the full analysis workspace only if you need the deep view.",
+          actionLabel: "Open full analysis workspace",
+          actionHref: workspaceHref(args.storySlug, "analysis"),
+        }));
+        setCommandResult({ tone: "ready", title: "Research context opened", detail: "I kept it in Write and opened the context inspector." });
         return;
       }
 
@@ -384,32 +266,68 @@ function useCommandRunner(args: {
           setCommandResult({ tone: "blocked", title: "Continuity Check", detail: "Choose or create a chapter before checking continuity." });
           return;
         }
+        args.onInspectorModeChange("progress");
         args.onQueueContinuity();
         setCommandResult({ tone: "running", title: "Continuity check queued", detail: "Canon, timeline, and reveal constraints are now marked for validation." });
         return;
       }
 
       if (command === "/analyze chapter") {
-        router.push(`${storyBase}/analysis`);
-        setCommandResult({ tone: "ready", title: "Opening analysis", detail: "The analysis workspace owns chapter and source diagnostics." });
+        args.onInspectorModeChange("context");
+        const stamp = Date.now();
+        args.onConversationBlock(buildWorkspaceWorkflowBlock({
+          id: `analysis-progress-${stamp}`,
+          workflowName: "Chapter Analysis",
+          stepLabel: "Analyzing chapter context",
+          chapterId: args.chapterId,
+          actionLabel: "Open full analysis workspace",
+          actionHref: workspaceHref(args.storySlug, "analysis"),
+        }));
+        args.onConversationBlock(buildWorkspaceArtifactBlock({
+          id: `analysis-artifact-${stamp}`,
+          artifactType: "analysis",
+          title: "Chapter analysis report",
+          description: "Analysis is attached to the Write timeline and expanded in the right inspector.",
+          actionLabel: "Open full analysis workspace",
+          actionHref: workspaceHref(args.storySlug, "analysis"),
+        }));
+        setCommandResult({ tone: "ready", title: "Analysis opened", detail: "I kept the command inside Write and opened the context inspector." });
         return;
       }
 
-      if (command === "/extract memory") {
-        router.push(`${storyBase}/memory`);
-        setCommandResult({ tone: "ready", title: "Opening memory hub", detail: "Memory extraction and conflict review continue in the story memory workspace." });
+      if (command === "/extract memory" || command === "/memory") {
+        args.onInspectorModeChange("memory");
+        setIntentBlock(buildContextDigestBlock(commandContext, [{ label: "Open full memory workspace", href: workspaceHref(args.storySlug, "memory") }]));
+        setCommandResult({ tone: "ready", title: "Memory notes opened", detail: "I kept memory and continuity notes in the Write workspace inspector." });
         return;
       }
 
       if (command === "/review chapter") {
-        router.push(`${storyBase}/reviews`);
-        setCommandResult({ tone: "ready", title: "Opening reviews", detail: "Chapter review requests, scoring, and responses live in the review workspace." });
+        args.onInspectorModeChange("artifacts");
+        const stamp = Date.now();
+        args.onConversationBlock(buildWorkspaceWorkflowBlock({
+          id: `review-progress-${stamp}`,
+          workflowName: "Chapter Review",
+          stepLabel: "Preparing review artifact",
+          chapterId: args.chapterId,
+          actionLabel: "Open full reviews workspace",
+          actionHref: workspaceHref(args.storySlug, "reviews"),
+        }));
+        args.onConversationBlock(buildWorkspaceArtifactBlock({
+          id: `review-artifact-${stamp}`,
+          artifactType: "review",
+          title: "Chapter review result",
+          description: "Review output is visible in Write and expands through the artifact inspector.",
+          actionLabel: "Open full reviews workspace",
+          actionHref: workspaceHref(args.storySlug, "reviews"),
+        }));
+        setCommandResult({ tone: "ready", title: "Review opened", detail: "I kept review output inside Write and opened the artifact inspector." });
         return;
       }
 
       setCommandResult({ tone: "blocked", title: `${commandLabel(command)} unavailable`, detail: "This command is not wired to a safe workflow action yet." });
     },
-    [args, router]
+    [args]
   );
 
   const submitMessage = React.useCallback((message: string) => {
@@ -421,8 +339,9 @@ function useCommandRunner(args: {
       return;
     }
     if (route.intent === "ADD_CONTEXT") {
-      router.push(`/stories/${encodeURIComponent(args.storySlug)}/analysis`);
-      setCommandResult({ tone: "ready", title: "Opening context tools", detail: "Add or analyze story context before writing." });
+      args.onInspectorModeChange("context");
+      setIntentBlock(buildContextDigestBlock(args.readinessContext, [{ label: "Open full analysis workspace", href: workspaceHref(args.storySlug, "analysis") }]));
+      setCommandResult({ tone: "ready", title: "Context tools opened", detail: "I kept context recovery in Write and opened the context inspector." });
       return;
     }
     if (route.intent === "BRAINSTORM") {
@@ -481,6 +400,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     mode: chatMode,
     onModeChange: setChatMode,
     onConversationBlock: (block) => setConversationBlocks((current) => [...current, block]),
+    onInspectorModeChange: props.onInspectorModeChange,
   });
   const blocks = buildTimelineBlocks({
     briefing,
@@ -496,10 +416,37 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
   });
 
   const handleChip = (chip: RecoveryChip) => {
-    const target = chipTarget(props.storySlug, chip);
+    const target = chipTarget(chip);
     if (chip.intent === "describe_goal" || chip.intent === "continue_degraded") {
       props.onComposerValueChange(props.chapterId ? `/write chapter ${props.chapterId} ` : "/write chapter ");
       props.onCommandMenuOpenChange(false);
+      return;
+    }
+    if (chip.intent === "add_context" || chip.intent === "analyze_source") {
+      props.onInspectorModeChange("context");
+      setConversationBlocks((current) => [
+        ...current,
+        buildWorkspaceWorkflowBlock({
+          id: `recovery-analysis-${Date.now()}`,
+          workflowName: "Context Recovery",
+          stepLabel: chip.intent === "analyze_source" ? "Analyzing source context" : "Preparing missing context",
+          chapterId: props.chapterId,
+          actionLabel: "Open full analysis workspace",
+          actionHref: workspaceHref(props.storySlug, "analysis"),
+        }),
+      ]);
+      return;
+    }
+    if (chip.intent === "inspect_context") {
+      props.onInspectorModeChange("context");
+      setConversationBlocks((current) => [
+        ...current,
+        buildContextDigestBlock(
+          props.assistantContext,
+          [{ label: "Open full memory workspace", href: workspaceHref(props.storySlug, "memory") }],
+          `recovery-context-${Date.now()}`
+        ),
+      ]);
       return;
     }
     if (target) router.push(target);

--- a/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/NovelLabWorkspace.tsx
@@ -11,6 +11,7 @@ import type {
   ContextReadiness,
   CurrentVersion,
   SceneItem,
+  WriteInspectorMode,
 } from "@/features/scenes/components/writeTab/types";
 
 type DraftSource = {
@@ -236,16 +237,21 @@ function WorkspaceAutoWriteModal(
 }
 
 export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
-  const { isArtifactVisible } = useStory();
+  const { isArtifactVisible, setIsArtifactVisible } = useStory();
   const [continuityQueued, setContinuityQueued] = useState(false);
   const [composerValue, setComposerValue] = useState("");
   const [commandMenuOpen, setCommandMenuOpen] = useState(false);
+  const [inspectorMode, setInspectorMode] = useState<WriteInspectorMode>("progress");
   const draftSource = useMemo(() => buildDraftSource(props), [props]);
   const chapterTitle = selectedChapterTitle(props.selectedChapterId);
   const hasDraft = draftSource.text.trim().length > 0;
   const loadingWorkspace = props.loadingScenes || props.loadingDetail || props.loadingChapter;
   const readiness: ContextReadiness = "degraded";
   const availability = assistantAvailability(props, hasDraft);
+  const openInspectorMode = (mode: WriteInspectorMode) => {
+    setInspectorMode(mode);
+    setIsArtifactVisible(false);
+  };
 
   return (
     <>
@@ -278,6 +284,7 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
           onCommandMenuOpenChange={setCommandMenuOpen}
           onOpenAutoWrite={() => props.setShowAutoWrite(true)}
           onQueueContinuity={() => setContinuityQueued(true)}
+          onInspectorModeChange={openInspectorMode}
           assistantContext={{
             storyTitle: storyLabelFromSlug(props.storySlug),
             storySelected: Boolean(props.storySlug),
@@ -298,6 +305,8 @@ export default function NovelLabWorkspace(props: NovelLabWorkspaceProps) {
           hasChapter={Boolean(props.selectedChapterId)}
           readiness={readiness}
           isVisible={isArtifactVisible}
+          inspectorMode={inspectorMode}
+          onInspectorModeChange={setInspectorMode}
           continuityQueued={continuityQueued}
           onOpenAutoWrite={() => props.setShowAutoWrite(true)}
           onQueueContinuity={() => setContinuityQueued(true)}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
@@ -101,6 +101,13 @@ export function WorkflowProgressBlockView({
           <button type="button">Cancel</button>
         </div>
       ) : null}
+      {block.action_links?.length ? (
+        <div className="timeline-card__actions">
+          {block.action_links.map((link) => (
+            <a key={link.href} href={link.href}>{link.label}</a>
+          ))}
+        </div>
+      ) : null}
     </article>
   );
 }
@@ -138,6 +145,9 @@ export function ArtifactPreviewBlockView({
           <button key={action} type="button">
             {action.replaceAll("_", " ")}
           </button>
+        ))}
+        {block.action_links?.map((link) => (
+          <a key={link.href} href={link.href}>{link.label}</a>
         ))}
       </div>
     </article>
@@ -199,6 +209,13 @@ export function ContextDigestBlockView({ block }: { block: Extract<TimelineBlock
         </div>
       </div>
       {block.conflicts.length ? <p>{block.conflicts.join("; ")}</p> : null}
+      {block.action_links?.length ? (
+        <div className="timeline-card__actions">
+          {block.action_links.map((link) => (
+            <a key={link.href} href={link.href}>{link.label}</a>
+          ))}
+        </div>
+      ) : null}
     </article>
   );
 }

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/commandSurfaceContracts.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/commandSurfaceContracts.ts
@@ -1,0 +1,242 @@
+import type { ChatCommandOption } from "@/features/scenes/components/writeTab/chatOrchestration/ChatComposer";
+import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
+import type {
+  AssistantReadinessContext,
+  ChatContextMiniBarPayload,
+  CommandId,
+  RecoveryChip,
+  TimelineBlock,
+} from "@/features/scenes/components/writeTab/types";
+
+export type CommandResult = {
+  tone: "ready" | "blocked" | "running";
+  title: string;
+  detail: string;
+};
+
+type CommandDefinition = {
+  id: CommandId;
+  description: string;
+  group: "primary" | "more" | "hidden";
+  visible: boolean;
+  unavailableDetail?: string;
+};
+
+const commandDefinitions: CommandDefinition[] = [
+  { id: "/write chapter", description: "Generate chapter draft", group: "primary", visible: true },
+  { id: "/plan", description: "Create chapter outline", group: "primary", visible: true },
+  { id: "/analyze chapter", description: "Analyze source or context", group: "primary", visible: true },
+  { id: "/research", description: "Research story or worldbuilding context", group: "primary", visible: true },
+  { id: "/inspect", description: "Show full context digest", group: "primary", visible: true },
+  { id: "/context", description: "Inspect context readiness", group: "primary", visible: true },
+  { id: "/pipeline", description: "Show pipeline progress", group: "primary", visible: true },
+  { id: "/check continuity", description: "Review canon and timeline handoff", group: "primary", visible: true },
+  { id: "/extract memory", description: "Open story memory extraction", group: "more", visible: true },
+  { id: "/memory", description: "Show memory and continuity notes", group: "more", visible: true },
+  { id: "/review chapter", description: "Open review panel", group: "more", visible: true },
+  { id: "/split", description: "Prepare chapter split request", group: "more", visible: true },
+  {
+    id: "/rewrite selection",
+    description: "Rewrite selected prose",
+    group: "hidden",
+    visible: false,
+    unavailableDetail: "Selection-backed rewriting is not wired in the Novel Lab artifact surface yet.",
+  },
+  {
+    id: "/continue from cursor",
+    description: "Continue from cursor",
+    group: "hidden",
+    visible: false,
+    unavailableDetail: "Cursor-backed continuation is not wired in the Novel Lab artifact surface yet.",
+  },
+  {
+    id: "/approve draft",
+    description: "Approve active draft",
+    group: "hidden",
+    visible: false,
+    unavailableDetail: "Approval gates are not connected to durable review state from the command surface yet.",
+  },
+  {
+    id: "/publish preview",
+    description: "Preview approved output",
+    group: "hidden",
+    visible: false,
+    unavailableDetail: "Publish preview remains owned by the artifact approval surface until publish workflow state is durable.",
+  },
+];
+
+export function commandDefinition(command: CommandId): CommandDefinition | null {
+  return commandDefinitions.find((item) => item.id === command) ?? null;
+}
+
+export function commandLabel(command: CommandId): string {
+  return command.replace("/", "").replaceAll("_", " ");
+}
+
+export function commandTail(command: CommandId, goal: string): string {
+  return goal.trim() ? `${command} ${goal.trim()}` : `${command} `;
+}
+
+export function contextWithCommandIntent(context: AssistantReadinessContext, command: CommandId, goal: string): AssistantReadinessContext {
+  if (command !== "/write chapter" && command !== "/plan" && command !== "/analyze chapter" && command !== "/research") return context;
+  return {
+    ...context,
+    availability: {
+      ...context.availability,
+      has_chapter_intent: context.availability.has_chapter_intent || goal.trim().length > 0,
+    },
+  };
+}
+
+export function chipTarget(chip: RecoveryChip): string | null {
+  if (chip.intent === "browse_stories" || chip.intent === "switch_story") return "/shelf";
+  if (chip.intent === "start_story") return "/";
+  return null;
+}
+
+export function buildCommands(context: AssistantReadinessContext, chapterId: string): ChatCommandOption[] {
+  const readiness = buildAssistantReadiness(context);
+
+  return commandDefinitions
+    .filter((command) => command.visible)
+    .map((command) => {
+      let blockedReason: string | undefined;
+      if (command.id === "/write chapter" && !readiness.canWrite) {
+        blockedReason = readiness.blockedWriteReason ?? "The chapter context is blocked.";
+      }
+      if (command.id === "/check continuity" && !chapterId) {
+        blockedReason = "Choose or create a chapter before checking continuity.";
+      }
+      if ((command.id === "/plan" || command.id === "/split") && !chapterId) {
+        blockedReason = "Choose or create a chapter before running this command.";
+      }
+
+      return {
+        id: command.id,
+        description: blockedReason ?? command.description,
+        group: command.group === "more" ? "more" : "primary",
+        status: blockedReason ? "blocked" : "ready",
+        blockedReason,
+      };
+    });
+}
+
+export function buildContextMiniBar(context: AssistantReadinessContext, status: ChatContextMiniBarPayload["status"]): ChatContextMiniBarPayload {
+  return {
+    storyTitle: context.storyTitle?.trim() || "No story selected",
+    chapterLabel: context.chapterTitle?.trim() || context.chapterId || "No chapter selected",
+    status,
+  };
+}
+
+export function workspaceHref(storySlug: string, workspace: "analysis" | "reviews" | "memory" | "pipelines"): string {
+  return `/stories/${encodeURIComponent(storySlug)}/${workspace}`;
+}
+
+function labelsFor(items: Array<[boolean, string]>): string[] {
+  return items.flatMap(([condition, label]) => condition ? [label] : []);
+}
+
+export function buildContextDigestBlock(context: AssistantReadinessContext, actionLinks: Array<{ label: string; href: string }> = [], id = "intent-context-digest"): TimelineBlock {
+  const included = labelsFor([
+    [context.storySelected, "Story selected"],
+    [Boolean(context.chapterId), "Chapter selected"],
+    [context.availability.has_source_chapters, "Source material"],
+    [context.availability.has_active_characters, "Active characters"],
+    [context.availability.has_memory_snapshot, "Memory snapshot"],
+    [context.availability.has_style_profile, "Style profile"],
+    [context.availability.has_immediate_continuity, "Immediate continuity"],
+    [context.availability.has_chapter_intent, "Chapter intent"],
+  ]);
+  const missing = labelsFor([
+    [!context.storySelected, "Story selected"],
+    [!context.chapterId, "Chapter selected"],
+    [!context.availability.has_source_chapters, "Source material"],
+    [!context.availability.has_active_characters, "Active characters"],
+    [!context.availability.has_chapter_intent, "Chapter intent"],
+  ]);
+  const degraded = labelsFor([
+    [!context.availability.has_memory_snapshot, "Memory snapshot"],
+    [!context.availability.has_style_profile, "Style profile"],
+    [!context.availability.has_immediate_continuity, "Immediate continuity"],
+  ]);
+
+  return {
+    id,
+    type: "context_digest",
+    source: "assistant",
+    title: context.chapterId ? `Chapter ${context.chapterId} context` : "Current story context",
+    included,
+    missing,
+    degraded,
+    conflicts: context.readiness === "blocked" ? ["Current context is blocked for writing."] : [],
+    action_links: actionLinks,
+  };
+}
+
+export function buildWorkspaceWorkflowBlock(args: {
+  id: string;
+  workflowName: string;
+  stepLabel: string;
+  chapterId: string;
+  actionLabel: string;
+  actionHref: string;
+}): TimelineBlock {
+  return {
+    id: args.id,
+    type: "workflow_progress",
+    source: "backend",
+    event_id: args.id,
+    chapter_id: args.chapterId || null,
+    job_id: null,
+    workflow_name: args.workflowName,
+    status: "running",
+    current_step: 1,
+    total_steps: 3,
+    current_step_label: args.stepLabel,
+    steps: [
+      { label: "Read workspace context", status: "complete" },
+      { label: args.stepLabel, status: "active" },
+      { label: "Create workspace artifact", status: "pending" },
+    ],
+    action_links: [{ label: args.actionLabel, href: args.actionHref }],
+  };
+}
+
+export function buildWorkspaceArtifactBlock(args: {
+  id: string;
+  artifactType: "analysis" | "review" | "research";
+  title: string;
+  description: string;
+  actionLabel: string;
+  actionHref: string;
+}): TimelineBlock {
+  return {
+    id: args.id,
+    type: "artifact_preview",
+    source: "backend",
+    artifact_id: args.id,
+    artifact_type: args.artifactType,
+    title: args.title,
+    status: "draft",
+    description: args.description,
+    word_count: null,
+    beat_count: null,
+    preview_lines: [args.description],
+    actions: [],
+    action_links: [{ label: args.actionLabel, href: args.actionHref }],
+  };
+}
+
+export function approvalGateBlock(chapterId: string): TimelineBlock {
+  return {
+    id: "intent-approval-gate",
+    type: "approval_gate",
+    source: "assistant",
+    gate_type: "import_to_editor",
+    description: chapterId
+      ? "This needs your sign-off before I can continue. Importing to the editor does not approve story memory or publish the chapter."
+      : "Choose a chapter before approving or importing draft content.",
+    actions: ["import_to_editor", "keep_as_draft", "run_continuity_check"],
+  };
+}

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -110,6 +110,13 @@ export type InlineChoiceChip = RecoveryChip & {
 
 export type WorkflowStepStatus = "complete" | "active" | "pending" | "failed";
 
+export type WriteInspectorMode = "progress" | "context" | "artifacts" | "memory";
+
+export type TimelineActionLink = {
+  label: string;
+  href: string;
+};
+
 export type WorkflowProgressBlock = {
   type: "workflow_progress";
   source: "backend" | "assistant";
@@ -126,6 +133,7 @@ export type WorkflowProgressBlock = {
     label: string;
     status: WorkflowStepStatus;
   }>;
+  action_links?: TimelineActionLink[];
 };
 
 export type ArtifactPreviewBlock = {
@@ -144,6 +152,7 @@ export type ArtifactPreviewBlock = {
   beat_count: number | null;
   preview_lines: string[];
   actions: string[];
+  action_links?: TimelineActionLink[];
 };
 
 export type ApprovalGateBlock = {
@@ -185,6 +194,7 @@ export type ContextDigestBlock = {
   missing: string[];
   degraded: string[];
   conflicts: string[];
+  action_links?: TimelineActionLink[];
 };
 
 export type TimelineBlock =
@@ -204,6 +214,9 @@ export type CommandId =
   | "/plan"
   | "/analyze chapter"
   | "/research"
+  | "/context"
+  | "/pipeline"
+  | "/memory"
   | "/rewrite selection"
   | "/continue from cursor"
   | "/check continuity"


### PR DESCRIPTION
## Summary
- keep Write workspace commands inside the Write UI by appending contract timeline blocks and switching the right inspector mode
- add shared inspector mode state, compact full-workspace action links, and command-surface contract builders
- document that deep Analysis/Reviews/Memory/Pipelines pages are explicit secondary links, not default command routes

## Verification
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/ArtifactInspectorRail.tsx src/features/scenes/components/writeTab/ArtifactSurface.tsx src/features/scenes/components/writeTab/NovelLabWorkspace.tsx src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx src/features/scenes/components/writeTab/chatOrchestration/commandSurfaceContracts.ts src/features/scenes/components/writeTab/types.ts
- git diff --check
- npm run build

Closes #126