### PR TITLE
Fix live composer draft echo

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -53,6 +53,7 @@ Refactor direction for large modules:
 
 - The Write workspace is viewport locked: the app shell reserves the fixed top bar, the Write grid fills the remaining visible height, and only internal panels scroll. The browser page itself must not become the scrolling surface for `/stories/[slug]/write`.
 - The center chat owns conversation history and the persistent bottom composer. User/assistant prose renders as compact chat bubbles with text-only copy actions; system state renders as compact timeline blocks.
+- Composer draft text is private input state. It must never be rendered as a timeline message; only submitted messages appended by the submit handler enter conversation history.
 - The slash command menu is anchored above the composer with internal scrolling and must not shift the page layout.
 - Write workspace commands stay inside Write by default. Command handlers append the relevant timeline block and switch the shared right-inspector mode; they must not use route navigation for `/analyze`, `/research`, `/review`, `/memory`, `/pipeline`, `/context`, `/inspect`, or `/status`.
 - Inspector mode is workspace UI state, not route state. Deep Analysis, Reviews, Memory, and Pipelines pages remain available only through explicit secondary links such as "Open full analysis workspace".

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -73,7 +73,6 @@ function resultBlock(result: CommandResult): TimelineBlock {
 
 function buildTimelineBlocks(args: {
   briefing: ReturnType<typeof buildAssistantReadiness>;
-  composerValue: string;
   conversationBlocks: TimelineBlock[];
   pendingAssistant: boolean;
   chapterId: string | null;
@@ -93,10 +92,6 @@ function buildTimelineBlocks(args: {
   ];
 
   blocks.push(...args.conversationBlocks);
-
-  if (args.composerValue.trim()) {
-    blocks.push({ id: "composer-echo", type: "text_message", source: "user", label: "You", text: args.composerValue.trim() });
-  }
 
   if (args.pendingAssistant) {
     blocks.push({
@@ -411,7 +406,6 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
   });
   const blocks = buildTimelineBlocks({
     briefing,
-    composerValue: props.composerValue,
     conversationBlocks,
     pendingAssistant,
     chapterId: props.chapterId,


### PR DESCRIPTION
## Summary
- remove composer draft text from chat timeline block construction
- keep submitted messages as the only user messages appended to conversation history
- document the composer draft/state boundary in the Studio README

## Root cause
`CommandWorkStream.buildTimelineBlocks()` appended `composerValue` as a `composer-echo` user `text_message` whenever the input had draft text. That rendered unsent composer drafts live in the conversation.

## Verification
- npm run typecheck
- npx eslint src/features/scenes/components/writeTab/CommandWorkStream.tsx
- git diff --check
- npm run build

## Manual QA notes
- Typing before submit no longer has a timeline path because `composerValue` is only passed to `ChatComposer`.
- Submit still appends exactly one user message through `onSubmitMessage`.
- Pending assistant state still renders from `pendingAssistant`, independent of composer draft text.
