### PR TITLE
Document Codex app harness usage

### DIFF
--- a/.agents/workflows/prompt-universe.md
+++ b/.agents/workflows/prompt-universe.md
@@ -1,0 +1,88 @@
+# Prompt Universe Router
+
+Status: Active workflow intake router
+Last updated: 2026-05-27
+
+## Purpose
+
+Use this workflow when a user gives a raw, vague, multi-intent, or high-context prompt and the right repo skill is not obvious.
+
+This is a router for the existing `novel-ai` agent harness. It is not a new capability layer, and it must not create parallel trees such as `.ai/skills`, `.ai-harness`, or `docs/ai-layer`.
+
+## Source Of Truth
+
+- Current checkout, GitHub issues/PRs, and repo docs are source of truth.
+- Local Codex, Claude, or desktop memory is cache only. Verify memory-derived claims against live files or GitHub state before acting.
+- Agent instructions are in `AGENTS.md`.
+- Runtime skills live under `.agents/skills/`.
+- Product architecture and workflow behavior live in `apps/studio/README.md`.
+- Harness specs and user-facing operating docs live under `docs/operations/`.
+
+## Intake Protocol
+
+1. Verify the repo root and Git state.
+2. Read `AGENTS.md`.
+3. If the task touches product architecture or workflow behavior, read `apps/studio/README.md`.
+4. Classify the prompt into one or more modes:
+   - investigation only
+   - implementation planning
+   - approved implementation
+   - GitHub issue/PR workflow
+   - strict review
+   - E2E verification
+   - harness/docs/skills maintenance
+5. Select the smallest relevant skill set from `.agents/skills/`.
+6. Identify source-of-truth files, likely files to change, risks, and verification before editing.
+7. Stop for a decision if the prompt requires an unapproved product, architecture, data model, workflow, or issue-planning decision.
+
+## Skill Routing
+
+| Prompt shape | Use |
+|---|---|
+| Unclear root cause, regression, data inconsistency, or unclear behavior | `investigation-workflow` |
+| User asks for an execution plan, issue plan, or file manifest | `implementation-planning` |
+| User asks to review a proposed plan or issue body | `implementation-plan-review` |
+| User asks for issues, branches, commits, PRs, or staging publish flow | `github-issue-pr-workflow` |
+| User asks for PR/local diff review | `pr-review-strict` |
+| Write Assistant, chat timeline, composer, slash commands, story switching | `chat-first-workspace` |
+| Story memory, context gaps, source traceability, context grooming | `story-context-grooming` |
+| Chapter planning, AutoWrite, CHAPTER_WRITE_V3, generation status | `chapter-generation-workflow` |
+| Progress/thinking cards, workflow progress, right inspector status | `agent-progress-panel` |
+| Artifacts, context digest, artifact preview, approval display | `artifact-context-contract` |
+| Triple-pane layout, viewport locking, independent scroll, responsive fallback | `codex-style-layout-review` |
+| Pasted/uploaded long text, mega files, ZIP imports, source docs | `long-text-ingestion` |
+| Browser, Playwright, E2E service requirements, layout verification | `playwright-e2e-verification` |
+| AGENTS/docs/skills/E2E drift or harness consistency | `agent-harness-consistency-pass` |
+
+Use multiple skills only when the prompt crosses surfaces. Prefer the minimal set that covers the actual task.
+
+## Stop Conditions
+
+Stop and ask for human review when:
+
+- The current checkout is stale, dirty in relevant files, or on the wrong branch.
+- GitHub issues or PRs already cover the work and updating them may be better than creating new ones.
+- The prompt would encode a new product, architecture, data model, or workflow decision.
+- Required services, secrets, databases, or local LLMs are unclear.
+- The task would create a duplicate docs taxonomy or parallel skill tree.
+- The implementation scope cannot be expressed as specific files and verification gates.
+
+## Output Contract
+
+For investigation-only tasks, return:
+
+- implementation map
+- source-of-truth files
+- risks
+- exact files likely to change
+- verification plan
+- open decisions
+
+For implementation-approved tasks, return:
+
+- files changed
+- checks run
+- skipped checks and why
+- behavior changed
+- risks
+- harness docs or skills that should be updated

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ _staging*
 !.agents/skills/github-issue-pr-workflow/SKILL.md
 !.agents/skills/agent-harness-consistency-pass/
 !.agents/skills/agent-harness-consistency-pass/SKILL.md
+!.agents/workflows/
+!.agents/workflows/prompt-universe.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,12 @@ Do not run whole-project lint unless requested. If verification cannot run, stat
 
 When behavior or contracts change, update the relevant docs in the same turn.
 
+Local Codex, Claude, or desktop memory is a cache, not a source of truth. Use it only to find likely context, then verify against the current checkout, GitHub issues/PRs, and repository docs before making claims or edits.
+
+## Prompt Router
+
+When a user prompt is vague, raw, multi-intent, or does not name the right skill, read `.agents/workflows/prompt-universe.md` before choosing a workflow. Use it as the intake router for mapping the request to investigation, implementation planning, GitHub issue/PR work, E2E verification, review, or harness maintenance.
+
 ## Repository Codex Skills
 
 Repo-specific Codex skills live under `.agents/skills/`. Use them after reading this file and before editing the related surface:

--- a/docs/operations/implementation/agent-harness-maintenance.md
+++ b/docs/operations/implementation/agent-harness-maintenance.md
@@ -8,6 +8,8 @@ Last updated: 2026-05-26
 
 Keep the Agent Harness useful as the repo changes. Harness rules should become more accurate over time, but they must not become noisy or self-mutating.
 
+This is an agent-assisted improvement loop: an agent may study sessions and propose skill changes, but a human must approve the proposal before any skill file is edited.
+
 ## Maintenance Triggers
 
 Review the harness when:
@@ -57,7 +59,61 @@ Use this format before editing a skill:
 ## Rules
 
 - Do not auto-edit skills after every run.
+- Do not let an agent apply its own proposal without human approval.
+- Use proposal-only mode when asking an agent to review sessions.
+- After approval, keep the patch limited to the approved docs or `.agents/skills/*` files.
 - Do not make skills long catch-all manuals.
 - Prefer small, evidence-backed edits.
 - Link accepted skill changes to the issue or PR that motivated them.
 - Keep runtime skills under `.agents/skills/`.
+
+## Session Review Workflow
+
+1. Collect evidence:
+   - session summary
+   - PR comments
+   - failed command output
+   - final report
+   - files touched
+   - checks run or skipped
+2. Ask the agent for proposal-only review.
+3. Review the proposal for overfitting, scope creep, stale assumptions, and duplication.
+4. Approve, reject, or request revision.
+5. If approved, ask the agent to patch only the approved skill/doc files.
+6. Run docs checks and open a PR to `staging`.
+
+## Proposal-Only Prompt
+
+```md
+Use the Novel AI Agent Harness v1.
+
+Task:
+Review these session notes and propose skill improvements.
+
+Mode:
+Proposal only. Do not edit files yet.
+
+Inputs:
+[session summary, PR notes, failed commands, or logs]
+
+Return:
+- failure patterns
+- evidence
+- current skill gap
+- proposed skill change
+- risk of overfitting
+- validation task
+- exact files that would change if approved
+```
+
+## Approved-Change Prompt
+
+```md
+Approved skill proposal:
+[paste approved proposal]
+
+Update only the approved docs or .agents/skills files.
+Do not change product code.
+Run docs checks.
+Open a PR to staging.
+```

--- a/docs/operations/implementation/agent-harness-user-guide.md
+++ b/docs/operations/implementation/agent-harness-user-guide.md
@@ -14,6 +14,47 @@ When using the Codex desktop app, open the workspace at the real repo path:
 
 Then use prompts that explicitly choose investigation-only or implementation-approved mode.
 
+## Fast Path For Future Sessions
+
+Use this when opening Codex in the desktop app and you do not want to remember the whole harness:
+
+```md
+Use the Novel AI Agent Harness v1.
+
+First verify this is the real repo:
+\\wsl.localhost\Ubuntu-24.04\home\danh\novel-ai
+
+Read:
+- AGENTS.md
+- docs/operations/specs/novel-ai-agent-harness.md
+- the relevant .agents/skills/*/SKILL.md for this task
+
+Task:
+[describe task]
+
+Mode:
+Investigation only first. Do not edit files until I approve the implementation plan.
+
+Return:
+- current implementation map
+- source-of-truth files
+- risks
+- exact files likely to change
+- verification plan
+- harness docs or skills that may need updates
+```
+
+When the investigation is acceptable, continue with:
+
+```md
+Approved. Implement the smallest safe change from the plan.
+
+Preserve the chat-first contract.
+Do not touch unrelated files.
+Run relevant checks.
+Report files changed, checks run, skipped checks and why, risks, and whether a harness doc or skill should be updated.
+```
+
 ## Daily Startup
 
 Terminal flow:
@@ -85,6 +126,44 @@ E2E verification plan first. Do not start long-running services until the requir
 
 Return:
 required services, exact commands, target specs, assertions, risks, and fallback manual checks.
+```
+
+## Session Review Prompt For Skill Improvements
+
+Use this when a Codex/Claude session went wrong, missed context, used stale commands, or produced a useful new pattern. This is proposal-only. The agent must not edit skills yet.
+
+```md
+Use the Novel AI Agent Harness v1.
+
+Task:
+Review these session notes and propose improvements to the repo agent skills.
+
+Mode:
+Proposal only. Do not edit files yet.
+
+Inputs:
+[paste session summary, PR review notes, failure logs, or links]
+
+Return:
+1. Failure patterns
+2. Evidence from the session
+3. Current skill gap
+4. Proposed skill change
+5. Risk of overfitting
+6. Validation task
+7. Exact files that would change if approved
+```
+
+After human approval, use:
+
+```md
+Approved skill proposal:
+[paste approved proposal]
+
+Update only the approved docs or .agents/skills files.
+Do not change product code.
+Run docs checks.
+Open a PR to staging.
 ```
 
 ## Review After Codex Finishes

--- a/docs/operations/implementation/agent-harness-user-guide.md
+++ b/docs/operations/implementation/agent-harness-user-guide.md
@@ -26,6 +26,7 @@ First verify this is the real repo:
 
 Read:
 - AGENTS.md
+- .agents/workflows/prompt-universe.md if this prompt is vague, raw, or mixes multiple request types
 - docs/operations/specs/novel-ai-agent-harness.md
 - the relevant .agents/skills/*/SKILL.md for this task
 
@@ -42,6 +43,24 @@ Return:
 - exact files likely to change
 - verification plan
 - harness docs or skills that may need updates
+```
+
+## Prompt-Universe Router
+
+Use `.agents/workflows/prompt-universe.md` when you have a messy prompt, pasted context, or you are not sure which skill/mode applies.
+
+```md
+Use .agents/workflows/prompt-universe.md as the intake router.
+
+Interpret this raw request before editing anything:
+[paste request]
+
+Return:
+- recommended mode
+- relevant .agents/skills
+- source-of-truth files to inspect
+- likely risks
+- whether this needs human approval before implementation
 ```
 
 When the investigation is acceptable, continue with:


### PR DESCRIPTION
## Summary

- Expands the Agent Harness user guide with a Codex desktop app fast path for future sessions.
- Adds proposal-only prompts for reviewing sessions and proposing skill improvements.
- Clarifies the maintenance workflow: agent studies sessions and proposes changes, human approves, then agent patches only approved docs/skills.

## Verification

- [x] `git diff --check`

## Notes

- Docs only. No product behavior or runtime code changed.

Refs #171
Refs #172