### PR TITLE
Fix brainstorm mode intent capture

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -56,6 +56,7 @@ Refactor direction for large modules:
 - The slash command menu is anchored above the composer with internal scrolling and must not shift the page layout.
 - Write workspace commands stay inside Write by default. Command handlers append the relevant timeline block and switch the shared right-inspector mode; they must not use route navigation for `/analyze`, `/research`, `/review`, `/memory`, `/pipeline`, `/context`, `/inspect`, or `/status`.
 - Inspector mode is workspace UI state, not route state. Deep Analysis, Reviews, Memory, and Pipelines pages remain available only through explicit secondary links such as "Open full analysis workspace".
+- Active chat mode is soft context, not a lock. Every user turn is routed through intent classification first, so brainstorm mode must yield to explicit repo/dev help, clarification, inspect/analyze/write commands, and quoted-response questions.
 - Chat artifact summary cards use the `artifact_preview` timeline block contract. The chat timeline renders a compact card with title, status, short description, and actions; full artifact or document content stays in the artifact panel or document workspace.
 - Workflow progress uses `workflow_progress` blocks mapped from backend-shaped pipeline/job events. The chat timeline renders compact progress, while the right inspector renders detailed step state. Worker logs and diagnostics stay in Operations surfaces.
 - Right inspector modes reuse timeline block contracts where possible:

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -145,6 +145,8 @@ function useCommandRunner(args: {
   readinessContext: AssistantReadinessContext;
   mode: "chat" | "brainstorm";
   onModeChange: (mode: "chat" | "brainstorm") => void;
+  recentBrainstormSeed: string | null;
+  onBrainstormSeedChange: (seed: string | null) => void;
   onConversationBlock: (block: TimelineBlock) => void;
   onInspectorModeChange: (mode: WriteInspectorMode) => void;
 }) {
@@ -331,8 +333,16 @@ function useCommandRunner(args: {
   );
 
   const submitMessage = React.useCallback((message: string) => {
-    const route = routeStudioIntent({ message, readiness: args.readinessContext.readiness, mode: args.mode });
+    const route = routeStudioIntent({
+      message,
+      readiness: args.readinessContext.readiness,
+      mode: args.mode,
+      recentBrainstormSeed: args.recentBrainstormSeed,
+    });
     setIntentBlock(null);
+    if (route.brainstormSeed !== undefined) {
+      args.onBrainstormSeedChange(route.brainstormSeed);
+    }
     if (route.intent === "SWITCH_STORY") {
       router.push("/shelf");
       setCommandResult({ tone: "ready", title: "Opening story selector", detail: "Choose the story you want to work on next." });
@@ -344,25 +354,19 @@ function useCommandRunner(args: {
       setCommandResult({ tone: "ready", title: "Context tools opened", detail: "I kept context recovery in Write and opened the context inspector." });
       return;
     }
-    if (route.intent === "BRAINSTORM") {
-      args.onModeChange("brainstorm");
+    if (route.assistantText) {
+      if (route.intent === "BRAINSTORM") {
+        args.onModeChange("brainstorm");
+      }
+      if (route.intent === "REPO_RUN_HELP" || route.intent === "REPO_TEST_HELP") {
+        args.onModeChange("chat");
+      }
       args.onConversationBlock({
         id: `assistant-${Date.now()}`,
         type: "text_message",
         source: "assistant",
         label: "Studio Writing Assistant",
-        text: route.assistantText ?? "I can brainstorm here without starting a writing workflow.",
-        tone: "ready",
-      });
-      return;
-    }
-    if (route.intent === "CHAT") {
-      args.onConversationBlock({
-        id: `assistant-${Date.now()}`,
-        type: "text_message",
-        source: "assistant",
-        label: "Studio Writing Assistant",
-        text: route.assistantText ?? "Hi. I can chat freely or help with writing workflows when you ask.",
+        text: route.assistantText,
         tone: "ready",
       });
       return;
@@ -387,6 +391,7 @@ function useCommandRunner(args: {
 export default function CommandWorkStream(props: CommandWorkStreamProps) {
   const router = useRouter();
   const [chatMode, setChatMode] = React.useState<"chat" | "brainstorm">("chat");
+  const [recentBrainstormSeed, setRecentBrainstormSeed] = React.useState<string | null>(null);
   const [conversationBlocks, setConversationBlocks] = React.useState<TimelineBlock[]>([]);
   const [pendingAssistant, setPendingAssistant] = React.useState(false);
   const briefing = buildAssistantReadiness(props.assistantContext);
@@ -399,6 +404,8 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     readinessContext: props.assistantContext,
     mode: chatMode,
     onModeChange: setChatMode,
+    recentBrainstormSeed,
+    onBrainstormSeedChange: setRecentBrainstormSeed,
     onConversationBlock: (block) => setConversationBlocks((current) => [...current, block]),
     onInspectorModeChange: props.onInspectorModeChange,
   });

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts
@@ -4,6 +4,8 @@ function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(message);
 }
 
+// Dense self-test keeps router regression cases beside the deterministic router.
+// eslint-disable-next-line complexity
 export function runIntentRouterSelfTest(): void {
   assert(detectStudioIntent("Hi") === "CHAT", "greeting maps to CHAT");
   assert(detectStudioIntent("continue") === "WRITE", "continue maps to WRITE");
@@ -18,12 +20,16 @@ export function runIntentRouterSelfTest(): void {
   assert(detectStudioIntent("inspect context") === "INSPECT", "inspect maps to INSPECT");
   assert(detectStudioIntent("approve this") === "APPROVE", "approve maps to APPROVE");
   assert(detectStudioIntent("what do we do now") === "CHAT", "next-step question maps to CHAT");
+  assert(detectStudioIntent("How do I run this src, and how do I test it?") === "REPO_RUN_HELP", "run/test help overrides brainstorm");
+  assert(detectStudioIntent("what angle?") === "BRAINSTORM_CLARIFICATION", "angle question maps to brainstorm clarification");
+  assert(detectStudioIntent("1") === "BRAINSTORM_EXPAND_CHOICE", "numbered brainstorm choice maps to expand choice");
 
   const ambiguous = routeStudioIntent({ message: "maybe later", readiness: "degraded" });
   assert(ambiguous.needsClarification && ambiguous.assistantText !== null, "ambiguous input asks one clarifying question");
 
   const brainstormFollowup = routeStudioIntent({ message: "maybe a betrayal scene", readiness: "degraded", mode: "brainstorm" });
   assert(brainstormFollowup.intent === "BRAINSTORM" && !brainstormFollowup.needsClarification, "brainstorm mode keeps free chat active");
+  assert(brainstormFollowup.brainstormSeed === "maybe a betrayal scene", "brainstorm seed is retained for follow-up clarification");
 
   const adoptionBrainstorm = routeStudioIntent({
     message: "a boy, who is adopted, living in normal family, he does not like it, confused",
@@ -31,6 +37,45 @@ export function runIntentRouterSelfTest(): void {
     mode: "brainstorm",
   });
   assert(adoptionBrainstorm.assistantText?.includes("adopted") === true, "brainstorm mode responds to adoption seed");
+  assert(adoptionBrainstorm.assistantText?.includes("1.") === true, "brainstorm mode renders numbered options");
+
+  const scienceBrainstorm = routeStudioIntent({
+    message: "bomb, heart attack, science",
+    readiness: "degraded",
+    mode: "brainstorm",
+  });
+  assert(scienceBrainstorm.assistantText?.includes("science-thriller tragedy") === true, "science seed gets concrete genre framing");
+  assert(scienceBrainstorm.assistantText?.includes("bomb design") === true, "science seed uses bomb detail");
+  assert(scienceBrainstorm.assistantText?.includes("heart monitor") === true, "science seed uses heart detail");
+
+  const repoHelp = routeStudioIntent({
+    message: "How do I run this src, and how do I test it?",
+    readiness: "degraded",
+    mode: "brainstorm",
+    recentBrainstormSeed: "bomb, heart attack, science",
+  });
+  assert(repoHelp.intent === "REPO_RUN_HELP", "repo help wins over active brainstorm mode");
+  assert(repoHelp.assistantText?.includes("npm run dev") === true, "repo help includes run command");
+  assert(repoHelp.assistantText?.includes("npm run typecheck") === true, "repo help includes test/check command");
+
+  const clarifyAngle = routeStudioIntent({
+    message: "what angle?",
+    readiness: "degraded",
+    mode: "brainstorm",
+    recentBrainstormSeed: "bomb, heart attack, science",
+  });
+  assert(clarifyAngle.intent === "BRAINSTORM_CLARIFICATION", "angle clarification wins over seed handling");
+  assert(clarifyAngle.assistantText?.includes("By \"angle\"") === true, "angle clarification explains the term");
+  assert(clarifyAngle.assistantText?.includes("bomb design") === true, "angle clarification uses previous seed");
+
+  const quotedClarification = routeStudioIntent({
+    message: "I can work with this seed: bomb, heart atack, science\n\nThree angles to explore...\n, wwhat angle",
+    readiness: "degraded",
+    mode: "brainstorm",
+    recentBrainstormSeed: "bomb, heart attack, science",
+  });
+  assert(quotedClarification.intent === "QUOTED_PREVIOUS_RESPONSE_QUESTION", "quoted assistant text plus question maps to clarification");
+  assert(quotedClarification.assistantText?.startsWith("By \"angle\"") === true, "quoted assistant text is not treated as a new seed");
 
   const blockedWrite = routeStudioIntent({ message: "continue", readiness: "blocked" });
   assert(blockedWrite.command === "/write chapter", "blocked write still routes through preflight");

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
@@ -6,12 +6,14 @@ export type IntentRoute = {
   goal: string;
   needsClarification: boolean;
   assistantText: string | null;
+  brainstormSeed?: string | null;
 };
 
 type RouteIntentArgs = {
   message: string;
   readiness: ContextReadiness;
   mode?: "chat" | "brainstorm";
+  recentBrainstormSeed?: string | null;
 };
 
 const commandByIntent: Partial<Record<StudioChatIntent, CommandId>> = {
@@ -55,6 +57,95 @@ function wantsNextStep(message: string): boolean {
   return includesAny(normalizedMessage(message), [/\bwhat do we do now\b/, /\bwhat now\b/, /\bnext step\b/, /\bwhere do we start\b/]);
 }
 
+function isRepoRunHelp(message: string): boolean {
+  const text = normalizedMessage(message);
+  return includesAny(text, [
+    /\bhow do i run\b/,
+    /\bhow to run\b/,
+    /\brun (this )?(src|source|project|app|studio)\b/,
+    /\bstart (the )?(dev server|studio|app)\b/,
+    /\bnpm run (dev|start)\b/,
+    /\bdev server\b/,
+  ]);
+}
+
+function isRepoTestHelp(message: string): boolean {
+  const text = normalizedMessage(message);
+  return includesAny(text, [
+    /\bhow do i test\b/,
+    /\bhow to test\b/,
+    /\btest (this )?(src|source|project|app|studio)\b/,
+    /\brun tests?\b/,
+    /\bnpm run (typecheck|build|lint)\b/,
+    /\btypecheck\b/,
+  ]);
+}
+
+function isBrainstormClarification(message: string): boolean {
+  const text = normalizedMessage(message).replace(/[?.!]+$/g, "");
+  return includesAny(text, [
+    /^what angle$/,
+    /^wwhat angle$/,
+    /^which angle$/,
+    /^what do you mean$/,
+    /^explain$/,
+    /^explain options?$/,
+    /^can you clarify$/,
+    /\bw?what angle\b/,
+  ]);
+}
+
+function isQuotedAssistantQuestion(message: string): boolean {
+  const text = normalizedMessage(message);
+  return includesAny(text, [/\bi can work with this seed\b/, /\bthree angles to explore\b/, /\bpick one angle\b/]) && /[?]|\bw?what\b|\bexplain\b|\bclarify\b/.test(text);
+}
+
+function isBrainstormChoice(message: string): boolean {
+  return /^(1|2|3|one|two|three|hidden wound|trigger event|opening scene)\b/i.test(message.trim());
+}
+
+function stripQuotedAssistantText(message: string): string {
+  return message
+    .replace(/i can work with this seed:[\s\S]*?(three angles to explore:)?/gi, "")
+    .replace(/pick one angle and i will expand it\.?/gi, "")
+    .trim();
+}
+
+function optionLabels(seed: string): { title: string; detail: string }[] {
+  const lower = normalizedMessage(seed);
+  if (includesAny(lower, [/\bbomb\b/, /\bheart attack\b/, /\bheart atack\b/, /\bscience\b/, /\blab\b/])) {
+    return [
+      { title: "Hidden wound", detail: "The protagonist believes her research helped create the bomb design that caused a death by panic and heart failure." },
+      { title: "Trigger event", detail: "A second attack appears, and only she recognizes the scientific pattern linking it to the old tragedy." },
+      { title: "Opening scene", detail: "She is in a hospital corridor after a bombing, watching a heart monitor flatline while a lab sample in her pocket starts reacting." },
+    ];
+  }
+  if (includesAny(lower, [/\bsad\b/, /\bgirl\b/, /\bwound\b/, /\bgrief\b/])) {
+    return [
+      { title: "Hidden wound", detail: "The sad girl hides the real reason she stopped trusting the people who say they love her." },
+      { title: "Trigger event", detail: "A small public crisis forces her private grief into view before she is ready to explain it." },
+      { title: "Opening scene", detail: "Start with her performing one ordinary task while every detail quietly reveals what she has lost." },
+    ];
+  }
+  if (includesAny(lower, [/\badopt/, /\badopted\b/, /\badoption\b/, /\bfamily\b/])) {
+    return [
+      { title: "Quiet coming-of-age", detail: "He is loved but still feels like a guest, so the conflict has no obvious villain." },
+      { title: "Identity mystery", detail: "A normal family habit exposes a clue that his past was deliberately hidden from him." },
+      { title: "Family secret", detail: "The family knows why he does not belong, but protecting him has become another kind of lie." },
+    ];
+  }
+  return [
+    { title: "Hidden wound", detail: "Define the pain the protagonist is hiding and why they cannot say it directly." },
+    { title: "Trigger event", detail: "Choose the incident that forces the hidden conflict into the open." },
+    { title: "Opening scene", detail: "Find the first visual scene that reveals the conflict without explaining it." },
+  ];
+}
+
+function formatBrainstormOptions(seed: string): string {
+  const options = optionLabels(seed);
+  return options.map((option, index) => `${index + 1}. ${option.title}\n${option.detail}`).join("\n\n");
+}
+
 function brainstormReply(message: string): string {
   const text = message.trim();
   const lower = normalizedMessage(message);
@@ -64,17 +155,52 @@ function brainstormReply(message: string): string {
   if (/^brainstorm\b/i.test(text)) {
     return "I can brainstorm here without starting a writing workflow. Send a premise, character, conflict, or scene problem.";
   }
-  if (includesAny(lower, [/\badopt/, /\badopted\b/, /\badoption\b/, /\bfamily\b/])) {
-    return [
-      "This is a strong emotional seed: a boy is adopted into a normal family, but the normal life feels wrong to him.",
-      "The core tension can be that he is not unloved, but he still feels like a guest, so his confusion has no obvious villain.",
-      "For chapter 1, open with a normal family moment where everyone fits except him, then choose the angle: quiet coming-of-age, identity mystery, or family secret.",
-    ].join("\n\n");
-  }
+  const lead = includesAny(lower, [/\bbomb\b/, /\bheart attack\b/, /\bheart atack\b/, /\bscience\b/])
+    ? "Good, this shifts the idea toward a science-thriller tragedy."
+    : includesAny(lower, [/\badopt/, /\badopted\b/, /\badoption\b/, /\bfamily\b/])
+      ? "This is a strong emotional seed about an adopted child who feels out of place in a normal family."
+      : "I can shape this as a story seed.";
   return [
-    `I can work with this seed: ${text}`,
-    "Three angles to explore: what wound the protagonist hides, what event forces it into the open, and what first scene reveals the conflict without explaining it.",
-    "Pick one angle and I will expand it.",
+    lead,
+    "Here are three concrete angles:",
+    formatBrainstormOptions(text),
+    "Pick 1, 2, or 3.",
+  ].join("\n\n");
+}
+
+function brainstormClarificationReply(seed: string | null | undefined): string {
+  const source = seed?.trim() || "your current idea";
+  return [
+    "By \"angle\", I mean the direction we use to expand your idea.",
+    `For ${seed?.trim() ? `your seed \"${source}\"` : source}, you can choose:`,
+    formatBrainstormOptions(source),
+    "Pick 1, 2, or 3.",
+  ].join("\n\n");
+}
+
+function brainstormChoiceReply(message: string, seed: string | null | undefined): string {
+  const selected = normalizedMessage(message);
+  const options = optionLabels(seed || "your current idea");
+  const index = selected.startsWith("2") || selected.startsWith("two") || selected.startsWith("trigger") ? 1
+    : selected.startsWith("3") || selected.startsWith("three") || selected.startsWith("opening") ? 2
+      : 0;
+  const option = options[index];
+  return [
+    `I will expand angle ${index + 1}: ${option.title}.`,
+    option.detail,
+    "Next, turn it into a scene goal, a character contradiction, or a chapter opening.",
+  ].join("\n\n");
+}
+
+function repoHelpReply(): string {
+  return [
+    "I’ll switch from brainstorming to project setup help for this question.",
+    "To run the Studio locally:",
+    "1. Start the repo infrastructure if you need DB-backed flows.",
+    "2. From `apps/studio`, install dependencies if needed.",
+    "3. Run `npm run dev` for the Next.js Studio.",
+    "4. Start worker/memory services only when testing ingest, analysis, or writing pipelines.",
+    "For checks: run `npm run typecheck`, targeted `npx eslint <changed files>`, and `npm run build` before shipping.",
   ].join("\n\n");
 }
 
@@ -92,6 +218,11 @@ function staysInBrainstormMode(mode: RouteIntentArgs["mode"], intent: StudioChat
 export function detectStudioIntent(message: string): StudioChatIntent {
   const text = normalizedMessage(message);
   if (!text) return "AMBIGUOUS";
+  if (isRepoRunHelp(message)) return "REPO_RUN_HELP";
+  if (isRepoTestHelp(message)) return "REPO_TEST_HELP";
+  if (isQuotedAssistantQuestion(message)) return "QUOTED_PREVIOUS_RESPONSE_QUESTION";
+  if (isBrainstormClarification(message)) return "BRAINSTORM_CLARIFICATION";
+  if (isBrainstormChoice(message)) return "BRAINSTORM_EXPAND_CHOICE";
   if (includesAny(text, [/^(hi|hello|hey|yo|chao|xin chao|chào)$/i, /\bhow are you\b/])) return "CHAT";
   if (wantsNextStep(message)) return "CHAT";
   const matched = intentPatterns.find((entry) => includesAny(text, entry.patterns));
@@ -106,16 +237,30 @@ function goalFromMessage(message: string, intent: StudioChatIntent): string {
   return text;
 }
 
+// Keep routing priority visible because mode override order is the bug surface.
+// eslint-disable-next-line complexity
 export function routeStudioIntent(args: RouteIntentArgs): IntentRoute {
   const intent = detectStudioIntent(args.message);
   const goal = goalFromMessage(args.message, intent);
+  if (intent === "REPO_RUN_HELP" || intent === "REPO_TEST_HELP") {
+    return { intent, command: null, goal, needsClarification: false, assistantText: repoHelpReply(), brainstormSeed: null };
+  }
+  if (intent === "BRAINSTORM_CLARIFICATION" || intent === "QUOTED_PREVIOUS_RESPONSE_QUESTION") {
+    const seed = intent === "QUOTED_PREVIOUS_RESPONSE_QUESTION" ? args.recentBrainstormSeed || stripQuotedAssistantText(args.message) : args.recentBrainstormSeed;
+    return { intent, command: null, goal, needsClarification: false, assistantText: brainstormClarificationReply(seed), brainstormSeed: seed ?? null };
+  }
+  if (intent === "BRAINSTORM_EXPAND_CHOICE") {
+    return { intent, command: null, goal, needsClarification: false, assistantText: brainstormChoiceReply(args.message, args.recentBrainstormSeed), brainstormSeed: args.recentBrainstormSeed ?? null };
+  }
   if (staysInBrainstormMode(args.mode, intent)) {
+    const seed = args.message.trim();
     return {
       intent: "BRAINSTORM",
       command: null,
-      goal: args.message.trim(),
+      goal: seed,
       needsClarification: false,
       assistantText: brainstormReply(args.message),
+      brainstormSeed: isShortAcknowledgement(seed) || /^brainstorm\b/i.test(seed) ? args.recentBrainstormSeed ?? null : seed,
     };
   }
   if (intent === "CHAT") {
@@ -143,6 +288,7 @@ export function routeStudioIntent(args: RouteIntentArgs): IntentRoute {
       goal,
       needsClarification: false,
       assistantText: brainstormReply(args.message),
+      brainstormSeed: /^brainstorm\b/i.test(args.message.trim()) ? args.recentBrainstormSeed ?? null : args.message.trim(),
     };
   }
   if (intent === "SWITCH_STORY" || intent === "ADD_CONTEXT") {

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -96,6 +96,11 @@ export type StudioChatIntent =
   | "SPLIT"
   | "INSPECT"
   | "APPROVE"
+  | "REPO_RUN_HELP"
+  | "REPO_TEST_HELP"
+  | "BRAINSTORM_CLARIFICATION"
+  | "BRAINSTORM_EXPAND_CHOICE"
+  | "QUOTED_PREVIOUS_RESPONSE_QUESTION"
   | "AMBIGUOUS";
 
 export type ChatContextMiniBarPayload = {


### PR DESCRIPTION
## Summary
- add turn-level repo help, brainstorm clarification, choice, and quoted-response intent categories
- keep brainstorm mode as soft context by tracking the latest seed and yielding to explicit non-brainstorm intents
- replace generic brainstorm template with numbered, seed-specific options and add regression self-tests

## Verification
- TMPDIR=/tmp npx tsx src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts src/features/scenes/components/writeTab/CommandWorkStream.tsx src/features/scenes/components/writeTab/types.ts
- git diff --check
- npm run build

Closes #128