### PR TITLE
[OPS + DB] Bootstrap fresh Docker databases from active migrations

### DIFF
--- a/.agents/skills/github-issue-pr-workflow/SKILL.md
+++ b/.agents/skills/github-issue-pr-workflow/SKILL.md
@@ -25,6 +25,11 @@ Check:
 - `git status --short --branch`
 - `git remote -v` to resolve the concrete repository name
 - Relevant issue/PR state through `gh` when available
+- Repository assignees, milestones, and project fields before creating or updating issues/PRs:
+  - `gh api repos/<owner>/<repo>/assignees`
+  - `gh api repos/<owner>/<repo>/milestones`
+  - `gh project list --owner <owner>`
+  - `gh project field-list <project-number> --owner <owner>`
 - Recent branch and git history for the affected work
 - Existing docs or reports that are the source of truth for roadmap status
 
@@ -35,8 +40,18 @@ Check:
 3. Use branch names with the repo prefixes from `AGENTS.md`; include issue number when available.
 4. Target normal PRs to `staging`. Use `product` only for explicit promotion work or after staging has landed.
 5. For new issues, choose Epic, Feature, Task, or Master Tracking shape and include Agent Mode and Human Mode fields where required.
-6. Keep PRs small. Explain unrelated dirty files and leave them out unless the user opts in.
-7. Write PR descriptions with scope, acceptance criteria, verification, risks, rollback notes, and follow-ups.
+6. Set GitHub metadata before calling the issue complete:
+   - assignee, usually the repo owner or explicitly requested owner
+   - milestone, chosen from live milestones and matched to the work area
+   - project, chosen from live project list
+   - project Status and Priority fields when those fields exist
+   - labels for area, type, priority, and risk when applicable
+7. Link related work explicitly:
+   - Put `Parent: #...`, `Related: #...`, `Blocks: #...`, or `Blocked by: #...` in issue bodies when GitHub relationship fields are not available through the CLI.
+   - For implementation PRs, include `Closes #...` or `Refs #...` in the PR body so the Development sidebar links the PR.
+   - After PR creation, verify the issue's Development/project linkage with `gh issue view ... --json projectItems` and `gh pr view ... --json closingIssuesReferences`.
+8. Keep PRs small. Explain unrelated dirty files and leave them out unless the user opts in.
+9. Write PR descriptions with scope, acceptance criteria, verification, risks, rollback notes, follow-ups, and skipped checks.
 
 ## Output Format
 
@@ -61,6 +76,8 @@ Codex should respond using:
 - [ ] Branch name follows the repo naming convention.
 - [ ] PR target is `staging` unless this is an explicit promotion.
 - [ ] Issue or PR body has scope, acceptance criteria, quality gates, risks, rollback notes, and follow-ups.
+- [ ] Issues have assignee, milestone, project item, project status, project priority, and labels unless the repo has no such metadata available.
+- [ ] PRs have assignee/reviewer/project/milestone metadata when available, and the body links implementation issues with `Closes` or `Refs`.
 - [ ] Live GitHub state is checked before claiming roadmap completion.
 - [ ] Unrelated dirty files are identified and excluded from the GitHub action.
 
@@ -78,6 +95,8 @@ Codex should respond using:
 | ------------ | -------------- | ---------- |
 | PR targets the wrong base | GitHub defaults or old habits choose `product` or default branch | Explicitly set base to `staging` for normal work |
 | Roadmap status is stale | Issue/PR state changed after the last local note | Re-fetch live GitHub state before declaring done/not done |
+| Missing issue sidebar metadata | Issue bodies are created but assignee, milestone, project, status, and priority are not set | Inspect live metadata first and set it immediately after issue creation |
+| Missing Development linkage | PR body omits `Closes`/`Refs`, or issue body omits parent/related references | Add explicit relationship text and verify with `gh issue view` / `gh pr view` JSON |
 | Branch name is vague | Work starts before issue scope is known | Use type prefix and issue number/slug when available |
 | Dirty files leak into PR | Worktree already has unrelated changes | Inspect status first and stage/commit only the intended paths |
 

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -266,20 +266,18 @@ Memory layer async (worker):
 
 ## 5) Data model liên quan
 
-Migration cần đọc khi sửa logic:
+Active migrations live directly under `db/migrations/` and are applied in
+filename order. `db/migrations/000_baseline_20260502.sql` is the current schema
+baseline for fresh local databases; later root-level SQL files are post-baseline
+deltas.
 
-- `db/migrations/001_ui_pipeline.sql` (nền tảng cũ)
-- `db/migrations/003_multi_story_foundation.sql` (thêm `story_series`, `story_id`, `workunit_id`)
-- `db/migrations/004_multi_story_scene_version_story_id.sql` (thêm `story_id` cho version)
-- `db/migrations/005_memory_bridge_foundation.sql` (canon/ingest/review)
-- `db/migrations/006_review_apply_policy_fields.sql` (review decision fields)
-- `db/migrations/007_fix_scene_unique_scope.sql` (unique scope theo story)
-- `db/migrations/008_author_stage1_global_memory.sql` (worldbuilding + style profile)
-- `db/migrations/010_shelf_library_foundation.sql` (library metadata + tags/cautions/images)
-- `db/migrations/011_story_background_image.sql` (background image path)
-- `db/migrations/015_source_doc_ssot.sql` (ingest source doc SSOT, hash/idempotency base)
-- `db/migrations/016_memory_layer_v1.sql` (async memory packs: canon/timeline/style + enrich queue)
-- `db/migrations/023_author_style_profile.sql` (ingest-mined author style profile memory)
+Local Docker startup runs the active replay through the `db-migrate` service in
+`infra/docker-compose.yml` before `novel_studio` starts. For non-Docker local
+setup, apply only root-level `db/migrations/*.sql` in filename order.
+
+Historical pre-baseline SQL files under
+`db/migrations/archive/pre_baseline_20260502/` are reference-only provenance.
+Do not include them in fresh setup commands or active migration runners.
 
 Thực thể chính:
 

--- a/apps/studio/scripts/doctor_e2e_preflight.mjs
+++ b/apps/studio/scripts/doctor_e2e_preflight.mjs
@@ -247,6 +247,10 @@ const REQUIRED_TABLES = [
   ["story_chapter", "chapter list"],
 ];
 
+const ACTIVE_MIGRATION_FIX =
+  "Run Docker bootstrap: docker compose -f infra/docker-compose.yml up db-migrate. " +
+  "Manual fallback: apply root-level db/migrations/*.sql in filename order; do not apply archived migrations.";
+
 async function checkDbTables() {
   const client = new Client({ connectionString: DB_URL, connectionTimeoutMillis: 5000 });
   try {
@@ -264,7 +268,7 @@ async function checkDbTables() {
         fail(
           `table:${table}`,
           `MISSING — required by ${reason}`,
-          "Apply migrations: psql $DATABASE_URL -f db/migrations/000_baseline_20260502.sql"
+          ACTIVE_MIGRATION_FIX
         );
       }
     }
@@ -279,7 +283,7 @@ async function checkDbTables() {
     // Check for assistant_conversation table (added in delta migration)
     const convMigration = existing.has("assistant_conversation");
     if (convMigration) pass("db-migration-delta", "assistant_conversation table present (delta migration applied)");
-    else fail("db-migration-delta", "assistant_conversation missing", "Apply: psql $DATABASE_URL -f db/migrations/20260508_assistant_conversation_history.sql");
+    else fail("db-migration-delta", "assistant_conversation missing", ACTIVE_MIGRATION_FIX);
 
   } catch (err) {
     fail("db-tables", `Query failed: ${err.message}`);

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -2,7 +2,9 @@
 
 Active migrations live directly in this directory.
 
-Fresh personal-project databases apply files in filename order:
+Fresh personal-project databases apply files in filename order. Local Docker
+startup does this through the `db-migrate` service in `infra/docker-compose.yml`.
+For non-Docker local setup, run the same active replay manually:
 
 ```powershell
 Get-ChildItem db/migrations/*.sql |
@@ -13,3 +15,6 @@ Get-ChildItem db/migrations/*.sql |
 `000_baseline_20260502.sql` is the current schema baseline. Historical migrations before the baseline are archived under `archive/pre_baseline_20260502/` for reference only and are not part of the active replay path.
 
 Future migrations should be added next to the baseline with names that sort after it.
+
+Do not include `archive/pre_baseline_20260502/` in fresh setup commands. Those
+files preserve schema provenance only; they are not active migrations.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -86,6 +86,32 @@ services:
     depends_on:
       - postgres
 
+  db-migrate:
+    image: postgres:15
+    container_name: novel_db_migrate
+    environment:
+      PGPASSWORD: novelpass
+    volumes:
+      - ../db/migrations:/migrations:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command:
+      - sh
+      - -lc
+      - |
+        set -eu
+        baseline_count="$(psql -h postgres -U novel -d novel -tAc "SELECT count(*) FROM pg_tables WHERE schemaname = 'public' AND tablename = 'story_series'")"
+        for file in /migrations/*.sql; do
+          name="$$(basename "$$file")"
+          if [ "$$baseline_count" = "1" ] && [ "$$name" = "000_baseline_20260502.sql" ]; then
+            echo "Skipping $$name because public.story_series already exists."
+            continue
+          fi
+          echo "Applying $$name"
+          psql -h postgres -U novel -d novel -v ON_ERROR_STOP=1 -f "$$file"
+        done
+
   novel-studio:
     build:
       context: ../apps/studio
@@ -104,8 +130,8 @@ services:
     ports:
       - "3001:3000"
     depends_on:
-      postgres:
-        condition: service_healthy
+      db-migrate:
+        condition: service_completed_successfully
       neo4j:
         condition: service_started
       qdrant:


### PR DESCRIPTION
﻿## Summary

- Add a local `db-migrate` Compose service that applies active root migrations before Studio starts.
- Update migration onboarding docs so fresh setup uses `db/migrations/*.sql` and treats archived migrations as provenance only.
- Improve E2E preflight migration hints and update the GitHub issue/PR workflow skill to require assignee, milestone, project, priority/status, and Development linkage checks.

Closes #178
Closes #176
Refs #177

## Verification

- `docker compose -f infra/docker-compose.yml config`
- `cd apps/studio && npx eslint scripts/doctor_e2e_preflight.mjs`
- `cd apps/studio && npm run typecheck`
- `cd apps/studio && npm run build`
- `git diff --check`

## Skipped checks

- Fresh Docker volume smoke was not run because Docker Desktop engine is not available in this environment. Docker CLI is installed, but `docker version` cannot connect to `dockerDesktopLinuxEngine`; WSL Docker integration is also unavailable.

## Risks

- Existing partial databases where `story_series` exists but later required tables are missing still need `doctor:e2e-preflight` or manual repair. The migrator intentionally avoids replaying the non-idempotent baseline over an initialized volume.
- `service_completed_successfully` requires a modern Docker Compose implementation.

## Rollback

- Revert the `db-migrate` service and `novel-studio` dependency change in `infra/docker-compose.yml`.
- Revert the docs and preflight hint updates; no schema/data migration is introduced by this PR.
