### PR TITLE
Add Agent Harness v1 docs and checks

### DIFF
--- a/.agents/skills/agent-harness-consistency-pass/SKILL.md
+++ b/.agents/skills/agent-harness-consistency-pass/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agent-harness-consistency-pass
+description: Use when auditing or updating the Novel AI Agent Harness, AGENTS.md, runtime skills, docs taxonomy, E2E paths, session hooks, or broken source-of-truth references.
+---
+
+# Agent Harness Consistency Pass
+
+## Purpose
+
+Keep the repo's agent harness accurate before adding or changing rules. This skill is for finding stale paths, duplicate docs, outdated skill instructions, missing source-of-truth files, and verification command drift.
+
+## Trigger Conditions
+
+Use this skill when a task mentions:
+
+- Agent Harness v1, AI layer, context pack, or agent operating guide.
+- `AGENTS.md`, `.agents/skills/`, `docs/agent-skills/`, or session hooks.
+- E2E command or Playwright path drift.
+- Broken documentation references.
+- Creating or updating harness GitHub issues.
+
+## Required Investigation Steps
+
+1. Verify the real repo root:
+   - `git status --short --branch`
+   - `git remote -v`
+   - root listing includes `.git`, `AGENTS.md`, `README.md`, `apps`, `docs`, and `scripts`.
+2. Read `AGENTS.md`.
+3. Read `apps/studio/README.md` if Studio workflow, UI, E2E, or product behavior is in scope.
+4. Inspect:
+   - `.agents/skills/*/SKILL.md`
+   - `docs/agent-skills/`
+   - `docs/operations/specs/`
+   - `docs/operations/implementation/`
+   - `docs/architecture/`
+   - `apps/studio/package.json`
+   - `apps/studio/playwright.config.ts`
+   - `apps/studio/e2e/`
+   - `scripts/ops/`
+   - `.github/`
+5. Search for drift:
+   - missing referenced docs
+   - stale `tests/e2e` references
+   - stale Playwright versions
+   - duplicate docs that claim to be source of truth
+   - recommendations to create `.ai/skills` when `.agents/skills` is the runtime home
+   - hidden service assumptions for Docker, PostgreSQL, Qdrant, Neo4j, local LLM, workers, or Studio
+
+## Output Format
+
+Return:
+
+```md
+# Agent Harness Consistency Report
+
+## Summary
+## Current Source-of-Truth Map
+## Drift Found
+## Required Fixes
+## Follow-up Issues
+## Verification
+## Risks
+```
+
+## Implementation Rules
+
+- Do not change product behavior during a consistency pass.
+- Prefer the existing docs taxonomy:
+  - `docs/operations/specs/` for canonical harness specs.
+  - `docs/operations/implementation/` for rollout, maintenance, guides, and reports.
+  - `docs/agent-skills/` for skill inventory and update reports.
+  - `.agents/skills/` for runtime skills.
+- Do not create `.ai/skills/` unless a human explicitly changes the repo convention.
+- If a referenced source-of-truth file is missing, either restore a small canonical file or track the fix in GitHub before adding new dependent docs.
+- Preserve chat-first product rules while documenting harness workflows.
+
+## Verification Requirements
+
+For docs-only harness work, run:
+
+```bash
+git diff --check
+```
+
+If package scripts or shell hooks change, also run:
+
+```bash
+bash -n scripts/ops/agent-session-start.sh
+bash -n scripts/ops/agent-session-stop-review.sh
+```
+
+If `apps/studio` TypeScript, config, or tests change, use the Studio gates from `AGENTS.md`.

--- a/.agents/skills/playwright-e2e-verification/SKILL.md
+++ b/.agents/skills/playwright-e2e-verification/SKILL.md
@@ -17,19 +17,19 @@ Use this skill when the task involves:
 - 5-chapter story quality rubric validation.
 - Screenshots, traces, or route-level browser checks.
 
-## Current Repo Reality (verified 2026-05-22)
+## Current Repo Reality (verified 2026-05-26)
 
 Playwright is installed and configured in `apps/studio`.
 
 | Item | State |
 |---|---|
-| Playwright version | `@playwright/test@1.60.0` |
+| Playwright version | `@playwright/test` `^1.51.1` in `apps/studio/package.json` |
 | Config | `apps/studio/playwright.config.ts` |
-| Test directory | `apps/studio/tests/e2e/` |
-| Test files | `story-five-chapter-flow.spec.ts` |
-| Total tests | 6 (TC1–TC6) |
+| Test directory | `apps/studio/e2e/tests/` |
+| Fixtures/helpers | `apps/studio/e2e/fixtures/`, `apps/studio/e2e/helpers/` |
+| Test files | `test-*.spec.ts`, `chat-first-chapter11.spec.ts`, `story-five-chapter-flow.spec.ts` |
 | Browsers installed | Chromium (run `npx playwright install chromium` on new machine) |
-| Base URL | `http://localhost:3000` (override with `E2E_BASE_URL`) |
+| Base URL | `http://127.0.0.1:3000` by default in config; override with `PLAYWRIGHT_BASE_URL` or `PLAYWRIGHT_PORT` |
 | Run command | `npm run test:e2e` |
 | Real local LLM run command | `npm run e2e:start-and-test` |
 | UI mode | `npm run test:e2e:ui` |
@@ -39,7 +39,7 @@ Playwright is installed and configured in `apps/studio`.
 
 ## Helper Files
 
-All helpers live in `apps/studio/tests/e2e/helpers/`:
+Helpers live in `apps/studio/e2e/helpers/`:
 
 | File | Purpose |
 |---|---|
@@ -95,10 +95,10 @@ npm run e2e:start-and-test
 E2E_REAL_LLM=1 npm run test:e2e:ui
 
 # Run a single spec
-npx playwright test story-five-chapter-flow --project=chromium
+npx playwright test e2e/tests/story-five-chapter-flow.spec.ts --project=chromium
 
-# Custom base URL (e.g., Docker port 3001)
-E2E_BASE_URL=http://localhost:3001 npm run test:e2e
+# Custom base URL
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npm run test:e2e
 
 # Show last HTML report
 npm run test:e2e:report
@@ -123,13 +123,13 @@ npm run test:e2e:report
 
 When adding a new test file:
 
-1. Import helpers from `./helpers/selectors`, `./helpers/story-fixtures`, `./helpers/ai-generation`.
+1. Import helpers from `../helpers/selectors`, `../helpers/story-fixtures`, `../helpers/ai-generation` when adding specs under `e2e/tests`.
 2. Use `test.beforeAll` / `test.afterAll` with `createTestStory` / `archiveTestStory`.
 3. Gate generation mocks behind `process.env.E2E_REAL_LLM !== "1"` before navigation to write workspace.
 4. Use `S.*` selector constants — never write raw selectors in test bodies.
-5. Run `npm run typecheck` via `tsconfig.e2e.json` after changes:
+5. Run the narrow Playwright discovery gate after changes:
    ```bash
-   npx tsc --project tsconfig.e2e.json --noEmit
+   npm run test:e2e -- --list
    ```
 
 ## Forbidden Actions
@@ -142,10 +142,10 @@ When adding a new test file:
 
 ## Verification Requirements
 
-After TypeScript changes to test files:
+After E2E test file changes:
 ```bash
 cd apps/studio
-npx tsc --project tsconfig.e2e.json --noEmit
+npm run test:e2e -- --list
 ```
 
 After changes to production components (e.g., adding `data-testid`):
@@ -202,10 +202,10 @@ Priority rows to automate next (not yet covered):
 
 ## Evidence
 
-- Source: `apps/studio/playwright.config.ts` (created 2026-05-22).
-- Source: `apps/studio/tests/e2e/story-five-chapter-flow.spec.ts` (created 2026-05-22).
-- Source: `apps/studio/tests/e2e/helpers/*.ts` (created 2026-05-22).
-- Source: `apps/studio/package.json` — `@playwright/test@1.60.0` in devDependencies.
-- Source: `npx playwright test --list` output — 6 tests confirmed discoverable.
+- Source: `apps/studio/playwright.config.ts` (`testDir: "./e2e/tests"`).
+- Source: `apps/studio/e2e/tests/*.spec.ts`.
+- Source: `apps/studio/e2e/helpers/*.ts`.
+- Source: `apps/studio/package.json` - `@playwright/test` `^1.51.1` in devDependencies.
+- Source: `npm run test:e2e -- --list` output.
 - Source: `docs/operations/implementation/write-assistant-chat-qa-barem.md` — manual barem still the fallback for uncovered flows.
 - Confidence: high.

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ _staging*
 !.agents/skills/implementation-planning/SKILL.md
 !.agents/skills/github-issue-pr-workflow/
 !.agents/skills/github-issue-pr-workflow/SKILL.md
+!.agents/skills/agent-harness-consistency-pass/
+!.agents/skills/agent-harness-consistency-pass/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ Repo-specific Codex skills live under `.agents/skills/`. Use them after reading 
 - `investigation-workflow`: evidence-first investigation before code changes for production failures, UI regressions, data issues, auth/storage/DB uncertainty, or unclear root cause.
 - `implementation-planning`: execution-ready plans with scope, non-goals, file manifest, acceptance criteria, quality gates, rollback notes, and Agent/Human mode structure.
 - `github-issue-pr-workflow`: GitHub issue, branch, PR, and review-note workflow using repo branch naming and `staging`-first PR targets.
+- `agent-harness-consistency-pass`: audit AGENTS, docs, runtime skills, E2E paths, scripts, and broken references before changing harness rules.
 
 Do not use these skills as a substitute for repo investigation. Each skill lists the exact docs and files to inspect for its surface.
 

--- a/docs/agent-skills/README.md
+++ b/docs/agent-skills/README.md
@@ -34,6 +34,7 @@ repo-specific skills are:
 - `investigation-workflow`
 - `implementation-planning`
 - `github-issue-pr-workflow`
+- `agent-harness-consistency-pass`
 
 `AGENTS.md` lists them with one-line descriptions. The other directories
 under `.agents/skills/` (api-patterns, app-builder, frontend-design,

--- a/docs/architecture/change-impact-map.md
+++ b/docs/architecture/change-impact-map.md
@@ -1,0 +1,26 @@
+# Change Impact Map
+
+Status: Active reference
+Last updated: 2026-05-26
+
+This map helps agents identify which source-of-truth files to inspect before changing a surface. It is intentionally compact; detailed contracts live in the linked docs and skills.
+
+| Change surface | Read first | Common files |
+|---|---|---|
+| Agent harness, skills, docs drift | `AGENTS.md`, `docs/operations/specs/novel-ai-agent-harness.md`, `.agents/skills/agent-harness-consistency-pass/SKILL.md` | `.agents/skills/*/SKILL.md`, `docs/agent-skills/*`, `docs/operations/implementation/agent-harness-*` |
+| Write chat, composer, slash commands | `.agents/skills/chat-first-workspace/SKILL.md`, `docs/operations/specs/studio-chat-orchestration-layer.md` | `apps/studio/src/features/scenes/components/writeTab/CommandWorkStream.tsx`, `apps/studio/src/features/scenes/components/writeTab/chatOrchestration/*` |
+| Write layout and inspector | `.agents/skills/codex-style-layout-review/SKILL.md`, `apps/studio/README.md` | `NovelLabWorkspace.tsx`, `ArtifactSurface.tsx`, `ArtifactInspectorRail.tsx` |
+| Artifact contracts | `.agents/skills/artifact-context-contract/SKILL.md` | `apps/studio/src/features/scenes/components/writeTab/types.ts`, `TimelineBlocks.tsx`, `ArtifactSurface.tsx` |
+| Workflow progress | `.agents/skills/agent-progress-panel/SKILL.md` | `workflowProgressEvents.ts`, `TimelineBlocks.tsx`, `ArtifactInspectorRail.tsx` |
+| Long text ingestion | `.agents/skills/long-text-ingestion/SKILL.md`, `apps/studio/README.md` ingest section | `apps/studio/src/features/ingest/*`, `services/memory-bridge/*` |
+| Story context and memory | `.agents/skills/story-context-grooming/SKILL.md`, `docs/architecture/writing-context-contract.md` | `apps/studio/src/features/memory/*`, `services/memory-bridge/worker_memory_*` |
+| Chapter generation | `.agents/skills/chapter-generation-workflow/SKILL.md`, `docs/architecture/chapter_first_v3_spec.md` | `services/memory-bridge/worker_chapter_writer.py`, `apps/studio/src/features/scenes/server/workflow/*` |
+| Playwright E2E | `.agents/skills/playwright-e2e-verification/SKILL.md` | `apps/studio/playwright.config.ts`, `apps/studio/e2e/*`, `scripts/ops/start_e2e_stack.sh` |
+| DB contracts | `db/migrations/*.sql`, relevant architecture docs | `db/migrations/*`, `services/memory-bridge/*`, server repos |
+
+Rules:
+
+- Read `AGENTS.md` before repo work.
+- Read `apps/studio/README.md` when product architecture or workflow behavior is involved.
+- Use the relevant skill, but verify actual paths before editing.
+- If this map becomes stale, update it in the same PR as the convention change.

--- a/docs/operations/implementation/agent-harness-consistency-report-2026-05-26.md
+++ b/docs/operations/implementation/agent-harness-consistency-report-2026-05-26.md
@@ -1,0 +1,52 @@
+# Agent Harness Consistency Report
+
+Issue: #165
+Date: 2026-05-26
+
+## Summary
+
+The repo already has an agent harness foundation: `AGENTS.md`, `.agents/skills/`, `docs/agent-skills/`, Studio chat-first contracts, Playwright E2E specs, and GitHub issue templates. The main work is consolidation and drift repair, not creating a parallel `.ai/skills` or `docs/ai-layer` tree.
+
+## Current Source-of-Truth Map
+
+| Area | Current Source of Truth | Status | Notes |
+|---|---|---|---|
+| Root agent rules | `AGENTS.md` | active | Canonical instruction file. |
+| Product/workflow behavior | `apps/studio/README.md` | active | Defines Write workspace chat contracts and UI rules. |
+| Runtime skills | `.agents/skills/` | active | Repo-specific skills are unignored individually in `.gitignore`. |
+| Skill docs inventory | `docs/agent-skills/` | active | Meta-docs only, not runtime skills. |
+| Chat-first policy | `docs/operations/implementation/chat-first-architecture-policy.md` | active | Defines no route-only command behavior. |
+| E2E config | `apps/studio/playwright.config.ts` | active | Uses `testDir: "./e2e/tests"`. |
+| E2E tests | `apps/studio/e2e/` | active | Contains fixtures, helpers, and specs. |
+| Dev stack scripts | `scripts/ops/start_e2e_stack.sh` | active | Starts Docker, local LLM, Studio, historian bridge, and worker support. |
+| GitHub source of truth | #164 through #172 | active | Tracks harness rollout. |
+
+## Drift Found
+
+| Drift | Evidence | Fix |
+|---|---|---|
+| Missing change impact map | `AGENTS.md` and `apps/studio/README.md` referenced `docs/architecture/change-impact-map.md`, which was absent. | Restore a compact `docs/architecture/change-impact-map.md`. |
+| Missing code ownership map | `apps/studio/README.md` referenced `docs/planning/code-ownership-map.md`, which was absent. | Restore a compact `docs/planning/code-ownership-map.md`. |
+| Stale Playwright skill path | `playwright-e2e-verification` referenced `apps/studio/tests/e2e/`. | Update to `apps/studio/e2e/`. |
+| Stale Playwright version | Skill referenced `@playwright/test@1.60.0`; `apps/studio/package.json` has `^1.51.1`. | Update skill to package value. |
+| Missing session hooks | Harness issue #169 proposed hooks; scripts did not exist. | Add lightweight non-mutating scripts under `scripts/ops/`. |
+
+## Minimal Fix Plan
+
+1. Add canonical harness spec and implementation docs.
+2. Add missing source-of-truth maps.
+3. Add `agent-harness-consistency-pass` skill.
+4. Update stale Playwright skill.
+5. Add session start/stop review scripts.
+6. Verify with docs and shell checks.
+
+## Verification
+
+Run:
+
+```bash
+git diff --check
+bash -n scripts/ops/agent-session-start.sh
+bash -n scripts/ops/agent-session-stop-review.sh
+cd apps/studio && npm run test:e2e -- --list
+```

--- a/docs/operations/implementation/agent-harness-maintenance.md
+++ b/docs/operations/implementation/agent-harness-maintenance.md
@@ -1,0 +1,63 @@
+# Agent Harness Maintenance
+
+Issue: #172
+Status: Active maintenance guide
+Last updated: 2026-05-26
+
+## Purpose
+
+Keep the Agent Harness useful as the repo changes. Harness rules should become more accurate over time, but they must not become noisy or self-mutating.
+
+## Maintenance Triggers
+
+Review the harness when:
+
+- an agent used stale paths or commands
+- an agent missed a required skill
+- an agent touched files outside scope
+- a test command or service requirement changed
+- a new repeated workflow emerged
+- a chat-first regression was found
+- a GitHub issue or PR revealed a missing guardrail
+
+## Skill Change Proposal
+
+Use this format before editing a skill:
+
+```md
+# Skill Change Proposal
+
+## Failure Observed
+
+## Current Skill Gap
+
+## Proposed Skill Edit
+
+## Validation Task
+
+## Risk
+
+## Decision
+- [ ] Accepted
+- [ ] Rejected
+- [ ] Needs revision
+```
+
+## Rubric
+
+| Dimension | Pass condition |
+|---|---|
+| Investigation quality | Agent verified repo root, read required sources, and mapped the relevant files before edits. |
+| Scope discipline | Agent changed only files declared in the plan or explained deviations before editing. |
+| Chat-first contract | Agent preserved Write workspace command routing, timeline readability, inspector role, and long-text handling. |
+| Verification quality | Agent ran or clearly explained the relevant checks. |
+| Environment transparency | Agent named required services and did not claim hidden E2E success. |
+| Final report quality | Agent reported files changed, tests, skipped checks, risks, and harness updates. |
+
+## Rules
+
+- Do not auto-edit skills after every run.
+- Do not make skills long catch-all manuals.
+- Prefer small, evidence-backed edits.
+- Link accepted skill changes to the issue or PR that motivated them.
+- Keep runtime skills under `.agents/skills/`.

--- a/docs/operations/implementation/agent-harness-rollout-plan.md
+++ b/docs/operations/implementation/agent-harness-rollout-plan.md
@@ -1,0 +1,129 @@
+# Agent Harness v1 Rollout Plan
+
+Issue: #164
+Status: Active rollout plan
+Last updated: 2026-05-26
+
+## Scope
+
+Implement the first operational harness for AI coding agents working in `novel-ai`. This rollout is docs, skills, issue workflow, and safe helper scripts. It does not change product behavior.
+
+## Phase 1: Consistency Pass
+
+Issue: #165
+
+Deliverables:
+
+- Confirm runtime skill home.
+- Confirm docs taxonomy.
+- Confirm E2E path and scripts.
+- Restore or track missing source-of-truth docs.
+- List stale skill instructions.
+
+Quality gate:
+
+```bash
+git diff --check
+```
+
+## Phase 2: Canonical Harness Docs
+
+Issue: #166
+
+Deliverables:
+
+- `docs/operations/specs/novel-ai-agent-harness.md`
+- `docs/operations/implementation/agent-harness-rollout-plan.md`
+- `docs/operations/implementation/agent-harness-maintenance.md`
+
+Quality gate:
+
+```bash
+git diff --check
+```
+
+## Phase 3: Runtime Skill Upgrades
+
+Issue: #167
+
+Deliverables:
+
+- Add `agent-harness-consistency-pass`.
+- Update stale Playwright E2E skill paths and version references.
+- Keep new skills under `.agents/skills/`.
+
+Quality gate:
+
+```bash
+git diff --check
+```
+
+## Phase 4: E2E Verification Contract
+
+Issue: #168
+
+Deliverables:
+
+- Document Playwright config and test paths.
+- Document service startup requirements.
+- Link related E2E roadmap issues #147 through #155.
+
+Quality gates:
+
+```bash
+cd apps/studio
+npm run test:e2e -- --list
+```
+
+Use full E2E only when the local stack is intentionally started.
+
+## Phase 5: Session Hooks
+
+Issue: #169
+
+Deliverables:
+
+- `scripts/ops/agent-session-start.sh`
+- `scripts/ops/agent-session-stop-review.sh`
+
+Quality gates:
+
+```bash
+bash -n scripts/ops/agent-session-start.sh
+bash -n scripts/ops/agent-session-stop-review.sh
+```
+
+## Phase 6: Pilot Active Story Identity
+
+Issue: #170
+
+Deliverables:
+
+- Investigation report first.
+- Scoped implementation plan.
+- Product changes only after approval.
+
+Quality gates:
+
+- `npm run typecheck`
+- `npm run build` when feasible
+- lint changed files
+- targeted E2E or documented test plan
+
+## Phase 7: User Operating Guide
+
+Issue: #171
+
+Deliverable:
+
+- `docs/operations/implementation/agent-harness-user-guide.md`
+
+## Phase 8: Manual Skill Optimization Loop
+
+Issue: #172
+
+Deliverables:
+
+- Skill change proposal template.
+- Rubric for evaluating agent runs.
+- Human approval process for skill edits.

--- a/docs/operations/implementation/agent-harness-user-guide.md
+++ b/docs/operations/implementation/agent-harness-user-guide.md
@@ -1,0 +1,129 @@
+# Agent Harness User Guide
+
+Issue: #171
+Status: Active user guide
+Last updated: 2026-05-26
+
+## Using Codex In This App
+
+When using the Codex desktop app, open the workspace at the real repo path:
+
+```text
+\\wsl.localhost\Ubuntu-24.04\home\danh\novel-ai
+```
+
+Then use prompts that explicitly choose investigation-only or implementation-approved mode.
+
+## Daily Startup
+
+Terminal flow:
+
+```bash
+cd ~/novel-ai
+git pull --rebase
+git checkout -b docs/<issue-number>-short-slug
+./scripts/ops/agent-session-start.sh
+```
+
+Codex app flow:
+
+```md
+Use the Novel AI Agent Harness v1.
+
+Task:
+[describe task]
+
+Mode:
+Investigation only. Do not edit code yet.
+```
+
+## Investigation Prompt
+
+```md
+Use the Novel AI Agent Harness v1.
+
+Task:
+[describe task]
+
+Mode:
+Investigation only. Do not edit code yet.
+
+Scope:
+[areas]
+
+Rules:
+- Verify repo root first.
+- Read AGENTS.md.
+- Read apps/studio/README.md if product/workflow behavior is involved.
+- Use relevant .agents/skills.
+- Return implementation map, source-of-truth files, risks, exact files likely to change, and test plan.
+```
+
+## Implementation Prompt
+
+```md
+Use the previous investigation report as source of truth.
+
+Proceed with the smallest safe implementation from the approved plan.
+
+Preserve chat-first UX.
+Do not touch unrelated files.
+Run relevant checks if feasible.
+Return files changed, tests run, skipped tests and why, risks, and harness updates.
+```
+
+## E2E Prompt
+
+```md
+Use the Novel AI Agent Harness v1 and the playwright-e2e-verification skill.
+
+Task:
+[describe flow]
+
+Mode:
+E2E verification plan first. Do not start long-running services until the required services and commands are listed.
+
+Return:
+required services, exact commands, target specs, assertions, risks, and fallback manual checks.
+```
+
+## Review After Codex Finishes
+
+Run or inspect:
+
+```bash
+git diff --stat
+git diff
+```
+
+For Studio source changes:
+
+```bash
+cd apps/studio
+npm run typecheck
+npm run build
+```
+
+For docs or shell hook changes:
+
+```bash
+git diff --check
+bash -n scripts/ops/agent-session-start.sh
+bash -n scripts/ops/agent-session-stop-review.sh
+```
+
+## Stop-Session Review
+
+```bash
+./scripts/ops/agent-session-stop-review.sh
+```
+
+Manual checklist:
+
+- Did the task reveal a new convention?
+- Did `AGENTS.md` become stale?
+- Did any `.agents/skills` file become stale?
+- Were test commands missing?
+- Did the agent touch files outside scope?
+- Did the chat-first contract remain intact?
+- Should a GitHub issue be updated?

--- a/docs/operations/specs/novel-ai-agent-harness.md
+++ b/docs/operations/specs/novel-ai-agent-harness.md
@@ -1,0 +1,137 @@
+# Novel AI Agent Harness v1
+
+Issue: #164
+Status: Active harness specification
+Last updated: 2026-05-26
+
+## Purpose
+
+The Agent Harness is the operating layer for AI coding agents working in `novel-ai`. It does not replace the product architecture or the agent model. It defines how agents load context, choose workflows, investigate safely, preserve product contracts, verify changes, and report drift.
+
+The harness exists because `novel-ai` is a chat-first long-form fiction workspace with frontend, backend, memory, analysis, E2E, local services, and AI orchestration surfaces. A vague task can otherwise lead an agent into the wrong route, stale docs, unrelated rewrites, hidden service assumptions, or broken Write workspace behavior.
+
+## Source Of Truth
+
+- GitHub master issue: #164.
+- Agent rules: `AGENTS.md`.
+- Studio product and workflow rules: `apps/studio/README.md`.
+- Runtime skills: `.agents/skills/`.
+- Skill inventory and reports: `docs/agent-skills/`.
+- Harness rollout, maintenance, and user guide: `docs/operations/implementation/`.
+- E2E config: `apps/studio/playwright.config.ts`.
+- E2E tests: `apps/studio/e2e/`.
+
+GitHub issues track harness work. Repo docs define durable rules after the work is accepted.
+
+## Product Contract
+
+Agents must preserve the chat-first writing workspace:
+
+- The main Write workspace is the central surface for brainstorming, context, memory, analysis, review, status, pipeline progress, and artifact previews.
+- `/memory`, `/analyze`, `/review`, `/research`, `/pipeline`, `/context`, `/inspect`, and `/status` must not become route-only primary flows.
+- Active story and active chapter context must be visible or recoverable in the Write workspace.
+- Long pasted or uploaded text must not render as a giant chat bubble. Use attachment, source document, artifact, collapsible preview, or chapter card patterns.
+- The right inspector owns detail views for context, memory, workflow progress, analysis, review, artifacts, continuity warnings, and next action.
+- Generated prose and full artifacts belong in the right artifact workspace or document surface, not as oversized chat messages.
+
+## Harness Components
+
+### 1. Context Loade
+
+Before editing, an agent verifies the repo root and reads only the relevant sources:
+
+1. Verify `.git`, `AGENTS.md`, `README.md`, `apps`, `docs`, and `scripts`.
+2. Read `AGENTS.md`.
+3. Read `apps/studio/README.md` for product, Studio, UI, or workflow tasks.
+4. Read the relevant `.agents/skills/<skill>/SKILL.md`.
+5. Read only directly affected docs, source files, tests, scripts, and migrations.
+
+### 2. Workflow Route
+
+Agents choose a runtime skill by surface:
+
+| Task surface | Skill |
+|---|---|
+| Harness, docs, skills, stale paths | `agent-harness-consistency-pass` |
+| Chat timeline, composer, slash commands | `chat-first-workspace` |
+| Context, memory, source traceability | `story-context-grooming` |
+| Chapter planning and AutoWrite | `chapter-generation-workflow` |
+| Progress blocks and inspector progress | `agent-progress-panel` |
+| Artifact previews and document panels | `artifact-context-contract` |
+| Write layout and scroll containment | `codex-style-layout-review` |
+| Long pasted/uploaded text | `long-text-ingestion` |
+| Playwright or browser verification | `playwright-e2e-verification` |
+| Issue and PR work | `github-issue-pr-workflow` |
+
+### 3. Guardrails
+
+- Do not perform broad rewrites without a GitHub issue and approved plan.
+- Do not hide service requirements.
+- Do not reset or purge DB data without explicit confirmation.
+- Do not create `.ai/skills`; `.agents/skills/` is the runtime skill home.
+- Do not create `docs/ai-layer/` unless a later decision changes docs taxonomy.
+- Do not let assistant prose invent backend-originated `workflow_progress`, `artifact_preview`, `approval_gate`, `failure_recovery`, or `context_digest` payloads.
+
+### 4. Investigation Protocol
+
+For non-trivial work, return an investigation report before implementation:
+
+- current implementation map
+- source-of-truth files
+- state ownership
+- API and persistence boundaries
+- product contract gaps
+- likely files to change
+- quality gates
+- open questions and risks
+
+### 5. Verification Contract
+
+Docs-only harness work:
+
+```bash
+git diff --check
+bash -n scripts/ops/agent-session-start.sh
+bash -n scripts/ops/agent-session-stop-review.sh
+```
+
+Studio source changes:
+
+```bash
+cd apps/studio
+npm run typecheck
+npm run build
+npx eslint <changed-files>
+```
+
+E2E work:
+
+```bash
+cd apps/studio
+npm run test:e2e
+npm run test:e2e:real
+npm run e2e:start-and-test
+```
+
+Use the narrowest meaningful gate first, then broader gates before final completion when feasible.
+
+### 6. Drift Detecto
+
+Agents must flag:
+
+- referenced files that no longer exist
+- skills that name stale paths or versions
+- docs that duplicate or conflict with `AGENTS.md`
+- E2E docs that hide Docker, DB, local LLM, Qdrant, Neo4j, historian bridge, or worker requirements
+- command behavior that violates chat-first routing
+
+### 7. Session Hooks
+
+Session hooks are lightweight helper scripts. They are optional and must not mutate product state:
+
+- `scripts/ops/agent-session-start.sh`
+- `scripts/ops/agent-session-stop-review.sh`
+
+### 8. Manual Skill Optimization Loop
+
+Skills improve through reviewed proposals, not automatic self-editing. See `docs/operations/implementation/agent-harness-maintenance.md`.

--- a/docs/planning/code-ownership-map.md
+++ b/docs/planning/code-ownership-map.md
@@ -1,0 +1,21 @@
+# Code Ownership Map
+
+Status: Active reference
+Last updated: 2026-05-26
+
+This map gives agents a first-pass ownership view. It does not replace source inspection.
+
+| Area | Owner boundary | Primary paths |
+|---|---|---|
+| App routes and API handlers | Next.js route parsing, page entry, thin API route handlers | `apps/studio/src/app/` |
+| Studio shell and story selector | Layout shell, selected story navigation, top-level story context | `apps/studio/src/components/`, `apps/studio/src/features/story/` |
+| Write workspace | Chat-first command stream, artifact panel, inspector rail, chapter controls | `apps/studio/src/features/scenes/components/writeTab/` |
+| Chat orchestration | Intent routing, timeline blocks, command handlers, conversation persistence | `apps/studio/src/features/scenes/components/writeTab/chatOrchestration/`, `apps/studio/src/features/chat-orchestration/` |
+| Scenes workflow | Story-scoped scene/chapter workflow routes and server orchestration | `apps/studio/src/features/scenes/server/` |
+| Memory and context | Story memory, context retrieval, core memory, conflict review | `apps/studio/src/features/memory/`, `services/memory-bridge/` |
+| Ingest | Upload validation, source docs, split drafts, worker interaction | `apps/studio/src/features/ingest/`, `services/memory-bridge/worker_ingest*` |
+| Reviews | Review request/response UI and server policy | `apps/studio/src/features/reviews/` |
+| DB schema | Durable data contracts and migrations | `db/migrations/` |
+| Local infrastructure | PostgreSQL, Qdrant, Neo4j, historian bridge, Studio container | `infra/docker-compose.yml` |
+| E2E | Playwright specs, fixtures, helpers, and local stack startup | `apps/studio/e2e/`, `apps/studio/playwright.config.ts`, `scripts/ops/start_e2e_stack.sh` |
+| Agent harness | Agent rules, runtime skills, docs, session hooks | `AGENTS.md`, `.agents/skills/`, `docs/operations/`, `docs/agent-skills/`, `scripts/ops/agent-session-*.sh` |

--- a/scripts/ops/agent-session-start.sh
+++ b/scripts/ops/agent-session-start.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "## Agent Session Context"
+echo
+echo "Repo: $(git remote get-url new-origin 2>/dev/null || git remote get-url origin 2>/dev/null || echo unknown)"
+echo "Branch: $(git branch --show-current)"
+echo
+echo "### Git Status"
+git status --short --branch
+echo
+echo "### Recent Commits"
+git log --oneline -5
+echo
+echo "### Agent Sources"
+printf '%s\n' "AGENTS.md"
+if [[ -f "apps/studio/README.md" ]]; then
+  printf '%s\n' "apps/studio/README.md"
+fi
+find .agents/skills -maxdepth 2 -name SKILL.md -print 2>/dev/null | sort
+echo
+echo "### Common Checks"
+cat <<'CHECKS'
+Docs/harness:
+  git diff --check
+  bash -n scripts/ops/agent-session-start.sh
+  bash -n scripts/ops/agent-session-stop-review.sh
+
+Studio:
+  cd apps/studio
+  npm run typecheck
+  npm run build
+  npx eslint <changed-files>
+
+E2E:
+  cd apps/studio
+  npm run test:e2e -- --list
+  npm run e2e:start-and-test
+CHECKS
+echo
+echo "Reminder: read AGENTS.md, then the relevant skill, before editing."

--- a/scripts/ops/agent-session-stop-review.sh
+++ b/scripts/ops/agent-session-stop-review.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "## Agent Session Stop Review"
+echo
+echo "### Changed Files"
+git status --short
+echo
+echo "### Checklist"
+cat <<'CHECKLIST'
+- [ ] Did this task reveal a new convention?
+- [ ] Did AGENTS.md become stale?
+- [ ] Did any .agents/skills file become stale?
+- [ ] Were test commands missing or wrong?
+- [ ] Did the agent touch files outside scope?
+- [ ] Did the chat-first contract remain intact?
+- [ ] Should a GitHub issue be updated?
+- [ ] Are skipped checks and service requirements documented?
+CHECKLIST
+echo
+echo "### Suggested Local Checks"
+cat <<'CHECKS'
+git diff --check
+bash -n scripts/ops/agent-session-start.sh
+bash -n scripts/ops/agent-session-stop-review.sh
+CHECKS


### PR DESCRIPTION
## Summary

- Adds the canonical Agent Harness v1 spec, rollout plan, maintenance guide, user guide, and consistency report.
- Adds a repo-specific `agent-harness-consistency-pass` runtime skill and wires it into `AGENTS.md` / `.gitignore` / skill inventory.
- Restores compact source-of-truth maps for change impact and code ownership.
- Updates the Playwright E2E skill to current repo paths/version and adds lightweight session start/stop review scripts.

## Verification

- [x] `git diff --cached --check`
- [x] `bash -n scripts/ops/agent-session-start.sh`
- [x] `bash -n scripts/ops/agent-session-stop-review.sh`
- [x] `./scripts/ops/agent-session-start.sh | head -80`
- [x] `./scripts/ops/agent-session-stop-review.sh | head -60`
- [x] `NODE_PATH=/home/danh/novel-ai/apps/studio/node_modules /home/danh/novel-ai/apps/studio/node_modules/.bin/playwright test --list` from the PR worktree, listing 37 tests in 10 files

## Notes

- Full E2E stack was not started; this is docs/skills/session-hook work and does not change product runtime behavior.
- The PR is based on `staging` using an isolated worktree to avoid unrelated dirty files in the original checkout.

Refs #164
Closes #165
Closes #166
Closes #167
Closes #168
Closes #169
Closes #171
Closes #172