### PR TITLE
Add interactive Write Assistant choices

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -55,6 +55,7 @@ Refactor direction for large modules:
 - The center chat owns conversation history and the persistent bottom composer. User/assistant prose renders as compact chat bubbles with text-only copy actions; system state renders as compact timeline blocks.
 - Write Assistant conversations are durable server-backed sessions scoped by story, workspace, and optional chapter. The chat surface can show current-chapter history or all story chats, and New Chat creates a new session without deleting prior sessions.
 - Assistant state needed for continuation, including brainstorm mode, recent seed, and pending brainstorm follow-up actions, is restored from conversation metadata instead of React-only state.
+- Assistant choices use structured `choice_group` blocks when the UI expects a decision. Brainstorm angle and follow-up choices render as single-choice controls with selected state, and clicks send structured intent metadata while freeform typed fallback remains supported.
 - Composer draft text is private input state. It must never be rendered as a timeline message; only submitted messages appended by the submit handler enter conversation history.
 - The slash command menu is anchored above the composer with internal scrolling and must not shift the page layout.
 - Write workspace commands stay inside Write by default. Command handlers append the relevant timeline block and switch the shared right-inspector mode; they must not use route navigation for `/analyze`, `/research`, `/review`, `/memory`, `/pipeline`, `/context`, `/inspect`, or `/status`.

--- a/apps/studio/src/app/globals.css
+++ b/apps/studio/src/app/globals.css
@@ -891,6 +891,7 @@ body.write-route-lock {
 
 .work-message,
 .timeline-card,
+.choice-group-card,
 .timeline-chip-row {
   max-width: min(620px, 78%);
   width: fit-content;
@@ -905,6 +906,7 @@ body.write-route-lock {
 
 .work-message--assistant,
 .timeline-card,
+.choice-group-card,
 .timeline-chip-row {
   justify-self: start;
 }
@@ -996,6 +998,79 @@ body.write-route-lock {
   border-radius: var(--radius-md);
   background: rgba(17, 24, 39, 0.72);
   padding: 12px;
+}
+
+.choice-group-card {
+  display: grid;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-md);
+  background: rgba(17, 24, 39, 0.58);
+  padding: 10px;
+}
+
+.choice-group-card__prompt {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.choice-group-card__choices {
+  display: grid;
+  gap: 7px;
+}
+
+.choice-option {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+  width: 100%;
+  min-width: min(520px, 70vw);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text-secondary);
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.choice-option:hover:not(:disabled),
+.choice-option:focus-visible {
+  border-color: rgba(66, 199, 184, 0.42);
+  color: var(--text-primary);
+}
+
+.choice-option--selected {
+  border-color: rgba(66, 199, 184, 0.5);
+  background: rgba(66, 199, 184, 0.12);
+  color: var(--text-primary);
+}
+
+.choice-option:disabled:not(.choice-option--selected) {
+  opacity: 0.52;
+}
+
+.choice-option__marker {
+  color: var(--accent);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.choice-option strong,
+.choice-option small {
+  display: block;
+}
+
+.choice-option strong {
+  font-size: 13px;
+}
+
+.choice-option small {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .timeline-card--failure {

--- a/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx
@@ -4,6 +4,11 @@ import ChatComposer from "@/features/scenes/components/writeTab/chatOrchestratio
 import ChatTimeline from "@/features/scenes/components/writeTab/chatOrchestration/ChatTimeline";
 import ConversationHistoryPanel from "@/features/scenes/components/writeTab/chatOrchestration/ConversationHistoryPanel";
 import {
+  buildBrainstormAngleChoiceGroup,
+  buildBrainstormFollowupChoiceGroup,
+  type StructuredChoiceSelection,
+} from "@/features/scenes/components/writeTab/chatOrchestration/choiceGroups";
+import {
   approvalGateBlock,
   buildCommands,
   buildContextDigestBlock,
@@ -27,6 +32,7 @@ import type {
   AssistantReadinessContext,
   CommandId,
   RecoveryChip,
+  StudioChatIntent,
   TimelineBlock,
   WriteInspectorMode,
 } from "@/features/scenes/components/writeTab/types";
@@ -245,13 +251,15 @@ function useCommandRunner(args: {
     [args]
   );
 
-  const submitMessage = React.useCallback((message: string) => {
+  // eslint-disable-next-line complexity
+  const submitMessage = React.useCallback((message: string, structuredIntent?: StudioChatIntent | null) => {
     const route = routeStudioIntent({
       message,
       readiness: args.readinessContext.readiness,
       mode: args.mode,
       recentBrainstormSeed: args.recentBrainstormSeed,
       pendingBrainstormActions: args.pendingBrainstormActions,
+      structuredIntent,
     });
     setIntentBlock(null);
     if (route.brainstormSeed !== undefined) {
@@ -278,14 +286,24 @@ function useCommandRunner(args: {
       if (route.intent === "REPO_RUN_HELP" || route.intent === "REPO_TEST_HELP") {
         args.onModeChange("chat");
       }
+      const stamp = Date.now();
       args.onConversationBlock({
-        id: `assistant-${Date.now()}`,
+        id: `assistant-${stamp}`,
         type: "text_message",
         source: "assistant",
         label: "Studio Writing Assistant",
         text: route.assistantText,
         tone: "ready",
       });
+      if (route.intent === "BRAINSTORM" && route.brainstormSeed && route.brainstormSeed === message.trim()) {
+        args.onConversationBlock(buildBrainstormAngleChoiceGroup(route.brainstormSeed, `choice-angle-${stamp}`));
+      }
+      if (route.intent === "BRAINSTORM_EXPAND_CHOICE") {
+        args.onConversationBlock(buildBrainstormFollowupChoiceGroup(route.brainstormSeed, `choice-followup-${stamp}`));
+      }
+      if (route.intent === "BRAINSTORM_SCENE_GOAL" || route.intent === "BRAINSTORM_CHARACTER_CONTRADICTION" || route.intent === "BRAINSTORM_CHAPTER_OPENING") {
+        args.onConversationBlock(buildBrainstormFollowupChoiceGroup(route.brainstormSeed, `choice-followup-${stamp}`));
+      }
       return;
     }
     if (route.needsClarification) {
@@ -323,6 +341,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     loadConversation,
     loading: conversationsLoading,
     persistConversationState,
+    selectChoice,
     scope: conversationScope,
     setScope: setConversationScope,
     startNewConversation,
@@ -341,8 +360,9 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
       chatMode,
       recentBrainstormSeed,
       pendingBrainstormActions,
+      choiceSelections: conversationState.choiceSelections,
     });
-  }, [chatMode, pendingBrainstormActions, persistConversationState, recentBrainstormSeed]);
+  }, [chatMode, conversationState.choiceSelections, pendingBrainstormActions, persistConversationState, recentBrainstormSeed]);
 
   const { commandResult, intentBlock, runCommand, submitMessage } = useCommandRunner({
     storySlug: props.storySlug,
@@ -406,6 +426,31 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
     if (target) router.push(target);
   };
 
+  const handleChoice = (selection: StructuredChoiceSelection) => {
+    const userBlock: TimelineBlock = {
+      id: `user-choice-${Date.now()}`,
+      type: "text_message",
+      source: "user",
+      label: "You",
+      text: `Selected: ${selection.label}`,
+      metadata: {
+        source: "choice_group",
+        choiceGroupId: selection.choiceGroupId,
+        choiceId: selection.choiceId,
+        intent: selection.intent,
+      },
+    };
+    setPendingAssistant(true);
+    void selectChoice(selection.choiceGroupId, selection.choiceId)
+      .then(() => appendBlock(userBlock))
+      .then(() => {
+        window.setTimeout(() => {
+          submitMessage(selection.value, selection.intent);
+          setPendingAssistant(false);
+        }, 220);
+      });
+  };
+
   return (
     <section className="work-stream" aria-label="Studio chat work stream">
       <ConversationHistoryPanel
@@ -418,7 +463,7 @@ export default function CommandWorkStream(props: CommandWorkStreamProps) {
         onNewChat={() => void startNewConversation()}
         onSelectConversation={(id) => void loadConversation(id)}
       />
-      <ChatTimeline context={buildContextMiniBar(props.assistantContext, briefing.status)} blocks={blocks} onChip={handleChip} />
+      <ChatTimeline context={buildContextMiniBar(props.assistantContext, briefing.status)} blocks={blocks} onChip={handleChip} onChoice={handleChoice} />
       <ChatComposer
         value={props.composerValue}
         menuOpen={props.commandMenuOpen}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatTimeline.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/ChatTimeline.tsx
@@ -3,11 +3,13 @@
 import React from "react";
 import TimelineBlocks from "@/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks";
 import type { ChatContextMiniBarPayload, RecoveryChip, TimelineBlock } from "@/features/scenes/components/writeTab/types";
+import type { StructuredChoiceSelection } from "@/features/scenes/components/writeTab/chatOrchestration/choiceGroups";
 
 type ChatTimelineProps = {
   context: ChatContextMiniBarPayload;
   blocks: TimelineBlock[];
   onChip: (chip: RecoveryChip) => void;
+  onChoice: (selection: StructuredChoiceSelection) => void;
 };
 
 function statusClass(status: ChatContextMiniBarPayload["status"]): string {
@@ -16,7 +18,7 @@ function statusClass(status: ChatContextMiniBarPayload["status"]): string {
   return "status-pill status-pill--blocked";
 }
 
-export default function ChatTimeline({ context, blocks, onChip }: ChatTimelineProps) {
+export default function ChatTimeline({ context, blocks, onChip, onChoice }: ChatTimelineProps) {
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const [nearBottom, setNearBottom] = React.useState(true);
 
@@ -43,7 +45,7 @@ export default function ChatTimeline({ context, blocks, onChip }: ChatTimelinePr
       </div>
       <div ref={scrollRef} className="work-stream__scroll" onScroll={updateNearBottom}>
         <div className="timeline-stack">
-          <TimelineBlocks blocks={blocks} onChip={onChip} />
+          <TimelineBlocks blocks={blocks} onChip={onChip} onChoice={onChoice} />
         </div>
         {!nearBottom ? (
           <button type="button" className="jump-to-bottom" onClick={() => {

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/TimelineBlocks.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import React from "react";
+import { choiceSelectionFromBlock } from "@/features/scenes/components/writeTab/chatOrchestration/choiceGroups";
 import ReadinessBriefing from "@/features/scenes/components/writeTab/chatOrchestration/ReadinessBriefing";
-import type { RecoveryChip, TimelineBlock, WorkflowStepStatus } from "@/features/scenes/components/writeTab/types";
+import type { ChoiceGroupChoice, RecoveryChip, TimelineBlock, WorkflowStepStatus } from "@/features/scenes/components/writeTab/types";
+import type { StructuredChoiceSelection } from "@/features/scenes/components/writeTab/chatOrchestration/choiceGroups";
 
 type TimelineBlocksProps = {
   blocks: TimelineBlock[];
   onChip: (chip: RecoveryChip) => void;
+  onChoice: (selection: StructuredChoiceSelection) => void;
 };
 
 function workflowMarker(status: WorkflowStepStatus): string {
@@ -60,6 +63,44 @@ function ChoiceChipsBlock({ block, onChip }: { block: Extract<TimelineBlock, { t
         </button>
       ))}
     </div>
+  );
+}
+
+function ChoiceGroup({
+  block,
+  onChoice,
+}: {
+  block: Extract<TimelineBlock, { type: "choice_group" }>;
+  onChoice: (block: Extract<TimelineBlock, { type: "choice_group" }>, choice: ChoiceGroupChoice) => void;
+}) {
+  const selectedIds = block.choices.filter((choice) => choice.selected).map((choice) => choice.id);
+  const hasSelection = selectedIds.length > 0;
+  return (
+    <article className="choice-group-card" aria-label={block.prompt}>
+      <div className="choice-group-card__prompt">{block.prompt}</div>
+      <div className={`choice-group-card__choices choice-group-card__choices--${block.selectionMode}`}>
+        {block.choices.map((choice) => {
+          const selected = Boolean(choice.selected);
+          const disabled = Boolean(choice.disabled || (hasSelection && block.selectionMode === "single"));
+          return (
+            <button
+              key={choice.id}
+              type="button"
+              className={`choice-option ${selected ? "choice-option--selected" : ""}`}
+              aria-pressed={selected}
+              disabled={disabled}
+              onClick={() => onChoice(block, choice)}
+            >
+              <span className="choice-option__marker">{selected ? "✓" : block.selectionMode === "multiple" ? "□" : "○"}</span>
+              <span>
+                <strong>{choice.label}</strong>
+                {choice.description ? <small>{choice.description}</small> : null}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </article>
   );
 }
 
@@ -220,13 +261,14 @@ export function ContextDigestBlockView({ block }: { block: Extract<TimelineBlock
   );
 }
 
-export default function TimelineBlocks({ blocks, onChip }: TimelineBlocksProps) {
+export default function TimelineBlocks({ blocks, onChip, onChoice }: TimelineBlocksProps) {
   return (
     <>
       {blocks.map((block) => {
         if (block.type === "text_message") return <TextBlock key={block.id} block={block} />;
         if (block.type === "readiness_card") return <ReadinessBriefing key={block.id} briefing={block.briefing} onChip={onChip} />;
         if (block.type === "inline_choice_chips") return <ChoiceChipsBlock key={block.id} block={block} onChip={onChip} />;
+        if (block.type === "choice_group") return <ChoiceGroup key={block.id} block={block} onChoice={(choiceBlock, choice) => onChoice(choiceSelectionFromBlock(choiceBlock, choice))} />;
         if (block.type === "workflow_progress") return <WorkflowProgressBlockView key={block.id} block={block} />;
         if (block.type === "artifact_preview") return <ArtifactPreviewBlockView key={block.id} block={block} />;
         if (block.type === "approval_gate") return <ApprovalGate key={block.id} block={block} />;

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/choiceGroups.test.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/choiceGroups.test.ts
@@ -1,0 +1,28 @@
+import {
+  buildBrainstormAngleChoiceGroup,
+  buildBrainstormFollowupChoiceGroup,
+  choiceSelectionFromBlock,
+} from "@/features/scenes/components/writeTab/chatOrchestration/choiceGroups";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+export function runChoiceGroupsSelfTest(): void {
+  const angle = buildBrainstormAngleChoiceGroup("bomb, heart attack, science", "angle-test");
+  assert(angle.type === "choice_group", "angle choices render as a choice group");
+  assert(angle.selectionMode === "single", "brainstorm angle is single-choice");
+  assert(angle.choices.length === 3, "brainstorm angle has three choices");
+  assert(angle.choices[0].description?.includes("bomb design") === true, "angle choices use seed-specific details");
+
+  const selection = choiceSelectionFromBlock(angle, angle.choices[0]);
+  assert(selection.intent === "BRAINSTORM_EXPAND_CHOICE", "angle selection preserves structured expand intent");
+  assert(selection.value === "1", "angle selection keeps freeform fallback value");
+
+  const followup = buildBrainstormFollowupChoiceGroup("a girl", "followup-test");
+  const character = followup.choices.find((choice) => choice.id === "character_contradiction");
+  assert(Boolean(character), "follow-up choices include character contradiction");
+  assert(Boolean(character && choiceSelectionFromBlock(followup, character).intent === "BRAINSTORM_CHARACTER_CONTRADICTION"), "follow-up click maps to structured brainstorm continuation");
+}
+
+runChoiceGroupsSelfTest();

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/choiceGroups.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/choiceGroups.ts
@@ -1,0 +1,108 @@
+import type { ChoiceGroupBlock, ChoiceGroupChoice, StudioChatIntent } from "@/features/scenes/components/writeTab/types";
+
+export type StructuredChoiceSelection = {
+  choiceGroupId: string;
+  choiceId: string;
+  label: string;
+  value: string;
+  intent?: StudioChatIntent;
+};
+
+type BrainstormOption = {
+  id: "hidden_wound" | "trigger_event" | "opening_scene";
+  label: string;
+  value: string;
+  description: string;
+};
+
+const fallbackOptions: BrainstormOption[] = [
+  { id: "hidden_wound", label: "Hidden wound", value: "1", description: "Define the pain the protagonist is hiding and why they cannot say it directly." },
+  { id: "trigger_event", label: "Trigger event", value: "2", description: "Choose the incident that forces the hidden conflict into the open." },
+  { id: "opening_scene", label: "Opening scene", value: "3", description: "Find the first visual scene that reveals the conflict without explaining it." },
+];
+
+function normalized(seed: string): string {
+  return seed.trim().toLowerCase();
+}
+
+function optionsForSeed(seed: string): BrainstormOption[] {
+  const lower = normalized(seed);
+  if (/\bbomb\b|\bheart attack\b|\bheart atack\b|\bscience\b|\blab\b/.test(lower)) {
+    return [
+      { id: "hidden_wound", label: "Hidden wound", value: "1", description: "The protagonist believes her research helped create the bomb design that caused a death by panic and heart failure." },
+      { id: "trigger_event", label: "Trigger event", value: "2", description: "A second attack appears, and only she recognizes the scientific pattern linking it to the old tragedy." },
+      { id: "opening_scene", label: "Opening scene", value: "3", description: "She is in a hospital corridor after a bombing, watching a heart monitor flatline while a lab sample in her pocket starts reacting." },
+    ];
+  }
+  if (/\bsad\b|\bgirl\b|\bwound\b|\bgrief\b/.test(lower)) {
+    return [
+      { id: "hidden_wound", label: "Hidden wound", value: "1", description: "The sad girl hides the real reason she stopped trusting the people who say they love her." },
+      { id: "trigger_event", label: "Trigger event", value: "2", description: "A small public crisis forces her private grief into view before she is ready to explain it." },
+      { id: "opening_scene", label: "Opening scene", value: "3", description: "Start with her performing one ordinary task while every detail quietly reveals what she has lost." },
+    ];
+  }
+  if (/\badopt|\badopted\b|\badoption\b|\bfamily\b/.test(lower)) {
+    return [
+      { id: "hidden_wound", label: "Quiet coming-of-age", value: "1", description: "He is loved but still feels like a guest, so the conflict has no obvious villain." },
+      { id: "trigger_event", label: "Identity mystery", value: "2", description: "A normal family habit exposes a clue that his past was deliberately hidden from him." },
+      { id: "opening_scene", label: "Family secret", value: "3", description: "The family knows why he does not belong, but protecting him has become another kind of lie." },
+    ];
+  }
+  return fallbackOptions;
+}
+
+export function buildBrainstormAngleChoiceGroup(seed: string, id = `choice-brainstorm-angle-${Date.now()}`): ChoiceGroupBlock {
+  return {
+    id,
+    type: "choice_group",
+    source: "assistant",
+    prompt: "Choose an angle to expand.",
+    selectionMode: "single",
+    choices: optionsForSeed(seed),
+    submitBehavior: "immediate",
+    metadata: {
+      intent: "BRAINSTORM_EXPAND_CHOICE",
+      groupKind: "brainstorm_angle",
+      seed,
+    },
+  };
+}
+
+function followupChoices(): ChoiceGroupChoice[] {
+  return [
+    { id: "scene_goal", label: "Scene goal", value: "scene goal", description: "Turn the selected angle into a clear scene objective." },
+    { id: "character_contradiction", label: "Character contradiction", value: "character contradiction", description: "Expand the inner and outer tension in the character." },
+    { id: "chapter_opening", label: "Chapter opening", value: "chapter opening", description: "Shape the angle into the first scene setup." },
+  ];
+}
+
+export function buildBrainstormFollowupChoiceGroup(seed: string | null | undefined, id = `choice-brainstorm-followup-${Date.now()}`): ChoiceGroupBlock {
+  return {
+    id,
+    type: "choice_group",
+    source: "assistant",
+    prompt: "Choose what to turn this into next.",
+    selectionMode: "single",
+    choices: followupChoices(),
+    submitBehavior: "immediate",
+    metadata: {
+      intent: "BRAINSTORM_CHARACTER_CONTRADICTION",
+      groupKind: "brainstorm_followup",
+      seed: seed ?? null,
+    },
+  };
+}
+
+export function choiceSelectionFromBlock(block: ChoiceGroupBlock, choice: ChoiceGroupChoice): StructuredChoiceSelection {
+  const intent = choice.id === "scene_goal" ? "BRAINSTORM_SCENE_GOAL"
+    : choice.id === "character_contradiction" ? "BRAINSTORM_CHARACTER_CONTRADICTION"
+      : choice.id === "chapter_opening" ? "BRAINSTORM_CHAPTER_OPENING"
+        : block.metadata?.intent;
+  return {
+    choiceGroupId: block.id,
+    choiceId: choice.id,
+    label: choice.label,
+    value: choice.value,
+    intent,
+  };
+}

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.test.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.test.ts
@@ -29,6 +29,7 @@ export function runConversationPersistenceSelfTest(): void {
   assert(state.chatMode === "brainstorm", "brainstorm mode restores from metadata");
   assert(state.recentBrainstormSeed === "a girl", "recent brainstorm seed restores from metadata");
   assert(state.pendingBrainstormActions?.[0] === "character_contradiction", "pending follow-up actions restore from metadata");
+  assert(Object.keys(state.choiceSelections).length === 0, "choice selections default to an object");
 
   const fallback = normalizeConversationState({ chatMode: "invalid", recentBrainstormSeed: 1 });
   assert(fallback.chatMode === "chat", "invalid state falls back to chat mode");

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.ts
@@ -5,12 +5,14 @@ export type AssistantConversationState = {
   chatMode: "chat" | "brainstorm";
   recentBrainstormSeed: string | null;
   pendingBrainstormActions: BrainstormFollowupAction[] | null;
+  choiceSelections: Record<string, string[]>;
 };
 
 export const defaultConversationState: AssistantConversationState = {
   chatMode: "chat",
   recentBrainstormSeed: null,
   pendingBrainstormActions: null,
+  choiceSelections: {},
 };
 
 export function isTimelineBlock(value: unknown): value is TimelineBlock {
@@ -23,6 +25,9 @@ export function normalizeConversationState(value: unknown): AssistantConversatio
     chatMode: obj.chatMode === "brainstorm" ? "brainstorm" : "chat",
     recentBrainstormSeed: typeof obj.recentBrainstormSeed === "string" ? obj.recentBrainstormSeed : null,
     pendingBrainstormActions: Array.isArray(obj.pendingBrainstormActions) ? obj.pendingBrainstormActions : null,
+    choiceSelections: obj.choiceSelections && typeof obj.choiceSelections === "object" && !Array.isArray(obj.choiceSelections)
+      ? obj.choiceSelections as Record<string, string[]>
+      : {},
   };
 }
 
@@ -35,6 +40,7 @@ export function blockRole(block: TimelineBlock): "user" | "assistant" | "workflo
 
 export function blockContent(block: TimelineBlock): string {
   if (block.type === "text_message") return block.text;
+  if (block.type === "choice_group") return block.prompt;
   if (block.type === "workflow_progress") return `${block.workflow_name}: ${block.current_step_label}`;
   if (block.type === "artifact_preview") return block.title;
   if (block.type === "approval_gate") return block.description;

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/intentRouter.ts
@@ -18,6 +18,7 @@ type RouteIntentArgs = {
   mode?: "chat" | "brainstorm";
   recentBrainstormSeed?: string | null;
   pendingBrainstormActions?: BrainstormFollowupAction[] | null;
+  structuredIntent?: StudioChatIntent | null;
 };
 
 const commandByIntent: Partial<Record<StudioChatIntent, CommandId>> = {
@@ -317,7 +318,7 @@ function goalFromMessage(message: string, intent: StudioChatIntent): string {
 // eslint-disable-next-line complexity
 export function routeStudioIntent(args: RouteIntentArgs): IntentRoute {
   const brainstormIntent = isExplicitChapterWrite(args.message) ? null : pendingBrainstormIntent(args.message, args.pendingBrainstormActions, args.mode);
-  const intent = brainstormIntent ?? detectStudioIntent(args.message);
+  const intent = args.structuredIntent ?? brainstormIntent ?? detectStudioIntent(args.message);
   const goal = goalFromMessage(args.message, intent);
   if (intent === "REPO_RUN_HELP" || intent === "REPO_TEST_HELP") {
     return { intent, command: null, goal, needsClarification: false, assistantText: repoHelpReply(), brainstormSeed: null };

--- a/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/useAssistantConversations.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/chatOrchestration/useAssistantConversations.ts
@@ -69,11 +69,23 @@ export function useAssistantConversations(args: { storySlug: string; chapterId: 
       const res = await fetch(`/api/stories/${encodeURIComponent(args.storySlug)}/assistant/conversations/${conversationId}/messages`, { cache: "no-store" });
       const json = await jsonOrError(res);
       const rows = Array.isArray(json.items) ? json.items as AssistantConversationMessage[] : [];
+      const found = itemsRef.current.find((item) => item.id === conversationId);
+      const restoredState = normalizeConversationState(found?.state_json);
       activeIdRef.current = conversationId;
       setActiveConversationId(conversationId);
-      setConversationBlocks(rows.map((row) => row.block).filter(isTimelineBlock));
-      const found = itemsRef.current.find((item) => item.id === conversationId);
-      setConversationState(normalizeConversationState(found?.state_json));
+      setConversationBlocks(rows.map((row) => row.block).filter(isTimelineBlock).map((block) => {
+        if (block.type !== "choice_group") return block;
+        const selectedIds = restoredState.choiceSelections[block.id] ?? [];
+        return {
+          ...block,
+          choices: block.choices.map((choice) => ({
+            ...choice,
+            selected: selectedIds.includes(choice.id),
+            disabled: selectedIds.length > 0 && !selectedIds.includes(choice.id),
+          })),
+        };
+      }));
+      setConversationState(restoredState);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "LOAD_CONVERSATION_FAILED");
     } finally {
@@ -175,6 +187,28 @@ export function useAssistantConversations(args: { storySlug: string; chapterId: 
     }).then(jsonOrError).catch(() => undefined);
   }, [args.storySlug]);
 
+  const selectChoice = React.useCallback(async (choiceGroupId: string, choiceId: string) => {
+    const nextState = {
+      ...conversationState,
+      choiceSelections: {
+        ...conversationState.choiceSelections,
+        [choiceGroupId]: [choiceId],
+      },
+    };
+    setConversationBlocks((current) => current.map((block) => {
+      if (block.type !== "choice_group" || block.id !== choiceGroupId) return block;
+      return {
+        ...block,
+        choices: block.choices.map((choice) => ({
+          ...choice,
+          selected: choice.id === choiceId,
+          disabled: choice.id !== choiceId,
+        })),
+      };
+    }));
+    await persistConversationState(nextState);
+  }, [conversationState, persistConversationState]);
+
   return {
     scope,
     setScope,
@@ -188,5 +222,6 @@ export function useAssistantConversations(args: { storySlug: string; chapterId: 
     startNewConversation,
     appendBlock,
     persistConversationState,
+    selectChoice,
   };
 }

--- a/apps/studio/src/features/scenes/components/writeTab/types.ts
+++ b/apps/studio/src/features/scenes/components/writeTab/types.ts
@@ -116,6 +116,31 @@ export type InlineChoiceChip = RecoveryChip & {
   action: RecoveryIntent;
 };
 
+export type ChoiceGroupChoice = {
+  id: string;
+  label: string;
+  description?: string;
+  value: string;
+  selected?: boolean;
+  disabled?: boolean;
+};
+
+export type ChoiceGroupBlock = {
+  type: "choice_group";
+  id: string;
+  source: "assistant";
+  prompt: string;
+  selectionMode: "single" | "multiple";
+  choices: ChoiceGroupChoice[];
+  submitBehavior: "immediate" | "requires_confirm";
+  metadata?: {
+    intent?: StudioChatIntent;
+    groupKind?: "brainstorm_angle" | "brainstorm_followup" | "context_recovery";
+    seed?: string | null;
+    [key: string]: unknown;
+  };
+};
+
 export type WorkflowStepStatus = "complete" | "active" | "pending" | "failed";
 
 export type WriteInspectorMode = "progress" | "context" | "artifacts" | "memory";
@@ -206,9 +231,10 @@ export type ContextDigestBlock = {
 };
 
 export type TimelineBlock =
-  | { type: "text_message"; id: string; source: "user" | "assistant"; label: string; text: string; tone?: "ready" | "blocked" | "running"; pending?: boolean }
+  | { type: "text_message"; id: string; source: "user" | "assistant"; label: string; text: string; tone?: "ready" | "blocked" | "running"; pending?: boolean; metadata?: Record<string, unknown> }
   | { type: "readiness_card"; id: string; briefing: AssistantReadinessBriefing }
   | { type: "inline_choice_chips"; id: string; chips: InlineChoiceChip[] }
+  | ChoiceGroupBlock
   | (WorkflowProgressBlock & { id: string })
   | (ArtifactPreviewBlock & { id: string })
   | (ApprovalGateBlock & { id: string })

--- a/docs/operations/specs/studio-chat-orchestration-layer.md
+++ b/docs/operations/specs/studio-chat-orchestration-layer.md
@@ -172,6 +172,7 @@ type TimelineBlock =
   | "text_message"
   | "readiness_card"
   | "inline_choice_chips"
+  | "choice_group"
   | "workflow_progress"
   | "artifact_preview"
   | "approval_gate"
@@ -189,7 +190,7 @@ Block source ownership is strict:
 
 | Source | Blocks |
 |---|---|
-| Assistant-originated | `text_message`, `readiness_card`, `inline_choice_chips`, assistant-detected `failure_recovery` |
+| Assistant-originated | `text_message`, `readiness_card`, `inline_choice_chips`, `choice_group`, assistant-detected `failure_recovery` |
 | Backend/workflow-originated | `workflow_progress`, `artifact_preview`, `approval_gate`, backend failure `failure_recovery`, `context_digest` |
 
 The assistant may acknowledge backend-originated blocks with short text, but it must not generate their payloads.
@@ -214,6 +215,14 @@ The assistant may acknowledge backend-originated blocks with short text, but it 
 - Minimum 2, maximum 4.
 - Each chip maps to an executable intent.
 - A blocked chip opens recovery, not silent failure.
+
+### `choice_group`
+
+- Use when the assistant asks the user to choose among explicit options.
+- Single-choice decisions render as selectable cards or chips, not checkboxes.
+- Multi-choice decisions render as checkboxes with a confirm/apply action.
+- Choice clicks must carry structured metadata such as `choiceGroupId`, `choiceId`, and intended route, while typed freeform fallback remains valid.
+- Selected state must remain visible when a conversation is restored from history.
 
 ### `workflow_progress`
 


### PR DESCRIPTION
## Summary
- Add a structured `choice_group` timeline block contract for assistant choices.
- Render brainstorm angle and follow-up decisions as interactive selectable controls with selected state.
- Send choice clicks as structured user metadata and route them before freeform parsing.
- Persist selected choice state through existing conversation metadata so restored chats show previous selections.
- Document the choice block contract in Studio README and orchestration spec.

## Verification
- `TMPDIR=/tmp npx tsx src/features/scenes/components/writeTab/chatOrchestration/choiceGroups.test.ts`
- `TMPDIR=/tmp npx tsx src/features/scenes/components/writeTab/chatOrchestration/conversationPersistence.test.ts`
- `TMPDIR=/tmp npx tsx src/features/scenes/components/writeTab/chatOrchestration/intentRouter.test.ts`
- `TMPDIR=/tmp npx tsx src/features/chat-orchestration/server/timelineEvents.test.ts`
- `npm run typecheck`
- targeted `npx eslint ...` on changed TS/TSX files
- `git diff --check`
- `npm run build`

## Notes
- This PR wires single-choice brainstorm interactions. The block contract includes `multiple`, but no current flow emits a multi-select context checklist yet.
