### PR TITLE
Add persistent Write Assistant chat history

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -53,6 +53,8 @@ Refactor direction for large modules:
 
 - The Write workspace is viewport locked: the app shell reserves the fixed top bar, the Write grid fills the remaining visible height, and only internal panels scroll. The browser page itself must not become the scrolling surface for `/stories/[slug]/write`.
 - The center chat owns conversation history and the persistent bottom composer. User/assistant prose renders as compact chat bubbles with text-only copy actions; system state renders as compact timeline blocks.
+- Write Assistant conversations are durable server-backed sessions scoped by story, workspace, and optional chapter. The chat surface can show current-chapter history or all story chats, and New Chat creates a new session without deleting prior sessions.
+- Assistant state needed for continuation, including brainstorm mode, recent seed, and pending brainstorm follow-up actions, is restored from conversation metadata instead of React-only state.
 - Composer draft text is private input state. It must never be rendered as a timeline message; only submitted messages appended by the submit handler enter conversation history.
 - The slash command menu is anchored above the composer with internal scrolling and must not shift the page layout.
 - Write workspace commands stay inside Write by default. Command handlers append the relevant timeline block and switch the shared right-inspector mode; they must not use route navigation for `/analyze`, `/research`, `/review`, `/memory`, `/pipeline`, `/context`, `/inspect`, or `/status`.

--- a/apps/studio/src/app/api/stories/[slug]/assistant/conversations/[conversationId]/messages/route.ts
+++ b/apps/studio/src/app/api/stories/[slug]/assistant/conversations/[conversationId]/messages/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import {
+  appendAssistantMessageResponse,
+  listAssistantMessagesResponse,
+} from "@/features/chat-orchestration/server/assistantConversationService";
+
+export const runtime = "nodejs";
+
+export async function GET(_req: NextRequest, ctx: { params: Promise<{ slug: string; conversationId: string }> }) {
+  const { slug, conversationId } = await ctx.params;
+  return listAssistantMessagesResponse(slug, conversationId);
+}
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ slug: string; conversationId: string }> }) {
+  const { slug, conversationId } = await ctx.params;
+  return appendAssistantMessageResponse(req, slug, conversationId);
+}

--- a/apps/studio/src/app/api/stories/[slug]/assistant/conversations/[conversationId]/route.ts
+++ b/apps/studio/src/app/api/stories/[slug]/assistant/conversations/[conversationId]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import {
+  getAssistantConversationResponse,
+  patchAssistantConversationResponse,
+} from "@/features/chat-orchestration/server/assistantConversationService";
+
+export const runtime = "nodejs";
+
+export async function GET(_req: NextRequest, ctx: { params: Promise<{ slug: string; conversationId: string }> }) {
+  const { slug, conversationId } = await ctx.params;
+  return getAssistantConversationResponse(slug, conversationId);
+}
+
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ slug: string; conversationId: string }> }) {
+  const { slug, conversationId } = await ctx.params;
+  return patchAssistantConversationResponse(req, slug, conversationId);
+}

--- a/apps/studio/src/app/api/stories/[slug]/assistant/conversations/route.ts
+++ b/apps/studio/src/app/api/stories/[slug]/assistant/conversations/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import {
+  createAssistantConversationResponse,
+  listAssistantConversationsResponse,
+} from "@/features/chat-orchestration/server/assistantConversationService";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ slug: string }> }) {
+  const { slug } = await ctx.params;
+  return listAssistantConversationsResponse(req, slug);
+}
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ slug: string }> }) {
+  const { slug } = await ctx.params;
+  return createAssistantConversationResponse(req, slug);
+}

--- a/apps/studio/src/app/globals.css
+++ b/apps/studio/src/app/globals.css
@@ -628,6 +628,91 @@ body.write-route-lock {
   border-right: 1px solid var(--border-subtle);
 }
 
+.conversation-history {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--border-subtle);
+  background: rgba(13, 18, 25, 0.98);
+  padding: 10px 18px;
+}
+
+.conversation-history__toolbar,
+.conversation-history__filters,
+.conversation-history__list {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.conversation-history__toolbar {
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.conversation-history__title {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.conversation-history button {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text-secondary);
+  padding: 5px 9px;
+  font-size: 11px;
+}
+
+.conversation-history button:hover,
+.conversation-history button.is-active {
+  border-color: rgba(66, 199, 184, 0.35);
+  color: var(--accent);
+}
+
+.conversation-history__list {
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.conversation-history__list::-webkit-scrollbar {
+  display: none;
+}
+
+.conversation-history__item {
+  flex: 0 0 170px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.conversation-history__item span,
+.conversation-history__item small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-history__item span {
+  max-width: 104px;
+}
+
+.conversation-history__item small {
+  max-width: 54px;
+  color: var(--text-muted);
+}
+
+.conversation-history__empty,
+.conversation-history__error {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.conversation-history__error {
+  color: var(--danger);
+}
+
 .chat-context-mini-bar {
   flex: 0 0 auto;
   z-index: 4;

--- a/apps/studio/src/features/chat-orchestration/server/assistantConversationService.ts
+++ b/apps/studio/src/features/chat-orchestration/server/assistantConversationService.ts
@@ -1,0 +1,340 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { Pool, PoolClient } from "pg";
+import { pool } from "@/server/db/pool";
+import { resolveStoryId, resolveStoryIdForWrite } from "@/features/scenes/server/workflow/routeUtils";
+
+const WORKSPACE = "write_assistant";
+const MAX_TITLE_LENGTH = 72;
+const MESSAGE_ROLES = new Set(["user", "assistant", "system", "tool", "workflow"]);
+const STATUS_VALUES = new Set(["active", "archived"]);
+
+type ConversationScope = "current_chapter" | "all_story";
+
+type ConversationRow = {
+  id: string;
+  story_id: string | number;
+  chapter_id: string | null;
+  workspace: string;
+  title: string | null;
+  summary: string | null;
+  status: string;
+  state_json: unknown;
+  created_at: string;
+  updated_at: string;
+  last_message_preview: string | null;
+};
+
+type MessageRow = {
+  id: string;
+  conversation_id: string;
+  role: string;
+  block_type: string | null;
+  content: string;
+  metadata_json: unknown;
+  sequence_no: number;
+  created_at: string;
+};
+
+function jsonObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function textValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function validUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function titleFromContent(content: string): string | null {
+  const compact = content.trim().replace(/\s+/g, " ");
+  if (!compact) return null;
+  return compact.length > MAX_TITLE_LENGTH ? `${compact.slice(0, MAX_TITLE_LENGTH - 1)}…` : compact;
+}
+
+function mapConversation(row: ConversationRow) {
+  return {
+    id: row.id,
+    story_id: Number(row.story_id),
+    chapter_id: row.chapter_id,
+    workspace: row.workspace,
+    title: row.title,
+    summary: row.summary,
+    status: row.status,
+    state_json: jsonObject(row.state_json),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    last_message_preview: row.last_message_preview,
+  };
+}
+
+function mapMessage(row: MessageRow) {
+  const metadata = jsonObject(row.metadata_json);
+  return {
+    id: row.id,
+    conversation_id: row.conversation_id,
+    role: row.role,
+    block_type: row.block_type,
+    content: row.content,
+    metadata_json: metadata,
+    block: metadata.block ?? null,
+    sequence_no: Number(row.sequence_no),
+    created_at: row.created_at,
+  };
+}
+
+function parseScope(value: string | null): ConversationScope {
+  return value === "all_story" ? "all_story" : "current_chapter";
+}
+
+async function assertConversation(poolOrClient: Pool | PoolClient, storyId: number, conversationId: string): Promise<boolean> {
+  if (!validUuid(conversationId)) return false;
+  const res = await poolOrClient.query(
+    `SELECT id
+     FROM public.assistant_conversation
+     WHERE id = $1::uuid
+       AND story_id = $2
+       AND workspace = $3
+     LIMIT 1`,
+    [conversationId, storyId, WORKSPACE]
+  );
+  return (res.rowCount ?? 0) > 0;
+}
+
+export async function listAssistantConversationsResponse(req: NextRequest, storySlug: string): Promise<NextResponse> {
+  try {
+    const storyId = await resolveStoryId(pool, storySlug);
+    const chapterId = textValue(req.nextUrl.searchParams.get("chapter_id")) || null;
+    const scope = parseScope(req.nextUrl.searchParams.get("scope"));
+    const params: Array<string | number | null> = [storyId, WORKSPACE];
+    const where = ["c.story_id = $1", "c.workspace = $2", "c.status = 'active'"];
+    if (scope === "current_chapter") {
+      params.push(chapterId);
+      where.push(`c.chapter_id IS NOT DISTINCT FROM $${params.length}`);
+    }
+    const res = await pool.query<ConversationRow>(
+      `SELECT
+         c.id::text,
+         c.story_id,
+         c.chapter_id,
+         c.workspace,
+         c.title,
+         c.summary,
+         c.status,
+         c.state_json,
+         c.created_at::text,
+         c.updated_at::text,
+         lm.content AS last_message_preview
+       FROM public.assistant_conversation c
+       LEFT JOIN LATERAL (
+         SELECT content
+         FROM public.assistant_message m
+         WHERE m.conversation_id = c.id
+         ORDER BY m.sequence_no DESC
+         LIMIT 1
+       ) lm ON true
+       WHERE ${where.join(" AND ")}
+       ORDER BY c.updated_at DESC
+       LIMIT 60`,
+      params
+    );
+    return NextResponse.json({ ok: true, items: res.rows.map(mapConversation) });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "LIST_ASSISTANT_CONVERSATIONS_FAILED";
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
+}
+
+export async function createAssistantConversationResponse(req: NextRequest, storySlug: string): Promise<NextResponse> {
+  try {
+    const storyId = await resolveStoryIdForWrite(pool, storySlug);
+    const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+    const chapterId = textValue(body.chapter_id) || null;
+    const title = titleFromContent(textValue(body.title));
+    const stateJson = jsonObject(body.state_json);
+    const res = await pool.query<ConversationRow>(
+      `INSERT INTO public.assistant_conversation
+        (story_id, chapter_id, workspace, title, state_json)
+       VALUES
+        ($1, $2, $3, $4, $5::jsonb)
+       RETURNING
+         id::text,
+         story_id,
+         chapter_id,
+         workspace,
+         title,
+         summary,
+         status,
+         state_json,
+         created_at::text,
+         updated_at::text,
+         NULL::text AS last_message_preview`,
+      [storyId, chapterId, WORKSPACE, title, JSON.stringify(stateJson)]
+    );
+    return NextResponse.json({ ok: true, item: mapConversation(res.rows[0]) }, { status: 201 });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "CREATE_ASSISTANT_CONVERSATION_FAILED";
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
+}
+
+export async function getAssistantConversationResponse(storySlug: string, conversationId: string): Promise<NextResponse> {
+  try {
+    const storyId = await resolveStoryId(pool, storySlug);
+    if (!validUuid(conversationId)) return NextResponse.json({ ok: false, error: "INVALID_CONVERSATION_ID" }, { status: 400 });
+    const res = await pool.query<ConversationRow>(
+      `SELECT
+         c.id::text,
+         c.story_id,
+         c.chapter_id,
+         c.workspace,
+         c.title,
+         c.summary,
+         c.status,
+         c.state_json,
+         c.created_at::text,
+         c.updated_at::text,
+         NULL::text AS last_message_preview
+       FROM public.assistant_conversation c
+       WHERE c.id = $1::uuid
+         AND c.story_id = $2
+         AND c.workspace = $3
+       LIMIT 1`,
+      [conversationId, storyId, WORKSPACE]
+    );
+    if (res.rowCount === 0) return NextResponse.json({ ok: false, error: "CONVERSATION_NOT_FOUND" }, { status: 404 });
+    return NextResponse.json({ ok: true, item: mapConversation(res.rows[0]) });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "GET_ASSISTANT_CONVERSATION_FAILED";
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
+}
+
+// eslint-disable-next-line complexity
+export async function patchAssistantConversationResponse(req: NextRequest, storySlug: string, conversationId: string): Promise<NextResponse> {
+  try {
+    const storyId = await resolveStoryIdForWrite(pool, storySlug);
+    if (!validUuid(conversationId)) return NextResponse.json({ ok: false, error: "INVALID_CONVERSATION_ID" }, { status: 400 });
+    const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+    const stateJson = body.state_json === undefined ? null : jsonObject(body.state_json);
+    const title = body.title === undefined ? undefined : titleFromContent(textValue(body.title));
+    const status = body.status === undefined ? undefined : textValue(body.status).toLowerCase();
+    if (status !== undefined && !STATUS_VALUES.has(status)) return NextResponse.json({ ok: false, error: "INVALID_STATUS" }, { status: 400 });
+    const res = await pool.query<ConversationRow>(
+      `UPDATE public.assistant_conversation
+       SET
+         title = COALESCE($4, title),
+         status = COALESCE($5, status),
+         state_json = CASE WHEN $6::jsonb IS NULL THEN state_json ELSE $6::jsonb END,
+         updated_at = now()
+       WHERE id = $1::uuid
+         AND story_id = $2
+         AND workspace = $3
+       RETURNING
+         id::text,
+         story_id,
+         chapter_id,
+         workspace,
+         title,
+         summary,
+         status,
+         state_json,
+         created_at::text,
+         updated_at::text,
+         NULL::text AS last_message_preview`,
+      [conversationId, storyId, WORKSPACE, title ?? null, status ?? null, stateJson === null ? null : JSON.stringify(stateJson)]
+    );
+    if (res.rowCount === 0) return NextResponse.json({ ok: false, error: "CONVERSATION_NOT_FOUND" }, { status: 404 });
+    return NextResponse.json({ ok: true, item: mapConversation(res.rows[0]) });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "PATCH_ASSISTANT_CONVERSATION_FAILED";
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
+}
+
+export async function listAssistantMessagesResponse(storySlug: string, conversationId: string): Promise<NextResponse> {
+  try {
+    const storyId = await resolveStoryId(pool, storySlug);
+    const exists = await assertConversation(pool, storyId, conversationId);
+    if (!exists) return NextResponse.json({ ok: false, error: "CONVERSATION_NOT_FOUND" }, { status: 404 });
+    const res = await pool.query<MessageRow>(
+      `SELECT
+         id::text,
+         conversation_id::text,
+         role,
+         block_type,
+         content,
+         metadata_json,
+         sequence_no,
+         created_at::text
+       FROM public.assistant_message
+       WHERE conversation_id = $1::uuid
+       ORDER BY sequence_no ASC`,
+      [conversationId]
+    );
+    return NextResponse.json({ ok: true, items: res.rows.map(mapMessage) });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "LIST_ASSISTANT_MESSAGES_FAILED";
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
+}
+
+export async function appendAssistantMessageResponse(req: NextRequest, storySlug: string, conversationId: string): Promise<NextResponse> {
+  const client = await pool.connect();
+  try {
+    const storyId = await resolveStoryIdForWrite(pool, storySlug);
+    const body = (await req.json()) as Record<string, unknown>;
+    const role = textValue(body.role).toLowerCase();
+    if (!MESSAGE_ROLES.has(role)) return NextResponse.json({ ok: false, error: "INVALID_ROLE" }, { status: 400 });
+    const blockType = textValue(body.block_type) || null;
+    const content = textValue(body.content);
+    const metadataJson = jsonObject(body.metadata_json);
+
+    await client.query("BEGIN");
+    const exists = await assertConversation(client, storyId, conversationId);
+    if (!exists) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ ok: false, error: "CONVERSATION_NOT_FOUND" }, { status: 404 });
+    }
+    const insertRes = await client.query<MessageRow>(
+      `WITH next_sequence AS (
+         SELECT COALESCE(MAX(sequence_no), 0) + 1 AS sequence_no
+         FROM public.assistant_message
+         WHERE conversation_id = $1::uuid
+       )
+       INSERT INTO public.assistant_message
+        (conversation_id, role, block_type, content, metadata_json, sequence_no)
+       SELECT $1::uuid, $2, $3, $4, $5::jsonb, sequence_no
+       FROM next_sequence
+       RETURNING
+         id::text,
+         conversation_id::text,
+         role,
+         block_type,
+         content,
+         metadata_json,
+         sequence_no,
+         created_at::text`,
+      [conversationId, role, blockType, content, JSON.stringify(metadataJson)]
+    );
+    const title = role === "user" ? titleFromContent(content) : null;
+    await client.query(
+      `UPDATE public.assistant_conversation
+       SET
+         title = COALESCE(title, $2),
+         updated_at = now()
+       WHERE id = $1::uuid`,
+      [conversationId, title]
+    );
+    await client.query("COMMIT");
+    return NextResponse.json({ ok: true, item: mapMessage(insertRes.rows[0]) }, { status: 201 });
+  } catch (error: unknown) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    const message = error instanceof Error ? error.message : "APPEND_ASSISTANT_MESSAGE_FAILED";
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  } finally {
+    client.release();
+  }
+}

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useRouter } from "next/navigation";
 import ChatComposer from "@/features/scenes/components/writeTab/chatOrchestration/ChatComposer";
 import ChatTimeline from "@/features/scenes/components/writeTab/chatOrchestration/ChatTimeline";
+import ConversationHistoryPanel from "@/features/scenes/components/writeTab/chatOrchestration/ConversationHistoryPanel";
 import {
   approvalGateBlock,
   buildCommands,
@@ -20,14 +21,11 @@ import {
 import { routeStudioIntent } from "@/features/scenes/components/writeTab/chatOrchestration/intentRouter";
 import type { BrainstormFollowupAction } from "@/features/scenes/components/writeTab/chatOrchestration/intentRouter";
 import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
-import {
-  continuityWorkflowProgressEvent,
-  workflowProgressBlockFromEvent,
-} from "@/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents";
+import { buildTimelineBlocks } from "@/features/scenes/components/writeTab/chatOrchestration/timelineBlockBuilder";
+import { useAssistantConversations } from "@/features/scenes/components/writeTab/chatOrchestration/useAssistantConversations";
 import type {
   AssistantReadinessContext,
   CommandId,
-  FailureRecoveryBlock,
   RecoveryChip,
   TimelineBlock,
   WriteInspectorMode,
@@ -47,89 +45,6 @@ type CommandWorkStreamProps = {
   onInspectorModeChange: (mode: WriteInspectorMode) => void;
   assistantContext: AssistantReadinessContext;
 };
-
-function resultBlock(result: CommandResult): TimelineBlock {
-  if (result.tone === "blocked") {
-    return {
-      id: "command-recovery",
-      type: "failure_recovery",
-      source: "assistant",
-      workflow_name: result.title,
-      stopped_at_step: "Preflight",
-      plain_reason: result.detail,
-      draft_preserved: true,
-      actions: ["retry", "cancel"],
-    } satisfies FailureRecoveryBlock & { id: string };
-  }
-
-  return {
-    id: "command-result",
-    type: "text_message",
-    source: "assistant",
-    label: "Studio Writing Assistant",
-    text: `${result.title}. ${result.detail}`,
-    tone: result.tone,
-  };
-}
-
-function buildTimelineBlocks(args: {
-  briefing: ReturnType<typeof buildAssistantReadiness>;
-  conversationBlocks: TimelineBlock[];
-  pendingAssistant: boolean;
-  chapterId: string | null;
-  hasDraft: boolean;
-  showDraftPreview: boolean;
-  continuityQueued: boolean;
-  commandResult: CommandResult | null;
-  intentBlock: TimelineBlock | null;
-}): TimelineBlock[] {
-  const blocks: TimelineBlock[] = [
-    { id: "readiness", type: "readiness_card", briefing: args.briefing },
-    {
-      id: "readiness-chips",
-      type: "inline_choice_chips",
-      chips: args.briefing.chips.map((chip) => ({ ...chip, action: chip.intent })),
-    },
-  ];
-
-  blocks.push(...args.conversationBlocks);
-
-  if (args.pendingAssistant) {
-    blocks.push({
-      id: "assistant-pending",
-      type: "text_message",
-      source: "assistant",
-      label: "Studio Writing Assistant",
-      text: "Thinking",
-      tone: "running",
-      pending: true,
-    });
-  }
-
-  const continuityEvent = continuityWorkflowProgressEvent({ chapterId: args.chapterId, queued: args.continuityQueued });
-  if (continuityEvent) blocks.push(workflowProgressBlockFromEvent(continuityEvent));
-
-  if (args.hasDraft && args.showDraftPreview) {
-    blocks.push({
-      id: "draft-preview",
-      type: "artifact_preview",
-      source: "backend",
-      artifact_id: "current-draft",
-      artifact_type: "draft",
-      title: "Current chapter draft",
-      status: "draft",
-      description: "Draft content is open in the artifact workspace.",
-      word_count: null,
-      beat_count: null,
-      preview_lines: ["Draft content is open in the artifact workspace.", "Use the editor surface for prose edits and approval gates."],
-      actions: ["open_draft", "review_continuity", "edit_in_document"],
-    });
-  }
-
-  if (args.commandResult) blocks.push(resultBlock(args.commandResult));
-  if (args.intentBlock) blocks.push(args.intentBlock);
-  return blocks;
-}
 
 // Command dispatch mirrors the slash-command contract table; keep branches explicit so blocked/degraded routing stays readable.
 // eslint-disable-next-line max-lines-per-function
@@ -390,15 +305,45 @@ function useCommandRunner(args: {
   return { commandResult, intentBlock, runCommand, submitMessage };
 }
 
+// eslint-disable-next-line max-lines-per-function
 export default function CommandWorkStream(props: CommandWorkStreamProps) {
   const router = useRouter();
   const [chatMode, setChatMode] = React.useState<"chat" | "brainstorm">("chat");
   const [recentBrainstormSeed, setRecentBrainstormSeed] = React.useState<string | null>(null);
   const [pendingBrainstormActions, setPendingBrainstormActions] = React.useState<BrainstormFollowupAction[] | null>(null);
-  const [conversationBlocks, setConversationBlocks] = React.useState<TimelineBlock[]>([]);
   const [pendingAssistant, setPendingAssistant] = React.useState(false);
+  const assistantConversations = useAssistantConversations({ storySlug: props.storySlug, chapterId: props.chapterId });
+  const {
+    activeConversationId,
+    appendBlock,
+    conversationBlocks,
+    conversationState,
+    conversations,
+    error: conversationError,
+    loadConversation,
+    loading: conversationsLoading,
+    persistConversationState,
+    scope: conversationScope,
+    setScope: setConversationScope,
+    startNewConversation,
+  } = assistantConversations;
   const briefing = buildAssistantReadiness(props.assistantContext);
   const commands = buildCommands(props.assistantContext, props.chapterId);
+
+  React.useEffect(() => {
+    setChatMode(conversationState.chatMode);
+    setRecentBrainstormSeed(conversationState.recentBrainstormSeed);
+    setPendingBrainstormActions(conversationState.pendingBrainstormActions);
+  }, [activeConversationId, conversationState]);
+
+  React.useEffect(() => {
+    void persistConversationState({
+      chatMode,
+      recentBrainstormSeed,
+      pendingBrainstormActions,
+    });
+  }, [chatMode, pendingBrainstormActions, persistConversationState, recentBrainstormSeed]);
+
   const { commandResult, intentBlock, runCommand, submitMessage } = useCommandRunner({
     storySlug: props.storySlug,
     chapterId: props.chapterId,
@@ -411,7 +356,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     onBrainstormSeedChange: setRecentBrainstormSeed,
     pendingBrainstormActions,
     onPendingBrainstormActionsChange: setPendingBrainstormActions,
-    onConversationBlock: (block) => setConversationBlocks((current) => [...current, block]),
+    onConversationBlock: (block) => void appendBlock(block),
     onInspectorModeChange: props.onInspectorModeChange,
   });
   const blocks = buildTimelineBlocks({
@@ -435,8 +380,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     }
     if (chip.intent === "add_context" || chip.intent === "analyze_source") {
       props.onInspectorModeChange("context");
-      setConversationBlocks((current) => [
-        ...current,
+      void appendBlock(
         buildWorkspaceWorkflowBlock({
           id: `recovery-analysis-${Date.now()}`,
           workflowName: "Context Recovery",
@@ -444,20 +388,19 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
           chapterId: props.chapterId,
           actionLabel: "Open full analysis workspace",
           actionHref: workspaceHref(props.storySlug, "analysis"),
-        }),
-      ]);
+        })
+      );
       return;
     }
     if (chip.intent === "inspect_context") {
       props.onInspectorModeChange("context");
-      setConversationBlocks((current) => [
-        ...current,
+      void appendBlock(
         buildContextDigestBlock(
           props.assistantContext,
           [{ label: "Open full memory workspace", href: workspaceHref(props.storySlug, "memory") }],
           `recovery-context-${Date.now()}`
-        ),
-      ]);
+        )
+      );
       return;
     }
     if (target) router.push(target);
@@ -465,6 +408,16 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
 
   return (
     <section className="work-stream" aria-label="Studio chat work stream">
+      <ConversationHistoryPanel
+        conversations={conversations}
+        activeConversationId={activeConversationId}
+        scope={conversationScope}
+        loading={conversationsLoading}
+        error={conversationError}
+        onScopeChange={setConversationScope}
+        onNewChat={() => void startNewConversation()}
+        onSelectConversation={(id) => void loadConversation(id)}
+      />
       <ChatTimeline context={buildContextMiniBar(props.assistantContext, briefing.status)} blocks={blocks} onChip={handleChip} />
       <ChatComposer
         value={props.composerValue}
@@ -477,17 +430,16 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
           runCommand(command, goal);
         }}
         onSubmitMessage={(message) => {
-          setConversationBlocks((current) => [
-            ...current,
-            { id: `user-${Date.now()}`, type: "text_message", source: "user", label: "You", text: message },
-          ]);
+          const userBlock: TimelineBlock = { id: `user-${Date.now()}`, type: "text_message", source: "user", label: "You", text: message };
           setPendingAssistant(true);
           props.onComposerValueChange("");
           props.onCommandMenuOpenChange(false);
-          window.setTimeout(() => {
-            submitMessage(message);
-            setPendingAssistant(false);
-          }, 220);
+          void appendBlock(userBlock).then(() => {
+            window.setTimeout(() => {
+              submitMessage(message);
+              setPendingAssistant(false);
+            }, 220);
+          });
         }}
       />
     </section>

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ConversationHistoryPanel.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ConversationHistoryPanel.tsx
@@ -1,0 +1,69 @@
+import type {
+  AssistantConversationListItem,
+  AssistantConversationScope,
+} from "@/features/scenes/components/writeTab/chatOrchestration/useAssistantConversations";
+
+type ConversationHistoryPanelProps = {
+  conversations: AssistantConversationListItem[];
+  activeConversationId: string | null;
+  scope: AssistantConversationScope;
+  loading: boolean;
+  error: string | null;
+  onScopeChange: (scope: AssistantConversationScope) => void;
+  onNewChat: () => void;
+  onSelectConversation: (id: string) => void;
+};
+
+function labelForConversation(item: AssistantConversationListItem): string {
+  return item.title?.trim() || item.last_message_preview?.trim() || "Untitled chat";
+}
+
+function formatUpdatedAt(value: string): string {
+  const time = new Date(value);
+  if (Number.isNaN(time.getTime())) return "";
+  return time.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+export default function ConversationHistoryPanel({
+  conversations,
+  activeConversationId,
+  scope,
+  loading,
+  error,
+  onScopeChange,
+  onNewChat,
+  onSelectConversation,
+}: ConversationHistoryPanelProps) {
+  return (
+    <section className="conversation-history" aria-label="Assistant conversation history">
+      <div className="conversation-history__toolbar">
+        <div className="conversation-history__title">Chats</div>
+        <button type="button" onClick={onNewChat}>New chat</button>
+      </div>
+      <div className="conversation-history__filters" role="group" aria-label="Conversation scope">
+        <button type="button" className={scope === "current_chapter" ? "is-active" : ""} onClick={() => onScopeChange("current_chapter")}>
+          Current chapter
+        </button>
+        <button type="button" className={scope === "all_story" ? "is-active" : ""} onClick={() => onScopeChange("all_story")}>
+          All story
+        </button>
+      </div>
+      <div className="conversation-history__list">
+        {conversations.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={`conversation-history__item ${item.id === activeConversationId ? "is-active" : ""}`}
+            onClick={() => onSelectConversation(item.id)}
+          >
+            <span>{labelForConversation(item)}</span>
+            <small>{formatUpdatedAt(item.updated_at)}</small>
+          </button>
+        ))}
+        {!loading && conversations.length === 0 ? <div className="conversation-history__empty">No saved chats yet.</div> : null}
+        {loading ? <div className="conversation-history__empty">Loading chats...</div> : null}
+        {error ? <div className="conversation-history__error">{error}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.test.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.test.ts
@@ -1,0 +1,38 @@
+import {
+  normalizeConversationState,
+  persistedBlockPayload,
+} from "@/features/scenes/components/writeTab/chatOrchestration/conversationPersistence";
+import type { TimelineBlock } from "@/features/scenes/components/writeTab/types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+export function runConversationPersistenceSelfTest(): void {
+  const userBlock: TimelineBlock = {
+    id: "user-1",
+    type: "text_message",
+    source: "user",
+    label: "You",
+    text: "scene goals",
+  };
+  const payload = persistedBlockPayload(userBlock);
+  assert(payload.role === "user", "submitted user text persists as one user message");
+  assert(payload.content === "scene goals", "persisted content uses final submitted text");
+  assert(payload.metadata_json.block === userBlock, "full timeline block is preserved under metadata");
+
+  const state = normalizeConversationState({
+    chatMode: "brainstorm",
+    recentBrainstormSeed: "a girl",
+    pendingBrainstormActions: ["character_contradiction"],
+  });
+  assert(state.chatMode === "brainstorm", "brainstorm mode restores from metadata");
+  assert(state.recentBrainstormSeed === "a girl", "recent brainstorm seed restores from metadata");
+  assert(state.pendingBrainstormActions?.[0] === "character_contradiction", "pending follow-up actions restore from metadata");
+
+  const fallback = normalizeConversationState({ chatMode: "invalid", recentBrainstormSeed: 1 });
+  assert(fallback.chatMode === "chat", "invalid state falls back to chat mode");
+  assert(fallback.recentBrainstormSeed === null, "invalid seed falls back to null");
+}
+
+runConversationPersistenceSelfTest();

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.ts
@@ -1,0 +1,54 @@
+import type { TimelineBlock } from "@/features/scenes/components/writeTab/types";
+import type { BrainstormFollowupAction } from "@/features/scenes/components/writeTab/chatOrchestration/intentRouter";
+
+export type AssistantConversationState = {
+  chatMode: "chat" | "brainstorm";
+  recentBrainstormSeed: string | null;
+  pendingBrainstormActions: BrainstormFollowupAction[] | null;
+};
+
+export const defaultConversationState: AssistantConversationState = {
+  chatMode: "chat",
+  recentBrainstormSeed: null,
+  pendingBrainstormActions: null,
+};
+
+export function isTimelineBlock(value: unknown): value is TimelineBlock {
+  return Boolean(value && typeof value === "object" && "type" in value && "id" in value);
+}
+
+export function normalizeConversationState(value: unknown): AssistantConversationState {
+  const obj = value && typeof value === "object" && !Array.isArray(value) ? value as Partial<AssistantConversationState> : {};
+  return {
+    chatMode: obj.chatMode === "brainstorm" ? "brainstorm" : "chat",
+    recentBrainstormSeed: typeof obj.recentBrainstormSeed === "string" ? obj.recentBrainstormSeed : null,
+    pendingBrainstormActions: Array.isArray(obj.pendingBrainstormActions) ? obj.pendingBrainstormActions : null,
+  };
+}
+
+export function blockRole(block: TimelineBlock): "user" | "assistant" | "workflow" {
+  if (block.type === "text_message") return block.source === "user" ? "user" : "assistant";
+  if (block.type === "readiness_card" || block.type === "inline_choice_chips") return "assistant";
+  if (block.source === "assistant") return "assistant";
+  return "workflow";
+}
+
+export function blockContent(block: TimelineBlock): string {
+  if (block.type === "text_message") return block.text;
+  if (block.type === "workflow_progress") return `${block.workflow_name}: ${block.current_step_label}`;
+  if (block.type === "artifact_preview") return block.title;
+  if (block.type === "approval_gate") return block.description;
+  if (block.type === "failure_recovery") return `${block.workflow_name} stopped: ${block.plain_reason}`;
+  if (block.type === "context_digest") return block.title;
+  if (block.type === "readiness_card") return block.briefing.title;
+  return block.chips.map((chip) => chip.label).join(", ");
+}
+
+export function persistedBlockPayload(block: TimelineBlock) {
+  return {
+    role: blockRole(block),
+    block_type: block.type,
+    content: blockContent(block),
+    metadata_json: { block },
+  };
+}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/timelineBlockBuilder.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/timelineBlockBuilder.ts
@@ -1,0 +1,90 @@
+import { buildAssistantReadiness } from "@/features/scenes/components/writeTab/chatOrchestration/readiness";
+import {
+  continuityWorkflowProgressEvent,
+  workflowProgressBlockFromEvent,
+} from "@/features/scenes/components/writeTab/chatOrchestration/workflowProgressEvents";
+import type { CommandResult } from "@/features/scenes/components/writeTab/chatOrchestration/commandSurfaceContracts";
+import type { FailureRecoveryBlock, TimelineBlock } from "@/features/scenes/components/writeTab/types";
+
+function resultBlock(result: CommandResult): TimelineBlock {
+  if (result.tone === "blocked") {
+    return {
+      id: "command-recovery",
+      type: "failure_recovery",
+      source: "assistant",
+      workflow_name: result.title,
+      stopped_at_step: "Preflight",
+      plain_reason: result.detail,
+      draft_preserved: true,
+      actions: ["retry", "cancel"],
+    } satisfies FailureRecoveryBlock & { id: string };
+  }
+
+  return {
+    id: "command-result",
+    type: "text_message",
+    source: "assistant",
+    label: "Studio Writing Assistant",
+    text: `${result.title}. ${result.detail}`,
+    tone: result.tone,
+  };
+}
+
+export function buildTimelineBlocks(args: {
+  briefing: ReturnType<typeof buildAssistantReadiness>;
+  conversationBlocks: TimelineBlock[];
+  pendingAssistant: boolean;
+  chapterId: string | null;
+  hasDraft: boolean;
+  showDraftPreview: boolean;
+  continuityQueued: boolean;
+  commandResult: CommandResult | null;
+  intentBlock: TimelineBlock | null;
+}): TimelineBlock[] {
+  const blocks: TimelineBlock[] = [
+    { id: "readiness", type: "readiness_card", briefing: args.briefing },
+    {
+      id: "readiness-chips",
+      type: "inline_choice_chips",
+      chips: args.briefing.chips.map((chip) => ({ ...chip, action: chip.intent })),
+    },
+  ];
+
+  blocks.push(...args.conversationBlocks);
+
+  if (args.pendingAssistant) {
+    blocks.push({
+      id: "assistant-pending",
+      type: "text_message",
+      source: "assistant",
+      label: "Studio Writing Assistant",
+      text: "Thinking",
+      tone: "running",
+      pending: true,
+    });
+  }
+
+  const continuityEvent = continuityWorkflowProgressEvent({ chapterId: args.chapterId, queued: args.continuityQueued });
+  if (continuityEvent) blocks.push(workflowProgressBlockFromEvent(continuityEvent));
+
+  if (args.hasDraft && args.showDraftPreview) {
+    blocks.push({
+      id: "draft-preview",
+      type: "artifact_preview",
+      source: "backend",
+      artifact_id: "current-draft",
+      artifact_type: "draft",
+      title: "Current chapter draft",
+      status: "draft",
+      description: "Draft content is open in the artifact workspace.",
+      word_count: null,
+      beat_count: null,
+      preview_lines: ["Draft content is open in the artifact workspace.", "Use the editor surface for prose edits and approval gates."],
+      actions: ["open_draft", "review_continuity", "edit_in_document"],
+    });
+  }
+
+  if (args.commandResult) blocks.push(resultBlock(args.commandResult));
+  if (args.intentBlock) blocks.push(args.intentBlock);
+  return blocks;
+}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/useAssistantConversations.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/useAssistantConversations.ts
@@ -1,0 +1,192 @@
+import React from "react";
+import type { TimelineBlock } from "@/features/scenes/components/writeTab/types";
+import {
+  defaultConversationState,
+  isTimelineBlock,
+  normalizeConversationState,
+  persistedBlockPayload,
+  type AssistantConversationState,
+} from "@/features/scenes/components/writeTab/chatOrchestration/conversationPersistence";
+
+
+export type AssistantConversationScope = "current_chapter" | "all_story";
+
+export type AssistantConversationListItem = {
+  id: string;
+  chapter_id: string | null;
+  title: string | null;
+  summary: string | null;
+  status: "active" | "archived";
+  state_json: Partial<AssistantConversationState>;
+  updated_at: string;
+  last_message_preview: string | null;
+};
+
+type AssistantConversationMessage = {
+  block: unknown;
+};
+
+async function jsonOrError(res: Response): Promise<Record<string, unknown>> {
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const error = typeof json?.error === "string" ? json.error : `REQUEST_FAILED_${res.status}`;
+    throw new Error(error);
+  }
+  return json as Record<string, unknown>;
+}
+
+// eslint-disable-next-line max-lines-per-function
+export function useAssistantConversations(args: { storySlug: string; chapterId: string }) {
+  const [scope, setScope] = React.useState<AssistantConversationScope>("current_chapter");
+  const [items, setItems] = React.useState<AssistantConversationListItem[]>([]);
+  const [activeConversationId, setActiveConversationId] = React.useState<string | null>(null);
+  const [conversationBlocks, setConversationBlocks] = React.useState<TimelineBlock[]>([]);
+  const [conversationState, setConversationState] = React.useState<AssistantConversationState>(defaultConversationState);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const creatingRef = React.useRef<Promise<string> | null>(null);
+  const activeIdRef = React.useRef<string | null>(null);
+  const itemsRef = React.useRef<AssistantConversationListItem[]>([]);
+
+  React.useEffect(() => {
+    activeIdRef.current = activeConversationId;
+  }, [activeConversationId]);
+
+  React.useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  const conversationsUrl = React.useCallback(() => {
+    const qs = new URLSearchParams({ scope });
+    if (args.chapterId) qs.set("chapter_id", args.chapterId);
+    return `/api/stories/${encodeURIComponent(args.storySlug)}/assistant/conversations?${qs.toString()}`;
+  }, [args.chapterId, args.storySlug, scope]);
+
+  const loadConversation = React.useCallback(async (conversationId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/stories/${encodeURIComponent(args.storySlug)}/assistant/conversations/${conversationId}/messages`, { cache: "no-store" });
+      const json = await jsonOrError(res);
+      const rows = Array.isArray(json.items) ? json.items as AssistantConversationMessage[] : [];
+      activeIdRef.current = conversationId;
+      setActiveConversationId(conversationId);
+      setConversationBlocks(rows.map((row) => row.block).filter(isTimelineBlock));
+      const found = itemsRef.current.find((item) => item.id === conversationId);
+      setConversationState(normalizeConversationState(found?.state_json));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "LOAD_CONVERSATION_FAILED");
+    } finally {
+      setLoading(false);
+    }
+  }, [args.storySlug]);
+
+  const reloadConversations = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(conversationsUrl(), { cache: "no-store" });
+      const json = await jsonOrError(res);
+      const nextItems = Array.isArray(json.items) ? json.items as AssistantConversationListItem[] : [];
+      itemsRef.current = nextItems;
+      setItems(nextItems);
+      const selected = activeIdRef.current && nextItems.some((item) => item.id === activeIdRef.current)
+        ? activeIdRef.current
+        : nextItems[0]?.id ?? null;
+      if (!selected) {
+        setActiveConversationId(null);
+        setConversationBlocks([]);
+        setConversationState(defaultConversationState);
+        return;
+      }
+      await loadConversation(selected);
+    } catch (e: unknown) {
+      setItems([]);
+      setActiveConversationId(null);
+      setConversationBlocks([]);
+      setConversationState(defaultConversationState);
+      setError(e instanceof Error ? e.message : "LIST_CONVERSATIONS_FAILED");
+    } finally {
+      setLoading(false);
+    }
+  }, [conversationsUrl, loadConversation]);
+
+  React.useEffect(() => {
+    activeIdRef.current = null;
+    void reloadConversations();
+  }, [reloadConversations]);
+
+  const createConversation = React.useCallback(async (): Promise<string> => {
+    if (creatingRef.current) return creatingRef.current;
+    creatingRef.current = (async () => {
+      const res = await fetch(`/api/stories/${encodeURIComponent(args.storySlug)}/assistant/conversations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chapter_id: args.chapterId || null,
+          state_json: defaultConversationState,
+        }),
+      });
+      const json = await jsonOrError(res);
+      const item = json.item as AssistantConversationListItem;
+      activeIdRef.current = item.id;
+      setItems((current) => [item, ...current.filter((existing) => existing.id !== item.id)]);
+      setActiveConversationId(item.id);
+      setConversationBlocks([]);
+      setConversationState(defaultConversationState);
+      return item.id;
+    })();
+    try {
+      return await creatingRef.current;
+    } finally {
+      creatingRef.current = null;
+    }
+  }, [args.chapterId, args.storySlug]);
+
+  const startNewConversation = React.useCallback(async () => {
+    setConversationBlocks([]);
+    setConversationState(defaultConversationState);
+    await createConversation();
+  }, [createConversation]);
+
+  const ensureConversation = React.useCallback(async () => activeIdRef.current ?? createConversation(), [createConversation]);
+
+  const appendBlock = React.useCallback(async (block: TimelineBlock) => {
+    const conversationId = await ensureConversation();
+    setConversationBlocks((current) => [...current, block]);
+    const payload = persistedBlockPayload(block);
+    const res = await fetch(`/api/stories/${encodeURIComponent(args.storySlug)}/assistant/conversations/${conversationId}/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    await jsonOrError(res);
+    await reloadConversations();
+  }, [args.storySlug, ensureConversation, reloadConversations]);
+
+  const persistConversationState = React.useCallback(async (state: AssistantConversationState) => {
+    setConversationState(state);
+    const conversationId = activeIdRef.current;
+    if (!conversationId) return;
+    await fetch(`/api/stories/${encodeURIComponent(args.storySlug)}/assistant/conversations/${conversationId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ state_json: state }),
+    }).then(jsonOrError).catch(() => undefined);
+  }, [args.storySlug]);
+
+  return {
+    scope,
+    setScope,
+    conversations: items,
+    activeConversationId,
+    conversationBlocks,
+    conversationState,
+    loading,
+    error,
+    loadConversation,
+    startNewConversation,
+    appendBlock,
+    persistConversationState,
+  };
+}

--- a/db/migrations/20260508_assistant_conversation_history.sql
+++ b/db/migrations/20260508_assistant_conversation_history.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS public.assistant_conversation (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    story_id bigint NOT NULL,
+    chapter_id text,
+    workspace text DEFAULT 'write_assistant'::text NOT NULL,
+    title text,
+    summary text,
+    status text DEFAULT 'active'::text NOT NULL,
+    state_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT assistant_conversation_pkey PRIMARY KEY (id),
+    CONSTRAINT assistant_conversation_status_check CHECK ((status = ANY (ARRAY['active'::text, 'archived'::text]))),
+    CONSTRAINT assistant_conversation_workspace_check CHECK (workspace = 'write_assistant'::text),
+    CONSTRAINT assistant_conversation_story_id_fkey FOREIGN KEY (story_id) REFERENCES public.story_series(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS public.assistant_message (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    conversation_id uuid NOT NULL,
+    role text NOT NULL,
+    block_type text,
+    content text DEFAULT ''::text NOT NULL,
+    metadata_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    sequence_no integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT assistant_message_pkey PRIMARY KEY (id),
+    CONSTRAINT assistant_message_role_check CHECK ((role = ANY (ARRAY['user'::text, 'assistant'::text, 'system'::text, 'tool'::text, 'workflow'::text]))),
+    CONSTRAINT assistant_message_conversation_id_fkey FOREIGN KEY (conversation_id) REFERENCES public.assistant_conversation(id) ON DELETE CASCADE,
+    CONSTRAINT assistant_message_sequence_uniq UNIQUE (conversation_id, sequence_no)
+);
+
+CREATE INDEX IF NOT EXISTS assistant_conversation_story_workspace_updated_idx
+    ON public.assistant_conversation USING btree (story_id, workspace, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS assistant_conversation_story_chapter_updated_idx
+    ON public.assistant_conversation USING btree (story_id, chapter_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS assistant_message_conversation_sequence_idx
+    ON public.assistant_message USING btree (conversation_id, sequence_no ASC);

--- a/docs/operations/specs/studio-chat-orchestration-layer.md
+++ b/docs/operations/specs/studio-chat-orchestration-layer.md
@@ -70,6 +70,14 @@ type StudioChatContext = {
 };
 ```
 
+## Conversation Sessions
+
+The Studio Writing Assistant chat timeline is backed by durable conversation sessions. A session is scoped by story, `write_assistant` workspace, and optional chapter. The UI may filter history to the current chapter or all story chats.
+
+Persist only committed timeline blocks: submitted user messages, final assistant messages, workflow/status blocks, artifact previews, approval gates, failure recovery, and context digests. Composer draft text, typing indicators, command-menu filter text, hover actions, and incomplete streaming chunks are transient UI state and must not be persisted as messages.
+
+Conversation metadata stores assistant continuation state such as brainstorm mode, recent brainstorm seed, and pending brainstorm follow-up actions. When a conversation is reopened, this metadata restores routing context before the next user turn. Restored history must not automatically trigger AutoWrite, preflight, or any workflow.
+
 If the context block is absent or malformed, the assistant must use the hard fallback:
 
 > "I'm missing the story context I need to help you. This usually means the Studio didn't load correctly. Try refreshing, or tell me which story and chapter you want to work on and I'll do my best."


### PR DESCRIPTION
## Summary
- Add PostgreSQL-backed Write Assistant conversation sessions and committed message persistence.
- Add story-scoped assistant conversation APIs for list/create/read/update/append.
- Wire the Write chat to show history, start New Chat, switch current-chapter/all-story scopes, and restore brainstorm state.
- Preserve composer draft as transient UI state and document the durable conversation boundary.

## Verification
- `TMPDIR=/tmp npx tsx src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.test.ts`
- `TMPDIR=/tmp npx tsx src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts`
- `TMPDIR=/tmp npx tsx src/features/chat-orchestration/server/timelineEvents.test.ts`
- `npm run typecheck`
- targeted `npx eslint ...` on changed TS/TSX files
- `git diff --check`
- `npm run build`

## Notes
- Added active migration `db/migrations/20260508_assistant_conversation_history.sql`; it is force-added because repo `.gitignore` ignores `*.sql` by default.
- Local Docker daemon was unavailable, so migration was not applied against a running local Postgres in this session.
